### PR TITLE
Streamline repository docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,126 +1,64 @@
 # LearnToDraw
 
-Local-first control panel for a closed-loop pen-plotter workflow.
+LearnToDraw is a local-first control panel for a pen-plotter workflow. The backend owns hardware access, plot execution, and artifact persistence; the frontend is a lightweight localhost dashboard for monitoring and safe control.
 
-This first slice includes:
+## What It Does
 
-- a FastAPI backend that owns hardware access
-- a React/Vite dashboard for local control
-- plotter and camera adapter interfaces
-- mock plotter and mock camera implementations
-- simple actions for `home` and `capture`
-- local capture persistence under `artifacts/captures`
+- Runs a FastAPI backend that stays responsible for plotter and camera access
+- Provides a React/Vite dashboard for local status, actions, and workflow visibility
+- Supports tracked plot runs from uploaded SVGs or built-in patterns
+- Persists captures, plot assets, plot runs, calibration, and workspace/device settings locally
+- Supports both mock adapters for development and a real AxiDraw-backed plotter path
 
-This second slice adds:
+## Architecture At A Glance
 
-- a tracked plot-run workflow
-- local SVG upload and a built-in `test-grid` source
-- planned SVG preview and captured result comparison
-- local asset persistence under `artifacts/plot_assets`
-- local plot-run metadata under `artifacts/plot_runs`
-- a real AxiDraw-backed plotter adapter path behind the existing backend interface
+- `apps/api` is the system of record for hardware status, commands, plot workflow orchestration, and artifact persistence
+- `apps/web` is a localhost dashboard that polls backend HTTP endpoints and never talks to hardware directly
+- `artifacts/` stores local captures, prepared plot assets, plot-run records, calibration data, and workspace/device state
+- AxiDraw-specific behavior stays isolated in backend adapters and wrappers
 
-This pen-reliability slice adds:
+## Repo Layout
 
-- explicit `return to origin` semantics instead of misleading `home`
-- documented AxiDraw pen-lift tuning via backend config
-- fixed diagnostic pen actions for the real AxiDraw adapter
-- tiny built-in diagnostic patterns: `tiny-square`, `dash-row`, and `double-box`
-- diagnostic plot runs that skip camera capture on purpose
+- `apps/api`: FastAPI backend, services, adapters, and models
+- `apps/web`: React/Vite dashboard
+- `artifacts/`: local captures, plot assets, plot runs, calibration, and workspace/device state
+- `docs/`: architecture notes, project history, and manual test assets
 
-This plot-sizing slice adds:
+## Quick Start
 
-- explicit physical `mm` dimensions for built-in plot patterns
-- backend-owned drawable-area preparation for normal plots
-- a configurable backend draw area for future page-layout and iterative drawing work
-- prepared plot-size metadata surfaced in plot-run records and the local UI
-
-This workspace slice adds:
-
-- stable plotter bounds separate from editable session paper setup
-- persisted backend workspace state under `artifacts/workspace`
-- backend validation that plotting stays inside the current drawable area and plotter bounds
-- page-size and margin controls in the Plotter card, stored as session/backend state
-
-This device-settings slice adds:
-
-- a separate persisted plotter device-settings record under `artifacts/device_settings`
-- read-only plotter model visibility in the Plotter card
-- vendor-aligned model labels and default bounds for AxiDraw when a model is explicitly configured
-- explicit bounds-source reporting so model-derived defaults and config overrides are visible
-- separate nominal machine bounds and operational safe bounds for real AxiDraw
-- backend-owned default clearances on the far right and bottom edges, with an optional persisted safe-bounds override
-
-## Repo layout
-
-- `apps/api`: Python backend API and hardware layer
-- `apps/web`: local dashboard UI
-- `artifacts/captures`: locally saved mock camera captures
-- `artifacts/plot_assets`: stored planned SVG assets
-- `artifacts/plot_runs`: stored plot-run metadata
-- `artifacts/device_settings`: persisted plotter device settings
-- `artifacts/workspace`: persisted plotter workspace/session setup
-- `docs/architecture.md`: slice-1 architecture notes
-
-## Backend setup
-
-Preferred long-term workflow is `uv`, but this repo also works with standard Python tooling.
+Install dependencies:
 
 ```bash
 make api-install
-make api-dev
-```
-
-`make api-dev` uses `PYTHONPATH=src`, so a non-editable install is enough for local development on older system Python setups.
-For explicit driver startup, use:
-
-```bash
-make api-dev-mock
-make api-dev-axidraw
-```
-
-These targets keep driver selection backend-owned and require a backend restart when you switch modes.
-Any AxiDraw-specific env overrides already in your shell still apply to `make api-dev-axidraw`.
-
-Run tests:
-
-```bash
-make api-test
-```
-
-## Frontend setup
-
-```bash
 make web-install
+```
+
+Start the backend and frontend:
+
+```bash
+make api-dev
 make web-dev
 ```
 
