### PR TITLE
Add helper install script for Applications

### DIFF
--- a/apps/macos-helper/README.md
+++ b/apps/macos-helper/README.md
@@ -18,7 +18,7 @@ From `apps/macos-helper`:
 swift run LearnToDrawCameraHelper
 ```
 
-To package a real `.app` bundle for macOS permission testing:
+To package a real `.app` bundle without installing it:
 
 ```sh
 swift build
@@ -33,8 +33,13 @@ same checkout.
 Recommended stable install location:
 
 ```sh
-./scripts/package-app.sh /Applications/LearnToDrawCameraHelper.app
-open /Applications/LearnToDrawCameraHelper.app
+./scripts/install-app.sh --open
+```
+
+If `/Applications` requires elevated privileges on your machine:
+
+```sh
+sudo ./scripts/install-app.sh --open
 ```
 
 The custom URL scheme `learntodraw-helper://open` only works when macOS LaunchServices

--- a/apps/macos-helper/scripts/install-app.sh
+++ b/apps/macos-helper/scripts/install-app.sh
@@ -1,0 +1,81 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEFAULT_TARGET="/Applications/LearnToDrawCameraHelper.app"
+OPEN_AFTER_INSTALL=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/install-app.sh [--open] [TARGET_APP_PATH]
+
+Examples:
+  ./scripts/install-app.sh
+  ./scripts/install-app.sh --open
+  ./scripts/install-app.sh ~/Applications/LearnToDrawCameraHelper.app
+
+Notes:
+  - Default install target is /Applications/LearnToDrawCameraHelper.app
+  - If /Applications requires elevated privileges, rerun with sudo
+EOF
+}
+
+TARGET_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --open)
+      OPEN_AFTER_INSTALL=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "$TARGET_PATH" ]]; then
+        echo "Unexpected extra argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      TARGET_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+TARGET_PATH="${TARGET_PATH:-$DEFAULT_TARGET}"
+TARGET_PARENT="$(dirname "$TARGET_PATH")"
+STAGING_PATH="$(mktemp -d)/LearnToDrawCameraHelper.app"
+
+cleanup() {
+  rm -rf "$(dirname "$STAGING_PATH")"
+}
+trap cleanup EXIT
+
+"$ROOT_DIR/scripts/package-app.sh" "$STAGING_PATH" >/dev/null
+
+mkdir -p "$TARGET_PARENT" 2>/dev/null || true
+
+if [[ -e "$TARGET_PATH" ]] && [[ ! -w "$TARGET_PATH" ]] && [[ $EUID -ne 0 ]]; then
+  echo "Cannot replace existing app at $TARGET_PATH without elevated privileges." >&2
+  echo "Rerun with sudo or choose a writable target path." >&2
+  exit 1
+fi
+
+if [[ ! -w "$TARGET_PARENT" ]] && [[ $EUID -ne 0 ]]; then
+  echo "Cannot write to $TARGET_PARENT without elevated privileges." >&2
+  echo "Rerun with sudo or choose a writable target path." >&2
+  exit 1
+fi
+
+rm -rf "$TARGET_PATH"
+ditto "$STAGING_PATH" "$TARGET_PATH"
+
+echo "Installed helper app to $TARGET_PATH"
+
+if [[ "$OPEN_AFTER_INSTALL" -eq 1 ]]; then
+  open "$TARGET_PATH"
+fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,7 @@ The repository now includes a macOS-first helper proof under `apps/macos-helper`
 - packaged helper bundles embed the current repo root so they can launch reliably from Finder or `/Applications`
 - the helper registers `learntodraw-helper://open` so the dashboard can prompt macOS to open it when missing
 - reliable URL-scheme launch depends on macOS LaunchServices recognizing a stable installed bundle, with `/Applications/LearnToDrawCameraHelper.app` as the recommended location
+- `apps/macos-helper/scripts/install-app.sh` is the supported local install/update path for placing the helper in `/Applications`
 - all hardware access still stays in the backend on `127.0.0.1:8000`
 - the web app can use the helper only for startup, retry, and failure state while keeping backend APIs unchanged
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -54,5 +54,6 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Fixed helper restart to wait for owned backend shutdown before relaunching, avoiding false "outside helper control" failures during post-permission retries
 - Made packaged helper bundles movable by embedding the repo root in a generated app resource config instead of deriving it from the bundle path
 - Added a dashboard `Open helper` action backed by the `learntodraw-helper://open` custom URL scheme for helper-missing recovery
+- Added a dedicated helper install/update script for `/Applications/LearnToDrawCameraHelper.app` to reduce ad hoc packaging and launch confusion
 
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary
- add a supported install/update script for /Applications/LearnToDrawCameraHelper.app
- make the helper README and architecture docs point to /Applications as the stable install path
- record the install-polish slice in history docs

## Validation
- swift test
- make web-test
- npm run build in apps/web
- manual end-to-end validation with the helper installed in /Applications
