### PR TITLE
Add operational safe bounds for AxiDraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This device-settings slice adds:
 - read-only plotter model visibility in the Plotter card
 - vendor-aligned model labels and default bounds for AxiDraw when a model is explicitly configured
 - explicit bounds-source reporting so model-derived defaults and config overrides are visible
+- separate nominal machine bounds and operational safe bounds for real AxiDraw
+- backend-owned default clearances on the far right and bottom edges, with an optional persisted safe-bounds override
 
 ## Repo layout
 
@@ -131,7 +133,7 @@ export LEARN_TO_DRAW_PLOTTER_BOUNDS_WIDTH_MM=300
 export LEARN_TO_DRAW_PLOTTER_BOUNDS_HEIGHT_MM=218
 ```
 
-For a V2/V3/SE A4 machine, `300 × 218 mm` is the observed safe bound to configure,
+For a V2/V3/SE A4 machine, `300 × 218 mm` is the nominal machine-travel example to configure,
 but it is now an explicit example config rather than an implicit backend fallback.
 
 Optional motion settings:
@@ -218,9 +220,10 @@ Optional workspace storage override:
 export LEARN_TO_DRAW_WORKSPACE_DIR=/absolute/path/to/workspace
 ```
 
-The app now treats sizing constraints as two separate layers:
+The app now treats sizing constraints as three separate layers:
 
-- `plotter bounds`: the maximum safe physical area for the machine
+- `nominal machine bounds`: explicit model/env machine travel
+- `operational safe bounds`: the backend-owned plotting envelope actually used for validation and plotting
 - `session paper setup`: the current page size and margins mounted in the app
 
 For the AxiDraw driver, the app also keeps a separate device-settings record under:
@@ -229,9 +232,9 @@ For the AxiDraw driver, the app also keeps a separate device-settings record und
 artifacts/device_settings/plotter.json
 ```
 
-If `LEARN_TO_DRAW_AXIDRAW_MODEL` is explicitly set, the backend derives default plotter
+If `LEARN_TO_DRAW_AXIDRAW_MODEL` is explicitly set, the backend derives nominal machine
 bounds from the same vendor travel constants used by the AxiDraw stack and surfaces a
-descriptive model label in the Plotter card. Effective bounds precedence is:
+descriptive model label in the Plotter card. Nominal bounds precedence is:
 
 1. `LEARN_TO_DRAW_PLOTTER_BOUNDS_WIDTH_MM` / `LEARN_TO_DRAW_PLOTTER_BOUNDS_HEIGHT_MM`
 2. model-derived AxiDraw bounds when `LEARN_TO_DRAW_AXIDRAW_MODEL` is explicitly configured
@@ -240,9 +243,22 @@ For the real AxiDraw driver, one of those two sources is now required. If neithe
 configured, the backend stays up but marks the plotter unavailable until explicit machine
 bounds or an explicit AxiDraw model are provided.
 
-The normal UI does not edit plotter bounds directly. It shows the current model, effective
-bounds, and bounds source read-only, while page size and margins remain editable session
-state through the backend.
+For real AxiDraw, the backend derives operational safe bounds from the nominal machine
+bounds by trimming `10 mm` from the far right edge and `10 mm` from the bottom edge.
+Those default clearances keep the current top-left origin unchanged while adding slack at
+the risky far edges. The Plotter card now shows both nominal machine bounds and operational
+safe bounds, and it allows a narrow backend-owned override/reset flow for the operational
+safe bounds only.
+
+The persisted device-settings record lives under:
+
+```text
+artifacts/device_settings/plotter.json
+```
+
+For real AxiDraw, that record stores the optional manual operational safe-bounds override.
+Clearing the override returns the backend to the default-clearance envelope derived from
+the nominal machine bounds.
 
 The persisted session workspace lives under:
 
@@ -252,7 +268,7 @@ artifacts/workspace/plotter.json
 
 The Plotter card can update page width, page height, and margins through the backend.
 The backend computes a drawable area from that session setup and validates that it stays
-inside the stable plotter bounds.
+inside the operational safe bounds.
 
 If corrected machine bounds make the saved paper setup invalid, `GET /api/plotter/workspace`
 now returns the persisted workspace plus `is_valid=false` and a `validation_error` message
@@ -266,11 +282,12 @@ Normal plotting now uses a single backend-owned preparation path:
 - the normal built-in `test-grid` uses this same preparation path
 - dedicated hardware diagnostics stay fixed-size and use a separate diagnostic passthrough path
 
-The backend refuses prepared output that would exceed the current drawable area or the configured plotter bounds.
+The backend refuses prepared output that would exceed the current drawable area or the
+current operational safe bounds.
 
 Each plot run now also records a preparation audit in the run metadata, including:
 
-- the effective plotter bounds, page size, and drawable area used for the run
+- the effective operational safe bounds, page size, and drawable area used for the run
 - derived workspace math such as drawable origin and remaining bounds headroom
 - preparation details such as strategy, placement origin, prepared content box, root `viewBox`, scale, and any computed overflow
 

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -138,7 +138,7 @@ class PlotPreparationMetadata(BaseModel):
     drawable_height_mm: float
     plotter_bounds_width_mm: float
     plotter_bounds_height_mm: float
-    plotter_bounds_source: Literal["model_default", "config_override", "config_default"]
+    plotter_bounds_source: Literal["manual_override", "default_clearance", "config_default"]
     plotter_model_code: Optional[int] = None
     plotter_model_label: Optional[str] = None
     units_inferred: bool = False
@@ -156,7 +156,8 @@ class PlotResult(BaseModel):
 PlotRunPurpose = Literal["normal", "diagnostic"]
 PlotRunCaptureMode = Literal["auto", "skip"]
 PlotterTestAction = Literal["raise_pen", "lower_pen", "cycle_pen", "align"]
-PlotterBoundsSource = Literal["model_default", "config_override", "config_default"]
+NominalPlotterBoundsSource = Literal["model_default", "config_override", "config_default"]
+PlotterBoundsSource = Literal["manual_override", "default_clearance", "config_default"]
 PlotterCalibrationSource = Literal[
     "vendor_default",
     "persisted",
@@ -299,10 +300,18 @@ class PlotterModelDescriptor(BaseModel):
 class PlotterDeviceSettings(BaseModel):
     driver: str
     plotter_model: Optional[PlotterModelDescriptor] = None
+    nominal_plotter_bounds_mm: SizeMm
+    nominal_plotter_bounds_source: NominalPlotterBoundsSource
     plotter_bounds_mm: SizeMm
     plotter_bounds_source: PlotterBoundsSource
     updated_at: datetime
     source: PlotterDeviceSettingsSource
+
+
+class PlotterDeviceSettingsRecord(BaseModel):
+    source: PlotterDeviceSettingsSource
+    updated_at: datetime
+    manual_safe_bounds_override_mm: Optional[SizeMm] = None
 
 
 class PlotterWorkspace(BaseModel):
@@ -337,3 +346,12 @@ class PlotterWorkspaceRequest(BaseModel):
 
 class PlotterWorkspaceResponse(CommandResponse):
     workspace: PlotterWorkspace
+
+
+class PlotterSafeBoundsRequest(BaseModel):
+    width_mm: Optional[float] = Field(default=None, gt=0)
+    height_mm: Optional[float] = Field(default=None, gt=0)
+
+
+class PlotterDeviceSettingsResponse(CommandResponse):
+    device: PlotterDeviceSettings

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -12,9 +12,11 @@ from learn_to_draw_api.models import (
     PlotterCalibrationRequest,
     PlotterCalibrationResponse,
     PlotterDeviceSettings,
+    PlotterDeviceSettingsResponse,
     PatternAssetCreateRequest,
     PlotAsset,
     PlotterPenHeightsRequest,
+    PlotterSafeBoundsRequest,
     PlotRun,
     PlotRunCreateRequest,
     PlotRunListResponse,
@@ -65,6 +67,12 @@ def build_api_router(
     @router.get("/api/plotter/device", response_model=PlotterDeviceSettings)
     def get_plotter_device() -> PlotterDeviceSettings:
         return hardware_service.get_plotter_device_settings()
+
+    @router.post("/api/plotter/device/safe-bounds", response_model=PlotterDeviceSettingsResponse)
+    def post_plotter_safe_bounds(
+        request: PlotterSafeBoundsRequest,
+    ) -> PlotterDeviceSettingsResponse:
+        return hardware_service.set_plotter_safe_bounds(request)
 
     @router.post("/api/plotter/calibration", response_model=PlotterCalibrationResponse)
     def post_plotter_calibration(

--- a/apps/api/src/learn_to_draw_api/services/hardware.py
+++ b/apps/api/src/learn_to_draw_api/services/hardware.py
@@ -14,7 +14,9 @@ from learn_to_draw_api.models import (
     PlotterCalibrationResponse,
     PlotterCommandResponse,
     PlotterDeviceSettings,
+    PlotterDeviceSettingsResponse,
     PlotterPenHeightsRequest,
+    PlotterSafeBoundsRequest,
     PlotterTestAction,
     PlotterWorkspace,
     PlotterWorkspaceRequest,
@@ -114,6 +116,28 @@ class HardwareService:
 
     def get_plotter_device_settings(self) -> PlotterDeviceSettings:
         return self._device_settings_service.current()
+
+    def set_plotter_safe_bounds(
+        self,
+        request: PlotterSafeBoundsRequest,
+    ) -> PlotterDeviceSettingsResponse:
+        if not self._plotter_lock.acquire(blocking=False):
+            raise HardwareBusyError("Plotter is busy.")
+        try:
+            device = self._device_settings_service.save_safe_bounds_override(
+                width_mm=request.width_mm,
+                height_mm=request.height_mm,
+            )
+            return PlotterDeviceSettingsResponse(
+                message=(
+                    "Operational safe bounds reset to the default clearance."
+                    if request.width_mm is None
+                    else "Operational safe bounds updated."
+                ),
+                device=device,
+            )
+        finally:
+            self._plotter_lock.release()
 
     def set_plotter_calibration(
         self,

--- a/apps/api/src/learn_to_draw_api/services/plotter_device_settings.py
+++ b/apps/api/src/learn_to_draw_api/services/plotter_device_settings.py
@@ -5,18 +5,26 @@ from pathlib import Path
 from threading import Lock
 from typing import Optional
 
-from learn_to_draw_api.adapters.axidraw_models import resolve_axidraw_model_info
+from learn_to_draw_api.adapters.axidraw_models import (
+    AxiDrawModelInfo,
+    resolve_axidraw_model_info,
+)
 from learn_to_draw_api.config import AppConfig
 from learn_to_draw_api.models import (
     HardwareUnavailableError,
+    InvalidArtifactError,
+    NominalPlotterBoundsSource,
     PlotterBoundsSource,
     PlotterDeviceSettings,
+    PlotterDeviceSettingsRecord,
     PlotterModelDescriptor,
     SizeMm,
 )
 
 
 DEFAULT_CONFIG_BOUNDS = SizeMm(width_mm=210.0, height_mm=297.0)
+DEFAULT_SAFE_CLEARANCE_RIGHT_MM = 10.0
+DEFAULT_SAFE_CLEARANCE_BOTTOM_MM = 10.0
 
 
 class PlotterDeviceSettingsStore:
@@ -26,14 +34,14 @@ class PlotterDeviceSettingsStore:
         self._file_path = self._settings_dir / "plotter.json"
         self._lock = Lock()
 
-    def load(self) -> Optional[PlotterDeviceSettings]:
+    def load(self) -> Optional[PlotterDeviceSettingsRecord]:
         if not self._file_path.exists():
             return None
-        return PlotterDeviceSettings.model_validate_json(
+        return PlotterDeviceSettingsRecord.model_validate_json(
             self._file_path.read_text(encoding="utf-8")
         )
 
-    def save(self, settings: PlotterDeviceSettings) -> PlotterDeviceSettings:
+    def save(self, settings: PlotterDeviceSettingsRecord) -> PlotterDeviceSettingsRecord:
         with self._lock:
             temp_path = self._file_path.with_suffix(".tmp")
             temp_path.write_text(settings.model_dump_json(indent=2), encoding="utf-8")
@@ -53,30 +61,91 @@ class PlotterDeviceSettingsService:
             settings = self._build_current_axidraw_settings(
                 source=persisted.source if persisted is not None else "config_default",
                 updated_at=persisted.updated_at if persisted is not None else datetime.now(timezone.utc),
+                manual_safe_bounds_override_mm=(
+                    persisted.manual_safe_bounds_override_mm if persisted is not None else None
+                ),
             )
-            self._store.save(settings)
+            self._store.save(
+                PlotterDeviceSettingsRecord(
+                    source=settings.source,
+                    updated_at=settings.updated_at,
+                    manual_safe_bounds_override_mm=(
+                        persisted.manual_safe_bounds_override_mm if persisted is not None else None
+                    ),
+                )
+            )
             return settings
         if persisted is not None:
             return self._validate_settings(persisted, source=persisted.source)
         settings = self._build_default_settings(source="config_default")
-        self._store.save(settings)
+        self._store.save(
+            PlotterDeviceSettingsRecord(
+                source=settings.source,
+                updated_at=settings.updated_at,
+                manual_safe_bounds_override_mm=None,
+            )
+        )
         return settings
+
+    def save_safe_bounds_override(
+        self,
+        *,
+        width_mm: Optional[float],
+        height_mm: Optional[float],
+    ) -> PlotterDeviceSettings:
+        if self._config.plotter_driver.strip().lower() != "axidraw":
+            raise InvalidArtifactError(
+                "Operational safe bounds can only be updated for the real AxiDraw driver."
+            )
+        if (width_mm is None) != (height_mm is None):
+            raise InvalidArtifactError(
+                "Provide both width_mm and height_mm, or clear both values."
+            )
+
+        current_record = self._store.load()
+        nominal_bounds, nominal_bounds_source, model_info = self._resolve_axidraw_nominal_bounds()
+        manual_override = (
+            None
+            if width_mm is None
+            else self._validate_safe_bounds_override(
+                width_mm=width_mm,
+                height_mm=height_mm,
+                nominal_bounds=nominal_bounds,
+            )
+        )
+        updated_at = datetime.now(timezone.utc)
+        record = PlotterDeviceSettingsRecord(
+            source="persisted",
+            updated_at=updated_at,
+            manual_safe_bounds_override_mm=manual_override,
+        )
+        self._store.save(record)
+        return self._build_axidraw_settings(
+            nominal_bounds=nominal_bounds,
+            nominal_bounds_source=nominal_bounds_source,
+            model_info=model_info,
+            manual_safe_bounds_override_mm=manual_override,
+            source=record.source,
+            updated_at=updated_at,
+        )
 
     def _validate_settings(
         self,
-        settings: PlotterDeviceSettings,
+        settings: PlotterDeviceSettingsRecord,
         *,
         source: str,
     ) -> PlotterDeviceSettings:
         driver = self._config.plotter_driver.strip().lower()
         if driver != "axidraw":
             return PlotterDeviceSettings(
-                driver=settings.driver,
+                driver=self._config.plotter_driver,
                 plotter_model=None,
+                nominal_plotter_bounds_mm=self._resolve_effective_bounds(DEFAULT_CONFIG_BOUNDS),
+                nominal_plotter_bounds_source="config_default",
                 plotter_bounds_mm=self._resolve_effective_bounds(DEFAULT_CONFIG_BOUNDS),
                 plotter_bounds_source=self._resolve_bounds_source(
                     driver="mock",
-                    has_model=False,
+                    has_override=False,
                 ),
                 updated_at=settings.updated_at,
                 source=source,
@@ -84,18 +153,25 @@ class PlotterDeviceSettingsService:
         return self._build_current_axidraw_settings(
             source=source,
             updated_at=settings.updated_at,
+            manual_safe_bounds_override_mm=settings.manual_safe_bounds_override_mm,
         )
 
     def _build_default_settings(self, *, source: str) -> PlotterDeviceSettings:
         driver = self._config.plotter_driver.strip().lower()
         updated_at = datetime.now(timezone.utc)
         if driver == "axidraw":
-            return self._build_current_axidraw_settings(source=source, updated_at=updated_at)
+            return self._build_current_axidraw_settings(
+                source=source,
+                updated_at=updated_at,
+                manual_safe_bounds_override_mm=None,
+            )
         return PlotterDeviceSettings(
             driver=self._config.plotter_driver,
             plotter_model=None,
+            nominal_plotter_bounds_mm=self._resolve_effective_bounds(DEFAULT_CONFIG_BOUNDS),
+            nominal_plotter_bounds_source="config_default",
             plotter_bounds_mm=self._resolve_effective_bounds(DEFAULT_CONFIG_BOUNDS),
-            plotter_bounds_source=self._resolve_bounds_source(driver=driver, has_model=False),
+            plotter_bounds_source=self._resolve_bounds_source(driver=driver, has_override=False),
             updated_at=updated_at,
             source=source,
         )
@@ -105,7 +181,21 @@ class PlotterDeviceSettingsService:
         *,
         source: str,
         updated_at: datetime,
+        manual_safe_bounds_override_mm: Optional[SizeMm],
     ) -> PlotterDeviceSettings:
+        nominal_bounds, nominal_bounds_source, model_info = self._resolve_axidraw_nominal_bounds()
+        return self._build_axidraw_settings(
+            nominal_bounds=nominal_bounds,
+            nominal_bounds_source=nominal_bounds_source,
+            model_info=model_info,
+            manual_safe_bounds_override_mm=manual_safe_bounds_override_mm,
+            source=source,
+            updated_at=updated_at,
+        )
+
+    def _resolve_axidraw_nominal_bounds(
+        self,
+    ) -> tuple[SizeMm, NominalPlotterBoundsSource, Optional[AxiDrawModelInfo]]:
         if (
             self._config.plotter_bounds_width_mm is None
             and self._config.plotter_bounds_height_mm is not None
@@ -144,7 +234,7 @@ class PlotterDeviceSettingsService:
                 width_mm=self._config.plotter_bounds_width_mm,
                 height_mm=self._config.plotter_bounds_height_mm,
             )
-            bounds_source: PlotterBoundsSource = "config_override"
+            bounds_source: NominalPlotterBoundsSource = "config_override"
         else:
             assert model_info is not None
             bounds = SizeMm(
@@ -152,7 +242,28 @@ class PlotterDeviceSettingsService:
                 height_mm=model_info.bounds_height_mm,
             )
             bounds_source = "model_default"
+        return bounds, bounds_source, model_info
 
+    def _build_axidraw_settings(
+        self,
+        *,
+        nominal_bounds: SizeMm,
+        nominal_bounds_source: NominalPlotterBoundsSource,
+        model_info: Optional[AxiDrawModelInfo],
+        manual_safe_bounds_override_mm: Optional[SizeMm],
+        source: str,
+        updated_at: datetime,
+    ) -> PlotterDeviceSettings:
+        operational_bounds = (
+            manual_safe_bounds_override_mm
+            if manual_safe_bounds_override_mm is not None
+            else self._default_safe_bounds(nominal_bounds)
+        )
+        operational_bounds_source: PlotterBoundsSource = (
+            "manual_override"
+            if manual_safe_bounds_override_mm is not None
+            else "default_clearance"
+        )
         return PlotterDeviceSettings(
             driver=self._config.plotter_driver,
             plotter_model=(
@@ -160,11 +271,35 @@ class PlotterDeviceSettingsService:
                 if model_info is not None
                 else None
             ),
-            plotter_bounds_mm=bounds,
-            plotter_bounds_source=bounds_source,
+            nominal_plotter_bounds_mm=nominal_bounds,
+            nominal_plotter_bounds_source=nominal_bounds_source,
+            plotter_bounds_mm=operational_bounds,
+            plotter_bounds_source=operational_bounds_source,
             updated_at=updated_at,
             source=source,
         )
+
+    def _default_safe_bounds(self, nominal_bounds: SizeMm) -> SizeMm:
+        width_mm = nominal_bounds.width_mm - DEFAULT_SAFE_CLEARANCE_RIGHT_MM
+        height_mm = nominal_bounds.height_mm - DEFAULT_SAFE_CLEARANCE_BOTTOM_MM
+        if width_mm <= 0 or height_mm <= 0:
+            raise HardwareUnavailableError(
+                "Configured nominal machine bounds are smaller than the default safe clearances."
+            )
+        return SizeMm(width_mm=round(width_mm, 3), height_mm=round(height_mm, 3))
+
+    def _validate_safe_bounds_override(
+        self,
+        *,
+        width_mm: float,
+        height_mm: float,
+        nominal_bounds: SizeMm,
+    ) -> SizeMm:
+        if width_mm > nominal_bounds.width_mm or height_mm > nominal_bounds.height_mm:
+            raise InvalidArtifactError(
+                "Operational safe bounds cannot exceed the nominal machine bounds."
+            )
+        return SizeMm(width_mm=round(width_mm, 3), height_mm=round(height_mm, 3))
 
     def _resolve_effective_bounds(self, default_bounds: SizeMm) -> SizeMm:
         width_mm = (
@@ -179,12 +314,7 @@ class PlotterDeviceSettingsService:
         )
         return SizeMm(width_mm=width_mm, height_mm=height_mm)
 
-    def _resolve_bounds_source(self, *, driver: str, has_model: bool) -> PlotterBoundsSource:
-        if (
-            self._config.plotter_bounds_width_mm is not None
-            or self._config.plotter_bounds_height_mm is not None
-        ):
-            return "config_override"
-        if driver.strip().lower() == "axidraw" and has_model:
-            return "model_default"
+    def _resolve_bounds_source(self, *, driver: str, has_override: bool) -> PlotterBoundsSource:
+        if driver.strip().lower() == "axidraw" and has_override:
+            return "manual_override"
         return "config_default"

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -209,9 +209,12 @@ def test_plotter_device_endpoint_reports_model_derived_bounds(tmp_path):
     payload = response.json()
     assert payload["plotter_model"]["code"] == 2
     assert payload["plotter_model"]["label"] == "AxiDraw V3/A3 or SE/A3"
-    assert payload["plotter_bounds_source"] == "model_default"
-    assert payload["plotter_bounds_mm"]["width_mm"] == 430.022
-    assert payload["plotter_bounds_mm"]["height_mm"] == 296.926
+    assert payload["nominal_plotter_bounds_source"] == "model_default"
+    assert payload["nominal_plotter_bounds_mm"]["width_mm"] == 430.022
+    assert payload["nominal_plotter_bounds_mm"]["height_mm"] == 296.926
+    assert payload["plotter_bounds_source"] == "default_clearance"
+    assert payload["plotter_bounds_mm"]["width_mm"] == 420.022
+    assert payload["plotter_bounds_mm"]["height_mm"] == 286.926
 
 
 def test_axidraw_without_explicit_bounds_degrades_safely(tmp_path):
@@ -262,9 +265,103 @@ def test_plotter_device_endpoint_reports_explicit_bounds_override(tmp_path):
     assert response.status_code == 200
     payload = response.json()
     assert payload["plotter_model"] is None
-    assert payload["plotter_bounds_source"] == "config_override"
-    assert payload["plotter_bounds_mm"]["width_mm"] == 300.0
-    assert payload["plotter_bounds_mm"]["height_mm"] == 218.0
+    assert payload["nominal_plotter_bounds_source"] == "config_override"
+    assert payload["nominal_plotter_bounds_mm"]["width_mm"] == 300.0
+    assert payload["nominal_plotter_bounds_mm"]["height_mm"] == 218.0
+    assert payload["plotter_bounds_source"] == "default_clearance"
+    assert payload["plotter_bounds_mm"]["width_mm"] == 290.0
+    assert payload["plotter_bounds_mm"]["height_mm"] == 208.0
+
+
+def test_plotter_safe_bounds_endpoint_persists_manual_override(tmp_path):
+    app = create_app(
+        AppConfig(
+            captures_dir=tmp_path / "captures",
+            plot_assets_dir=tmp_path / "plot_assets",
+            plot_runs_dir=tmp_path / "plot_runs",
+            calibration_dir=tmp_path / "calibration",
+            device_settings_dir=tmp_path / "device-settings",
+            workspace_dir=tmp_path / "workspace",
+            plotter_driver="axidraw",
+            plotter_bounds_width_mm=300.0,
+            plotter_bounds_height_mm=218.0,
+        ),
+        plotter=MockPlotter(),
+        camera=MockCamera(capture_delay_s=0),
+    )
+    with TestClient(app) as client:
+        updated = client.post(
+            "/api/plotter/device/safe-bounds",
+            json={"width_mm": 280.0, "height_mm": 200.0},
+        )
+        current = client.get("/api/plotter/device")
+
+    assert updated.status_code == 200
+    assert updated.json()["device"]["plotter_bounds_source"] == "manual_override"
+    assert updated.json()["device"]["plotter_bounds_mm"]["width_mm"] == 280.0
+    assert updated.json()["device"]["plotter_bounds_mm"]["height_mm"] == 200.0
+    assert current.status_code == 200
+    assert current.json()["plotter_bounds_source"] == "manual_override"
+    assert current.json()["plotter_bounds_mm"]["width_mm"] == 280.0
+    assert current.json()["plotter_bounds_mm"]["height_mm"] == 200.0
+
+
+def test_plotter_safe_bounds_endpoint_clears_to_default_clearance(tmp_path):
+    app = create_app(
+        AppConfig(
+            captures_dir=tmp_path / "captures",
+            plot_assets_dir=tmp_path / "plot_assets",
+            plot_runs_dir=tmp_path / "plot_runs",
+            calibration_dir=tmp_path / "calibration",
+            device_settings_dir=tmp_path / "device-settings",
+            workspace_dir=tmp_path / "workspace",
+            plotter_driver="axidraw",
+            plotter_bounds_width_mm=300.0,
+            plotter_bounds_height_mm=218.0,
+        ),
+        plotter=MockPlotter(),
+        camera=MockCamera(capture_delay_s=0),
+    )
+    with TestClient(app) as client:
+        client.post(
+            "/api/plotter/device/safe-bounds",
+            json={"width_mm": 280.0, "height_mm": 200.0},
+        )
+        cleared = client.post(
+            "/api/plotter/device/safe-bounds",
+            json={"width_mm": None, "height_mm": None},
+        )
+
+    assert cleared.status_code == 200
+    assert cleared.json()["device"]["plotter_bounds_source"] == "default_clearance"
+    assert cleared.json()["device"]["plotter_bounds_mm"]["width_mm"] == 290.0
+    assert cleared.json()["device"]["plotter_bounds_mm"]["height_mm"] == 208.0
+
+
+def test_plotter_safe_bounds_endpoint_rejects_partial_values(tmp_path):
+    app = create_app(
+        AppConfig(
+            captures_dir=tmp_path / "captures",
+            plot_assets_dir=tmp_path / "plot_assets",
+            plot_runs_dir=tmp_path / "plot_runs",
+            calibration_dir=tmp_path / "calibration",
+            device_settings_dir=tmp_path / "device-settings",
+            workspace_dir=tmp_path / "workspace",
+            plotter_driver="axidraw",
+            plotter_bounds_width_mm=300.0,
+            plotter_bounds_height_mm=218.0,
+        ),
+        plotter=MockPlotter(),
+        camera=MockCamera(capture_delay_s=0),
+    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/plotter/device/safe-bounds",
+            json={"width_mm": 280.0, "height_mm": None},
+        )
+
+    assert response.status_code == 400
+    assert "Provide both width_mm and height_mm" in response.json()["detail"]
 
 
 def test_plotter_workspace_endpoint_persists_page_setup(tmp_path):

--- a/apps/api/tests/test_services.py
+++ b/apps/api/tests/test_services.py
@@ -164,9 +164,12 @@ def test_device_settings_service_uses_explicit_axidraw_model_bounds(tmp_path):
 
     assert settings.plotter_model is not None
     assert settings.plotter_model.code == 1
-    assert settings.plotter_bounds_source == "model_default"
-    assert settings.plotter_bounds_mm.width_mm == 299.974
-    assert settings.plotter_bounds_mm.height_mm == 217.932
+    assert settings.nominal_plotter_bounds_source == "model_default"
+    assert settings.nominal_plotter_bounds_mm.width_mm == 299.974
+    assert settings.nominal_plotter_bounds_mm.height_mm == 217.932
+    assert settings.plotter_bounds_source == "default_clearance"
+    assert settings.plotter_bounds_mm.width_mm == 289.974
+    assert settings.plotter_bounds_mm.height_mm == 207.932
 
 
 def test_device_settings_service_uses_explicit_axidraw_bounds_override(tmp_path):
@@ -182,9 +185,51 @@ def test_device_settings_service_uses_explicit_axidraw_bounds_override(tmp_path)
     settings = service.current()
 
     assert settings.plotter_model is None
-    assert settings.plotter_bounds_source == "config_override"
-    assert settings.plotter_bounds_mm.width_mm == 300.0
-    assert settings.plotter_bounds_mm.height_mm == 218.0
+    assert settings.nominal_plotter_bounds_source == "config_override"
+    assert settings.nominal_plotter_bounds_mm.width_mm == 300.0
+    assert settings.nominal_plotter_bounds_mm.height_mm == 218.0
+    assert settings.plotter_bounds_source == "default_clearance"
+    assert settings.plotter_bounds_mm.width_mm == 290.0
+    assert settings.plotter_bounds_mm.height_mm == 208.0
+
+
+def test_device_settings_service_persists_manual_safe_bounds_override(tmp_path):
+    service = build_device_settings_service(
+        tmp_path,
+        config_overrides={
+            "plotter_driver": "axidraw",
+            "plotter_bounds_width_mm": 300.0,
+            "plotter_bounds_height_mm": 218.0,
+        },
+    )
+
+    saved = service.save_safe_bounds_override(width_mm=280.0, height_mm=200.0)
+    current = service.current()
+
+    assert saved.plotter_bounds_source == "manual_override"
+    assert saved.plotter_bounds_mm.width_mm == 280.0
+    assert saved.plotter_bounds_mm.height_mm == 200.0
+    assert current.plotter_bounds_source == "manual_override"
+    assert current.plotter_bounds_mm.width_mm == 280.0
+    assert current.plotter_bounds_mm.height_mm == 200.0
+
+
+def test_device_settings_service_clears_manual_safe_bounds_override(tmp_path):
+    service = build_device_settings_service(
+        tmp_path,
+        config_overrides={
+            "plotter_driver": "axidraw",
+            "plotter_bounds_width_mm": 300.0,
+            "plotter_bounds_height_mm": 218.0,
+        },
+    )
+    service.save_safe_bounds_override(width_mm=280.0, height_mm=200.0)
+
+    cleared = service.save_safe_bounds_override(width_mm=None, height_mm=None)
+
+    assert cleared.plotter_bounds_source == "default_clearance"
+    assert cleared.plotter_bounds_mm.width_mm == 290.0
+    assert cleared.plotter_bounds_mm.height_mm == 208.0
 
 
 def test_device_settings_service_rejects_unconfigured_axidraw_bounds(tmp_path):
@@ -210,6 +255,30 @@ def test_device_settings_service_rejects_partial_axidraw_bounds_override(tmp_pat
 
     with pytest.raises(HardwareUnavailableError, match="Set both LEARN_TO_DRAW_PLOTTER_BOUNDS_WIDTH_MM"):
         service.current()
+
+
+def test_device_settings_service_rejects_safe_bounds_override_that_exceeds_nominal(tmp_path):
+    service = build_device_settings_service(
+        tmp_path,
+        config_overrides={
+            "plotter_driver": "axidraw",
+            "plotter_bounds_width_mm": 300.0,
+            "plotter_bounds_height_mm": 218.0,
+        },
+    )
+
+    with pytest.raises(InvalidArtifactError, match="cannot exceed the nominal machine bounds"):
+        service.save_safe_bounds_override(width_mm=301.0, height_mm=200.0)
+
+
+def test_mock_device_settings_keep_nominal_and_operational_bounds_identical(tmp_path):
+    service = build_device_settings_service(tmp_path)
+
+    settings = service.current()
+
+    assert settings.nominal_plotter_bounds_mm == settings.plotter_bounds_mm
+    assert settings.nominal_plotter_bounds_source == "config_default"
+    assert settings.plotter_bounds_source == "config_default"
 
 
 def test_workspace_service_returns_invalid_state_for_misaligned_axidraw_defaults(tmp_path):

--- a/apps/web/src/features/hardware/HardwareDashboard.tsx
+++ b/apps/web/src/features/hardware/HardwareDashboard.tsx
@@ -20,6 +20,11 @@ interface CalibrationValue {
   nativeResFactor: string;
 }
 
+interface SafeBoundsValues {
+  widthMm: string;
+  heightMm: string;
+}
+
 interface WorkspaceValues {
   pageWidthMm: string;
   pageHeightMm: string;
@@ -60,6 +65,13 @@ function areCalibrationValuesEqual(
   right: CalibrationValue | null,
 ) {
   return left?.nativeResFactor === right?.nativeResFactor;
+}
+
+function areSafeBoundsValuesEqual(
+  left: SafeBoundsValues | null,
+  right: SafeBoundsValues | null,
+) {
+  return left?.widthMm === right?.widthMm && left?.heightMm === right?.heightMm;
 }
 
 function areWorkspaceValuesEqual(
@@ -121,6 +133,31 @@ function getCalibrationValidation(nativeResFactor: string): string | null {
     return "Native resolution factor must be greater than zero.";
   }
 
+  return null;
+}
+
+function getSafeBoundsValidation(
+  safeBounds: SafeBoundsValues,
+  nominalBounds: { width_mm: number; height_mm: number } | null,
+): string | null {
+  if (safeBounds.widthMm.trim() === "" || safeBounds.heightMm.trim() === "") {
+    return "Enter both operational safe bounds before saving.";
+  }
+
+  const widthMm = Number(safeBounds.widthMm);
+  const heightMm = Number(safeBounds.heightMm);
+  if (!Number.isFinite(widthMm) || !Number.isFinite(heightMm)) {
+    return "Operational safe bounds must be numeric values.";
+  }
+  if (widthMm <= 0 || heightMm <= 0) {
+    return "Operational safe bounds must be greater than zero.";
+  }
+  if (
+    nominalBounds &&
+    (widthMm > nominalBounds.width_mm || heightMm > nominalBounds.height_mm)
+  ) {
+    return `Operational safe bounds cannot exceed nominal machine bounds of ${nominalBounds.width_mm} x ${nominalBounds.height_mm} mm.`;
+  }
   return null;
 }
 
@@ -255,6 +292,7 @@ export function HardwareDashboard() {
     runPlotterTestAction,
     runDiagnosticPattern,
     setPlotterCalibration,
+    setPlotterSafeBounds,
     setPlotterWorkspace,
     setPlotterPenHeights,
     capture,
@@ -272,6 +310,15 @@ export function HardwareDashboard() {
     useState<CalibrationValue | null>(null);
   const [pendingAppliedCalibration, setPendingAppliedCalibration] =
     useState<CalibrationValue | null>(null);
+  const [safeBoundsValues, setSafeBoundsValues] = useState<SafeBoundsValues>({
+    widthMm: "200",
+    heightMm: "200",
+  });
+  const [isSafeBoundsDirty, setIsSafeBoundsDirty] = useState(false);
+  const [lastSyncedSafeBounds, setLastSyncedSafeBounds] =
+    useState<SafeBoundsValues | null>(null);
+  const [pendingAppliedSafeBounds, setPendingAppliedSafeBounds] =
+    useState<SafeBoundsValues | null>(null);
   const [workspaceValues, setWorkspaceValues] = useState<WorkspaceValues>({
     pageWidthMm: "210",
     pageHeightMm: "297",
@@ -318,6 +365,13 @@ export function HardwareDashboard() {
           marginTopMm: String(plotterWorkspace.margins_mm.top_mm),
           marginRightMm: String(plotterWorkspace.margins_mm.right_mm),
           marginBottomMm: String(plotterWorkspace.margins_mm.bottom_mm),
+        }
+      : null;
+  const currentSafeBoundsValue =
+    plotterDevice !== null
+      ? {
+          widthMm: String(plotterDevice.plotter_bounds_mm.width_mm),
+          heightMm: String(plotterDevice.plotter_bounds_mm.height_mm),
         }
       : null;
 
@@ -409,6 +463,49 @@ export function HardwareDashboard() {
       actionFeedback.tone === "error"
     ) {
       setPendingAppliedCalibration(null);
+    }
+  }, [actionFeedback]);
+
+  useEffect(() => {
+    if (!currentSafeBoundsValue) {
+      return;
+    }
+
+    const shouldSyncDraft =
+      lastSyncedSafeBounds === null ||
+      !isSafeBoundsDirty ||
+      areSafeBoundsValuesEqual(pendingAppliedSafeBounds, currentSafeBoundsValue);
+
+    if (!shouldSyncDraft) {
+      return;
+    }
+
+    if (!areSafeBoundsValuesEqual(safeBoundsValues, currentSafeBoundsValue)) {
+      setSafeBoundsValues(currentSafeBoundsValue);
+    }
+
+    if (!areSafeBoundsValuesEqual(lastSyncedSafeBounds, currentSafeBoundsValue)) {
+      setLastSyncedSafeBounds(currentSafeBoundsValue);
+    }
+
+    if (areSafeBoundsValuesEqual(pendingAppliedSafeBounds, currentSafeBoundsValue)) {
+      setIsSafeBoundsDirty(false);
+      setPendingAppliedSafeBounds(null);
+    }
+  }, [
+    currentSafeBoundsValue,
+    isSafeBoundsDirty,
+    lastSyncedSafeBounds,
+    pendingAppliedSafeBounds,
+    safeBoundsValues,
+  ]);
+
+  useEffect(() => {
+    if (
+      actionFeedback?.action === "plotter-safe-bounds" &&
+      actionFeedback.tone === "error"
+    ) {
+      setPendingAppliedSafeBounds(null);
     }
   }, [actionFeedback]);
 
@@ -506,6 +603,11 @@ export function HardwareDashboard() {
       : null;
   const penHeightValidation = getPenHeightValidation(penPosUp, penPosDown);
   const calibrationValidation = getCalibrationValidation(nativeResFactor);
+  const nominalPlotterBounds = plotterDevice?.nominal_plotter_bounds_mm ?? null;
+  const safeBoundsValidation = getSafeBoundsValidation(
+    safeBoundsValues,
+    nominalPlotterBounds,
+  );
   const workspaceMetrics = getWorkspaceMetrics(workspaceValues);
   const workspaceValidation = getWorkspaceValidation(
     workspaceMetrics,
@@ -531,6 +633,8 @@ export function HardwareDashboard() {
       : plotterCalibration?.motion_scale ?? null;
   const plotterModelLabel = plotterDevice?.plotter_model?.label ?? null;
   const plotterBoundsSource = plotterDevice?.plotter_bounds_source ?? null;
+  const nominalPlotterBoundsSource =
+    plotterDevice?.nominal_plotter_bounds_source ?? null;
   const drawableWidth = workspaceMetrics.drawableWidthMm;
   const drawableHeight = workspaceMetrics.drawableHeightMm;
   const workspaceSourceLabel = plotterWorkspace?.source
@@ -546,6 +650,8 @@ export function HardwareDashboard() {
   const penHeightDisabled =
     actionName !== null || hardwareStatus.plotter.busy || !hardwareStatus.plotter.available;
   const calibrationDisabled =
+    actionName !== null || hardwareStatus.plotter.busy || !hardwareStatus.plotter.available;
+  const safeBoundsDisabled =
     actionName !== null || hardwareStatus.plotter.busy || !hardwareStatus.plotter.available;
   const workspaceDisabled =
     actionName !== null || hardwareStatus.plotter.busy || !hardwareStatus.plotter.available;
@@ -564,6 +670,11 @@ export function HardwareDashboard() {
         lastSyncedCalibration,
       ),
     );
+  }
+
+  function handleSafeBoundsChange(nextValues: SafeBoundsValues) {
+    setSafeBoundsValues(nextValues);
+    setIsSafeBoundsDirty(!areSafeBoundsValuesEqual(nextValues, lastSyncedSafeBounds));
   }
 
   function handleWorkspaceChange(nextValues: WorkspaceValues) {
@@ -613,6 +724,7 @@ export function HardwareDashboard() {
               : actionFeedback &&
                   (actionFeedback.action === "plotter-walk-home" ||
                     actionFeedback.action === "plotter-calibration" ||
+                    actionFeedback.action === "plotter-safe-bounds" ||
                     actionFeedback.action === "plotter-workspace" ||
                     actionFeedback.action === "plotter-pen-heights" ||
                     actionFeedback.action.startsWith("plotter-test:") ||
@@ -782,7 +894,7 @@ export function HardwareDashboard() {
                   <div className="workspace-card">
                     <div className="workspace-card-header">
                       <h4>Plotter</h4>
-                      <span className="workspace-unit-chip">Read only</span>
+                      <span className="workspace-unit-chip">Backend owned</span>
                     </div>
                     <ul className="details-list compact-details workspace-capability-list">
                       <li>
@@ -790,7 +902,23 @@ export function HardwareDashboard() {
                         <strong>{plotterModelLabel ?? "Model unavailable"}</strong>
                       </li>
                       <li>
-                        <span>Safe plotter bounds</span>
+                        <span>Nominal machine bounds</span>
+                        <strong>
+                          {plotterDevice
+                            ? `${formatMm(plotterDevice.nominal_plotter_bounds_mm.width_mm)} x ${formatMm(
+                                plotterDevice.nominal_plotter_bounds_mm.height_mm,
+                              )}`
+                            : "unknown"}
+                        </strong>
+                      </li>
+                      {nominalPlotterBoundsSource ? (
+                        <li>
+                          <span>Nominal source</span>
+                          <strong>{formatLabel(nominalPlotterBoundsSource)}</strong>
+                        </li>
+                      ) : null}
+                      <li>
+                        <span>Operational safe bounds</span>
                         <strong>
                           {plotterDevice
                             ? `${formatMm(plotterDevice.plotter_bounds_mm.width_mm)} x ${formatMm(
@@ -801,11 +929,87 @@ export function HardwareDashboard() {
                       </li>
                       {plotterBoundsSource ? (
                         <li>
-                          <span>Bounds source</span>
+                          <span>Operational source</span>
                           <strong>{formatLabel(plotterBoundsSource)}</strong>
                         </li>
                       ) : null}
                     </ul>
+                    {isAxiDraw ? (
+                      <div className="diagnostic-subsection">
+                        <h4>Operational safe bounds</h4>
+                        <div className="workspace-grid workspace-grid-two">
+                          {renderWorkspaceInput(
+                            "Width",
+                            safeBoundsValues.widthMm,
+                            (nextValue) =>
+                              handleSafeBoundsChange({
+                                ...safeBoundsValues,
+                                widthMm: nextValue,
+                              }),
+                            safeBoundsDisabled,
+                            1,
+                          )}
+                          {renderWorkspaceInput(
+                            "Height",
+                            safeBoundsValues.heightMm,
+                            (nextValue) =>
+                              handleSafeBoundsChange({
+                                ...safeBoundsValues,
+                                heightMm: nextValue,
+                              }),
+                            safeBoundsDisabled,
+                            1,
+                          )}
+                        </div>
+                        <div className="section-actions workspace-actions">
+                          <button
+                            type="button"
+                            className="button-secondary button-compact"
+                            onClick={() => {
+                              setPendingAppliedSafeBounds(safeBoundsValues);
+                              void setPlotterSafeBounds({
+                                width_mm: Number(safeBoundsValues.widthMm),
+                                height_mm: Number(safeBoundsValues.heightMm),
+                              });
+                            }}
+                            disabled={
+                              safeBoundsDisabled ||
+                              safeBoundsValidation !== null ||
+                              areSafeBoundsValuesEqual(safeBoundsValues, lastSyncedSafeBounds)
+                            }
+                          >
+                            Save safe bounds
+                          </button>
+                          <button
+                            type="button"
+                            className="button-secondary button-compact"
+                            onClick={() => {
+                              setPendingAppliedSafeBounds(null);
+                              void setPlotterSafeBounds({
+                                width_mm: null,
+                                height_mm: null,
+                              });
+                            }}
+                            disabled={
+                              safeBoundsDisabled ||
+                              plotterBoundsSource === "default_clearance"
+                            }
+                          >
+                            Reset to default clearance
+                          </button>
+                        </div>
+                        {safeBoundsValidation ? (
+                          <div className="inline-notice inline-notice-error workspace-inline-notice">
+                            {safeBoundsValidation}
+                          </div>
+                        ) : null}
+                        <p className="footer-note">
+                          Operational safe bounds are the backend-owned plotting envelope. Default
+                          clearance trims the nominal machine travel on the far right and bottom
+                          edges.
+                        </p>
+                      </div>
+                    ) : null}
                   </div>
 
                   <div className="workspace-layout">

--- a/apps/web/src/features/hardware/useHardwareDashboard.ts
+++ b/apps/web/src/features/hardware/useHardwareDashboard.ts
@@ -8,6 +8,7 @@ import {
   fetchLatestCapture,
   fetchPlotterCalibration,
   fetchPlotterDevice,
+  setPlotterSafeBounds,
   fetchPlotterWorkspace,
   walkPlotterHome,
   runPlotterTestAction,
@@ -30,6 +31,7 @@ type DiagnosticPatternId = "tiny-square" | "dash-row" | "double-box";
 type ActionName =
   | "plotter-walk-home"
   | "plotter-calibration"
+  | "plotter-safe-bounds"
   | "plotter-workspace"
   | "plotter-pen-heights"
   | "camera-capture"
@@ -207,6 +209,29 @@ export function useHardwareDashboard() {
         {
           pending: "Saving plotter calibration...",
           success: "Plotter calibration saved.",
+        },
+      ),
+    setPlotterSafeBounds: (safeBounds: {
+      width_mm: number | null;
+      height_mm: number | null;
+    }) =>
+      runAction(
+        "plotter-safe-bounds",
+        async () => {
+          const response = await setPlotterSafeBounds(safeBounds);
+          if (mountedRef.current) {
+            setPlotterDeviceState(response.device);
+          }
+        },
+        {
+          pending:
+            safeBounds.width_mm === null
+              ? "Resetting operational safe bounds..."
+              : "Saving operational safe bounds...",
+          success:
+            safeBounds.width_mm === null
+              ? "Operational safe bounds reset."
+              : "Operational safe bounds updated.",
         },
       ),
     setPlotterWorkspace: (workspace: {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   PlotterCalibrationResponse,
   PlotterCommandResponse,
   PlotterDeviceSettings,
+  PlotterDeviceSettingsResponse,
   PlotterWorkspace,
   PlotterWorkspaceResponse,
 } from "../types/hardware";
@@ -94,6 +95,21 @@ export function setPlotterCalibration(nativeResFactor: number) {
 
 export function fetchPlotterWorkspace() {
   return requestJson<PlotterWorkspace>("/api/plotter/workspace");
+}
+
+export function setPlotterSafeBounds(
+  safeBounds: {
+    width_mm: number | null;
+    height_mm: number | null;
+  },
+) {
+  return requestJson<PlotterDeviceSettingsResponse>("/api/plotter/device/safe-bounds", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(safeBounds),
+  });
 }
 
 export function setPlotterWorkspace(workspace: {

--- a/apps/web/src/types/hardware.ts
+++ b/apps/web/src/types/hardware.ts
@@ -43,6 +43,10 @@ export type PlotterCalibrationSource =
   | "env_override"
   | "explicit_path";
 export type PlotterBoundsSource =
+  | "manual_override"
+  | "default_clearance"
+  | "config_default";
+export type NominalPlotterBoundsSource =
   | "model_default"
   | "config_override"
   | "config_default";
@@ -71,10 +75,18 @@ export type PlotterDeviceSettingsSource = "config_default" | "persisted";
 export interface PlotterDeviceSettings {
   driver: string;
   plotter_model: PlotterModelDescriptor | null;
+  nominal_plotter_bounds_mm: SizeMm;
+  nominal_plotter_bounds_source: NominalPlotterBoundsSource;
   plotter_bounds_mm: SizeMm;
   plotter_bounds_source: PlotterBoundsSource;
   updated_at: string;
   source: PlotterDeviceSettingsSource;
+}
+
+export interface PlotterDeviceSettingsResponse {
+  ok: boolean;
+  message: string;
+  device: PlotterDeviceSettings;
 }
 
 export interface SizeMm {

--- a/apps/web/tests/dashboard.test.tsx
+++ b/apps/web/tests/dashboard.test.tsx
@@ -93,6 +93,11 @@ const defaultWorkspace = {
 const defaultDevice = {
   driver: "mock",
   plotter_model: null,
+  nominal_plotter_bounds_mm: {
+    width_mm: 210,
+    height_mm: 297,
+  },
+  nominal_plotter_bounds_source: "config_default" as const,
   plotter_bounds_mm: {
     width_mm: 210,
     height_mm: 297,
@@ -143,11 +148,19 @@ type DeviceFixture = {
     code: number;
     label: string;
   } | null;
+  nominal_plotter_bounds_mm: {
+    width_mm: number;
+    height_mm: number;
+  };
+  nominal_plotter_bounds_source:
+    | "model_default"
+    | "config_override"
+    | "config_default";
   plotter_bounds_mm: {
     width_mm: number;
     height_mm: number;
   };
-  plotter_bounds_source: "model_default" | "config_override" | "config_default";
+  plotter_bounds_source: "manual_override" | "default_clearance" | "config_default";
   updated_at: string;
   source: "config_default" | "persisted";
 };
@@ -236,10 +249,17 @@ describe("Hardware dashboard", () => {
         };
 
         if (url === "/api/hardware/status") {
-          return new Response(JSON.stringify(hardwareStatus), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
+          return new Response(
+            JSON.stringify(
+              currentDevice.driver === "axidraw"
+                ? axidrawHardwareStatus
+                : hardwareStatus,
+            ),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
         }
 
         if (url === "/api/captures/latest") {
@@ -285,6 +305,67 @@ describe("Hardware dashboard", () => {
             status: 200,
             headers: { "Content-Type": "application/json" },
           });
+        }
+
+        if (url === "/api/plotter/device/safe-bounds" && method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}"));
+          currentDevice = {
+            ...currentDevice,
+            plotter_bounds_mm:
+              body.width_mm === null && body.height_mm === null
+                ? {
+                    width_mm: currentDevice.nominal_plotter_bounds_mm.width_mm,
+                    height_mm: currentDevice.nominal_plotter_bounds_mm.height_mm,
+                  }
+                : {
+                    width_mm: body.width_mm,
+                    height_mm: body.height_mm,
+                  },
+            plotter_bounds_source:
+              body.width_mm === null && body.height_mm === null
+                ? currentDevice.driver === "axidraw"
+                  ? "default_clearance"
+                  : "config_default"
+                : "manual_override",
+            updated_at: "2026-03-15T20:00:11Z",
+            source: "persisted",
+          };
+          if (body.width_mm === null && body.height_mm === null && currentDevice.driver === "axidraw") {
+            currentDevice = {
+              ...currentDevice,
+              plotter_bounds_mm: {
+                width_mm: currentDevice.nominal_plotter_bounds_mm.width_mm - 10,
+                height_mm: currentDevice.nominal_plotter_bounds_mm.height_mm - 10,
+              },
+            };
+          }
+          currentWorkspace = {
+            ...currentWorkspace,
+            plotter_bounds_mm: currentDevice.plotter_bounds_mm,
+            is_valid:
+              currentWorkspace.page_size_mm.width_mm <= currentDevice.plotter_bounds_mm.width_mm &&
+              currentWorkspace.page_size_mm.height_mm <= currentDevice.plotter_bounds_mm.height_mm,
+            validation_error:
+              currentWorkspace.page_size_mm.width_mm > currentDevice.plotter_bounds_mm.width_mm
+                ? "Configured page width exceeds the plotter bounds width."
+                : currentWorkspace.page_size_mm.height_mm > currentDevice.plotter_bounds_mm.height_mm
+                  ? "Configured page height exceeds the plotter bounds height."
+                  : null,
+          };
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              message:
+                body.width_mm === null && body.height_mm === null
+                  ? "Operational safe bounds reset to the default clearance."
+                  : "Operational safe bounds updated.",
+              device: currentDevice,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
         }
 
         if (url === "/api/plotter/workspace") {
@@ -603,7 +684,8 @@ describe("Hardware dashboard", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/^paper setup$/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^preview$/i })).toBeInTheDocument();
-    expect(screen.getByText(/safe plotter bounds/i)).toBeInTheDocument();
+    expect(screen.getByText(/nominal machine bounds/i)).toBeInTheDocument();
+    expect(screen.getByText(/operational safe bounds/i)).toBeInTheDocument();
     expect(screen.getByRole("img", { name: /paper setup preview/i })).toBeInTheDocument();
     expect(screen.getByText(/paper 210 x 297 mm/i)).toBeInTheDocument();
   });
@@ -710,17 +792,22 @@ describe("Hardware dashboard", () => {
     currentDevice = {
       ...currentDevice,
       driver: "axidraw",
-      plotter_bounds_mm: {
+      nominal_plotter_bounds_mm: {
         width_mm: 300,
         height_mm: 218,
       },
-      plotter_bounds_source: "config_override",
+      nominal_plotter_bounds_source: "config_override",
+      plotter_bounds_mm: {
+        width_mm: 290,
+        height_mm: 208,
+      },
+      plotter_bounds_source: "default_clearance",
     };
     currentWorkspace = {
       ...currentWorkspace,
       plotter_bounds_mm: {
-        width_mm: 300,
-        height_mm: 218,
+        width_mm: 290,
+        height_mm: 208,
       },
       is_valid: false,
       validation_error: "Configured page height exceeds the plotter bounds height.",
@@ -800,6 +887,49 @@ describe("Hardware dashboard", () => {
     expect(screen.getByRole("button", { name: /tiny square/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /start plot run/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /save paper setup/i })).toBeDisabled();
+  });
+
+  it("saves and resets operational safe bounds for axidraw", async () => {
+    currentDevice = {
+      ...currentDevice,
+      driver: "axidraw",
+      nominal_plotter_bounds_mm: {
+        width_mm: 300,
+        height_mm: 218,
+      },
+      nominal_plotter_bounds_source: "config_override",
+      plotter_bounds_mm: {
+        width_mm: 290,
+        height_mm: 208,
+      },
+      plotter_bounds_source: "default_clearance",
+    };
+    currentWorkspace = {
+      ...currentWorkspace,
+      plotter_bounds_mm: {
+        width_mm: 290,
+        height_mm: 208,
+      },
+    };
+
+    render(<App />);
+
+    const widthInputs = await screen.findAllByLabelText(/^width$/i);
+    const heightInputs = await screen.findAllByLabelText(/^height$/i);
+
+    fireEvent.change(widthInputs[0], { target: { value: "280" } });
+    fireEvent.change(heightInputs[0], { target: { value: "200" } });
+    fireEvent.click(screen.getByRole("button", { name: /save safe bounds/i }));
+
+    expect(await screen.findByText(/operational safe bounds updated\./i)).toBeInTheDocument();
+    expect(screen.getByText(/280 mm x 200 mm/i)).toBeInTheDocument();
+    expect(screen.getByText(/^manual override$/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /reset to default clearance/i }));
+
+    expect(await screen.findByText(/operational safe bounds reset\./i)).toBeInTheDocument();
+    expect(screen.getByText(/290 mm x 208 mm/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^default clearance$/i).length).toBeGreaterThan(0);
   });
 
   it("captures an image and refreshes the preview", async () => {
@@ -1589,10 +1719,13 @@ describe("Hardware dashboard", () => {
 
     render(<App />);
 
-    fireEvent.change(await screen.findByLabelText(/^width$/i), {
+    const widthInputs = await screen.findAllByLabelText(/^width$/i);
+    const heightInputs = await screen.findAllByLabelText(/^height$/i);
+
+    fireEvent.change(widthInputs[1], {
       target: { value: "148" },
     });
-    fireEvent.change(screen.getByLabelText(/^height$/i), {
+    fireEvent.change(heightInputs[1], {
       target: { value: "210" },
     });
     fireEvent.change(screen.getByLabelText(/^left$/i), {


### PR DESCRIPTION
## Summary

Separates nominal AxiDraw machine bounds from the operational safe plotting envelope.

This keeps the configured/model machine travel visible, but stops treating it as a zero-slack plotting area. Real AxiDraw now uses backend-owned operational safe bounds for workspace validation and plotting, with a default right/bottom clearance and an optional persisted manual override.

## What changed

- Added `nominal_plotter_bounds_mm` and `nominal_plotter_bounds_source` to plotter device settings.
- Kept `plotter_bounds_mm`, but changed its meaning to the operational safe bounds actually used by the app.
- For real AxiDraw, default operational safe bounds now derive from nominal bounds by trimming:
  - `10 mm` from the right edge
  - `10 mm` from the bottom edge
- Added persisted manual safe-bounds override support in the backend device-settings record.
- Added `POST /api/plotter/device/safe-bounds` to:
  - save a manual override
  - clear the override and return to the default-clearance envelope
- Updated the Hardware panel to show:
  - nominal machine bounds
  - operational safe bounds
  - source of each
  - a small AxiDraw-only save/reset control for operational safe bounds
- Updated README to document nominal vs operational bounds and the new override/reset flow.

## Behavior notes

- Workspace validation and plot preparation continue to use `plotter_bounds_mm`, which now means the operational safe bounds.
- Mock behavior stays simple:
  - nominal bounds and operational bounds are the same
- This slice does not change:
  - top-left origin behavior
  - fit/preparation strategy
  - diagnostic-vs-normal plotting behavior

## Why

Recent hardware validation showed that nominal machine travel is too aggressive to use directly as a safe plotting envelope near the far edges. This change introduces a conservative backend-owned envelope without changing the current plotting strategy.

## Verification

Passed:
- `make api-test`
- `make web-test`
- `npm run build` in `apps/web`

Manual validation:
- verified nominal and operational safe bounds display correctly in the Hardware panel
- verified manual safe-bounds override and reset to default clearance
- verified valid/invalid paper setup behavior against operational safe bounds
- verified normal plotting and downscaling continue to work inside the safer envelope

## Remaining risk

- The default clearance is intentionally conservative but still heuristic.
- If the real machine needs a tighter safe envelope, the manual safe-bounds override is now the backend-owned adjustment point.