-Run tests:
+Then open [http://127.0.0.1:5173](http://127.0.0.1:5173).
 
-```bash
-make web-test
-```
+By default, the backend runs against the mock plotter path so the app can be explored locally without hardware.
 
-The Vite dev server proxies `/api` and `/captures` to the backend on `http://127.0.0.1:8000`.
-It also proxies `/plot-assets` for planned SVG previews.
+## Mock Vs Real Hardware
 
-## Real AxiDraw adapter
-
-The backend still defaults to the mock plotter. For local switching, prefer:
+For mock-backed local development:
 
 ```bash
 make api-dev-mock
+```
+
+For a real AxiDraw-backed backend:
+
+```bash
 make api-dev-axidraw
 ```
 
-If you need to launch the backend another way, set:
-
-```bash
-export LEARN_TO_DRAW_PLOTTER_DRIVER=axidraw
-```
-
-Real AxiDraw no longer falls back to a generic hard-coded machine size. You must also
-configure either:
+The real AxiDraw path also requires the vendor `pyaxidraw` package to be installed separately and an explicit machine definition via either:
 
 ```bash
 export LEARN_TO_DRAW_AXIDRAW_MODEL=1
@@ -133,163 +71,26 @@ export LEARN_TO_DRAW_PLOTTER_BOUNDS_WIDTH_MM=300
 export LEARN_TO_DRAW_PLOTTER_BOUNDS_HEIGHT_MM=218
 ```
 
-For a V2/V3/SE A4 machine, `300 × 218 mm` is the nominal machine-travel example to configure,
-but it is now an explicit example config rather than an implicit backend fallback.
+Additional AxiDraw tuning remains backend-owned and is configured through backend environment variables rather than browser controls.
 
-Optional motion settings:
+## Testing
 
-```bash
-export LEARN_TO_DRAW_AXIDRAW_PORT=YOUR_PORT
-export LEARN_TO_DRAW_AXIDRAW_SPEED_PENDOWN=35
-export LEARN_TO_DRAW_AXIDRAW_SPEED_PENUP=75
-export LEARN_TO_DRAW_AXIDRAW_MODEL=3
-```
-
-Optional documented pen-lift tuning settings:
+Run the backend and frontend test suites with:
 
 ```bash
-export LEARN_TO_DRAW_AXIDRAW_PEN_POS_UP=60
-export LEARN_TO_DRAW_AXIDRAW_PEN_POS_DOWN=30
-export LEARN_TO_DRAW_AXIDRAW_PEN_RATE_RAISE=75
-export LEARN_TO_DRAW_AXIDRAW_PEN_RATE_LOWER=50
-export LEARN_TO_DRAW_AXIDRAW_PEN_DELAY_UP=0
-export LEARN_TO_DRAW_AXIDRAW_PEN_DELAY_DOWN=0
-export LEARN_TO_DRAW_AXIDRAW_PENLIFT=1
+make api-test
+make web-test
 ```
 
-The real adapter expects the official `pyaxidraw` package to be installed separately.
-In practice, the vendor-documented unpack-and-install flow (`pip install .` from the
-unpacked AxiDraw API archive) is what produced the importable `pyaxidraw` module here.
-
-Optional AxiDraw config override settings:
+To verify the frontend production build:
 
 ```bash
-export LEARN_TO_DRAW_AXIDRAW_CONFIG_PATH=/absolute/path/to/axidraw_conf.py
-export LEARN_TO_DRAW_AXIDRAW_NATIVE_RES_FACTOR=1905.0
+cd apps/web
+npm run build
 ```
 
-`LEARN_TO_DRAW_AXIDRAW_CONFIG_PATH` points to an explicit vendor-style config file.
-`LEARN_TO_DRAW_AXIDRAW_NATIVE_RES_FACTOR` generates a temporary override config from the
-vendor default without editing the installed package in place. If both are set, the explicit
-config path wins.
+## Further Docs
 
-Persisted plotter calibration is stored separately under:
-
-```text
-artifacts/calibration/plotter.json
-```
-
-For this slice, the authoritative persisted value is AxiDraw-specific
-`driver_calibration.native_res_factor`; the app also stores a derived generic
-`motion_scale` alongside it for future plotter support. Effective precedence is:
-
-1. `LEARN_TO_DRAW_AXIDRAW_NATIVE_RES_FACTOR`
-2. persisted `artifacts/calibration/plotter.json`
-3. vendor default config
-
-The Plotter card can save the persisted value through the backend. If an env override
-is active, the saved calibration is kept on disk but does not become effective until
-the override is removed and the backend restarts.
-
-## Plot sizing, bounds, and workspace
-
-Built-in patterns now use explicit physical `mm` dimensions so AxiDraw plotting stays deterministic.
-Uploaded SVG sizing is prepared in the backend before the plotter adapter runs.
-
-Stable backend plotter-bounds settings:
-
-```bash
-export LEARN_TO_DRAW_PLOTTER_BOUNDS_WIDTH_MM=300
-export LEARN_TO_DRAW_PLOTTER_BOUNDS_HEIGHT_MM=218
-```
-
-Default session page-setup settings:
-
-```bash
-export LEARN_TO_DRAW_PLOT_PAGE_WIDTH_MM=210
-export LEARN_TO_DRAW_PLOT_PAGE_HEIGHT_MM=297
-export LEARN_TO_DRAW_PLOT_MARGIN_LEFT_MM=20
-export LEARN_TO_DRAW_PLOT_MARGIN_TOP_MM=20
-export LEARN_TO_DRAW_PLOT_MARGIN_RIGHT_MM=20
-export LEARN_TO_DRAW_PLOT_MARGIN_BOTTOM_MM=20
-```
-
-Optional workspace storage override:
-
-```bash
-export LEARN_TO_DRAW_WORKSPACE_DIR=/absolute/path/to/workspace
-```
-
-The app now treats sizing constraints as three separate layers:
-
-- `nominal machine bounds`: explicit model/env machine travel
-- `operational safe bounds`: the backend-owned plotting envelope actually used for validation and plotting
-- `session paper setup`: the current page size and margins mounted in the app
-
-For the AxiDraw driver, the app also keeps a separate device-settings record under:
-
-```text
-artifacts/device_settings/plotter.json
-```
-
-If `LEARN_TO_DRAW_AXIDRAW_MODEL` is explicitly set, the backend derives nominal machine
-bounds from the same vendor travel constants used by the AxiDraw stack and surfaces a
-descriptive model label in the Plotter card. Nominal bounds precedence is:
-
-1. `LEARN_TO_DRAW_PLOTTER_BOUNDS_WIDTH_MM` / `LEARN_TO_DRAW_PLOTTER_BOUNDS_HEIGHT_MM`
-2. model-derived AxiDraw bounds when `LEARN_TO_DRAW_AXIDRAW_MODEL` is explicitly configured
-
-For the real AxiDraw driver, one of those two sources is now required. If neither is
-configured, the backend stays up but marks the plotter unavailable until explicit machine
-bounds or an explicit AxiDraw model are provided.
-
-For real AxiDraw, the backend derives operational safe bounds from the nominal machine
-bounds by trimming `10 mm` from the far right edge and `10 mm` from the bottom edge.
-Those default clearances keep the current top-left origin unchanged while adding slack at
-the risky far edges. The Plotter card now shows both nominal machine bounds and operational
-safe bounds, and it allows a narrow backend-owned override/reset flow for the operational
-safe bounds only.
-
-The persisted device-settings record lives under:
-
-```text
-artifacts/device_settings/plotter.json
-```
-
-For real AxiDraw, that record stores the optional manual operational safe-bounds override.
-Clearing the override returns the backend to the default-clearance envelope derived from
-the nominal machine bounds.
-
-The persisted session workspace lives under:
-
-```text
-artifacts/workspace/plotter.json
-```
-
-The Plotter card can update page width, page height, and margins through the backend.
-The backend computes a drawable area from that session setup and validates that it stays
-inside the operational safe bounds.
-
-If corrected machine bounds make the saved paper setup invalid, `GET /api/plotter/workspace`
-now returns the persisted workspace plus `is_valid=false` and a `validation_error` message
-so the UI can stay usable while plotting remains blocked until the paper setup is fixed.
-
-Normal plotting now uses a single backend-owned preparation path:
-
-- normal runs are prepared into page-mm coordinates and anchored at the drawable area's top-left origin
-- uploaded SVGs with explicit physical units keep their authored size when already within the drawable area and are only downscaled when oversized
-- unitless or px-only uploads are max-fit into the drawable area
-- the normal built-in `test-grid` uses this same preparation path
-- dedicated hardware diagnostics stay fixed-size and use a separate diagnostic passthrough path
-
-The backend refuses prepared output that would exceed the current drawable area or the
-current operational safe bounds.
-
-Each plot run now also records a preparation audit in the run metadata, including:
-
-- the effective operational safe bounds, page size, and drawable area used for the run
-- derived workspace math such as drawable origin and remaining bounds headroom
-- preparation details such as strategy, placement origin, prepared content box, root `viewBox`, scale, and any computed overflow
-
-The Plot Workflow panel shows this audit as a compact read-only summary so bounds,
-workspace math, and prepared placement can be inspected alongside each run.
+- [Architecture](docs/architecture.md): current system structure and boundaries
+- [Project history](docs/history.md): internal slice-by-slice evolution notes
+- [Manual test assets](docs/manual-test-assets): SVGs used for plot sizing and bounds checks

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,37 +1,77 @@
-# Slice 1 Architecture
+# LearnToDraw Architecture
 
-## Goals
+## System Goals And Guardrails
 
-- keep the system local-first
-- keep hardware control in the backend
-- stay modular enough for future real-device adapters
-- avoid premature orchestration or iterative drawing logic
-- add one end-to-end plotting workflow before building the closed loop
+- Keep the system local-first
+- Keep hardware control in the backend
+- Preserve a thin localhost dashboard rather than a browser-side hardware client
+- Isolate AxiDraw-specific behavior inside backend adapters and wrappers
+- Prefer explicit persisted state and explicit run transitions over implicit side effects
 
-## Backend
+## Backend Responsibilities
 
-The backend is the source of truth for hardware state and action execution.
+The backend is the system of record for hardware access and workflow state.
 
-- `models.py` holds shared API and domain models plus hardware exceptions
-- `adapters/` defines plotter and camera contracts and mock implementations
-- `services/hardware.py` coordinates status reads and command execution
-- `services/captures.py` persists capture artifacts and reloads the latest metadata
-- `services/plot_workflow.py` stores SVG assets, tracks plot runs, and advances runs through prepare, plot, and capture stages
-- `api.py` exposes a thin REST surface and static serving for capture previews
+- exposes the HTTP API used by the local dashboard
+- reads hardware status and executes plotter/camera actions
+- persists captures, plot assets, plot runs, calibration, device settings, and workspace state
+- prepares normal plot runs into validated page coordinates before adapter execution
+- keeps diagnostic hardware actions narrow, fixed, and backend-owned
 
-## Frontend
+The current backend structure centers on:
 
-The frontend is a small local control panel.
+- `routes.py` and `api.py` for the thin FastAPI surface
+- `services/hardware.py` for hardware status and control orchestration
+- `services/captures.py` for persisted capture storage and latest-capture lookup
+- `services/plot_workflow.py` for asset storage, run creation, preparation, plotting, and capture flow
+- `services/plotter_calibration.py`, `services/plotter_device_settings.py`, and `services/plotter_workspace.py` for persisted plotter state
 
-- polls hardware status and latest capture
-- polls latest plot run and recent plot runs
-- triggers `home` and `capture` through REST calls
-- uploads SVGs or creates a built-in test pattern
-- shows current state, action progress, errors, and planned-vs-captured comparison
+## Frontend Responsibilities
 
-## Future extension points
+The frontend is a lightweight local dashboard.
 
-- keep the `pyaxidraw` wrapper isolated so a more durable runner can replace the current in-process execution model later
-- expand the real AxiDraw adapter before replacing the mock camera
-- replace the in-process plot-run executor once longer-running or queued work is needed
-- add drawing generation and iterative analysis as separate services without moving hardware access into the browser
+- polls backend endpoints for hardware status, captures, plot runs, and plotter state
+- triggers safe backend-owned actions such as capture, return-to-origin, test actions, and plot workflow operations
+- presents read-only hardware detail plus a small number of bounded controls
+- previews planned-vs-captured output and current workspace information without becoming a second hardware API
+
+## Adapters And Hardware Boundary
+
+Hardware integration stays behind backend interfaces.
+
+- `adapters/plotter.py` and `adapters/camera.py` define the app-facing contracts
+- mock adapters remain available for development and tests
+- the AxiDraw adapter path lives behind the same backend-owned interface
+- undocumented or version-sensitive AxiDraw behavior should stay isolated in the wrapper/client layer rather than leaking into services or routes
+
+## Persistence Under `artifacts/`
+
+Local persisted state is organized by purpose:
+
+- `artifacts/captures`: saved capture metadata and SVG output
+- `artifacts/plot_assets`: uploaded or built-in plot sources
+- `artifacts/plot_runs`: run records and prepared output where applicable
+- `artifacts/calibration`: persisted plotter calibration values
+- `artifacts/device_settings`: persisted plotter device settings such as safe-bounds overrides
+- `artifacts/workspace`: persisted page size and margin setup
+
+Filesystem paths and public URLs are kept separate in the backend so local storage layout does not leak into the HTTP surface.
+
+## Current Workflow Shape
+
+The app currently supports a single backend-owned plotting workflow with a few narrow supporting flows.
+
+- `status`: the frontend polls backend hardware status and availability
+- `captures`: the backend can trigger and persist camera captures, then serve the latest result
+- `plot runs`: uploaded SVGs and built-in patterns become stored assets, then tracked runs with explicit preparation, plotting, and optional capture stages
+- `diagnostics`: fixed built-in pen and pattern tests stay separate from normal plotting semantics
+- `workspace`: page size and margins are persisted and validated against the current drawable area
+- `device settings`: stable machine information and operational safe bounds are backend-owned and surfaced read-only except for narrow safe overrides
+- `calibration`: persisted plotter calibration remains backend-owned and separate from transient runtime overrides
+
+## Extension Points
+
+- replace or extend adapters without changing the frontend’s hardware model
+- evolve the in-process plot-run executor if queued or longer-running work becomes necessary
+- expand capture and analysis workflows without moving hardware control into the browser
+- add more plotter backends by implementing the existing adapter contracts and keeping device-specific behavior isolated

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,47 @@
+# LearnToDraw Project History
+
+This document keeps the internal slice-by-slice evolution notes that used to live in the README. It is meant for contributors and maintainers who want the delivery history, while the README stays focused on explaining the project to new GitHub visitors.
+
+## First Slice
+
+- Established the local-first shape: FastAPI backend plus React/Vite dashboard
+- Introduced plotter and camera adapter contracts with mock implementations
+- Added simple backend-owned `home` and `capture` actions
+- Started local capture persistence under `artifacts/captures`
+
+## Second Slice
+
+- Added tracked plot-run workflow and local plot-run metadata
+- Added SVG upload and a built-in `test-grid` source
+- Introduced local plot asset persistence under `artifacts/plot_assets`
+- Added the first real AxiDraw-backed adapter path behind the existing backend interface
+
+## Pen-Reliability Slice
+
+- Replaced misleading `home` language with explicit `return to origin` semantics
+- Added backend-configured AxiDraw pen-lift tuning
+- Added fixed diagnostic pen actions and tiny built-in diagnostic patterns
+- Split diagnostic plot runs from normal runs by intentionally skipping camera capture for diagnostics
+
+## Plot-Sizing Slice
+
+- Gave built-in plot patterns explicit physical `mm` dimensions
+- Moved normal plot preparation into a backend-owned sizing path
+- Surfaced prepared plot-size metadata in plot-run records and the local UI
+- Added a configurable backend draw area for future layout work
+
+## Workspace Slice
+
+- Separated stable plotter bounds from editable session paper setup
+- Persisted workspace state under `artifacts/workspace`
+- Added backend validation to keep prepared plotting inside drawable area and plotter bounds
+- Added page-size and margin controls in the Plotter card backed by backend state
+
+## Device-Settings Slice
+
+- Added a separate persisted plotter device-settings record under `artifacts/device_settings`
+- Surfaced read-only plotter model information in the Plotter card
+- Added vendor-aligned model labels and model-derived nominal bounds for explicit AxiDraw configurations
+- Separated nominal machine bounds from operational safe bounds, including backend-owned clearances and narrow override support
+
+For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary
- rewrite the README as a GitHub-first project overview
- move slice-by-slice evolution notes into docs/history.md
- refresh docs/architecture.md to describe the current system boundaries and workflow shape

## Testing
- not run (docs-only change)