### PR TITLE
Harden helper camera startup and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,38 @@ export LEARN_TO_DRAW_CAMERA_DISCARD_FRAMES=2
 
 On macOS, the first real capture may trigger a camera permission prompt. A denied permission or missing device will surface through the backend camera status and capture endpoint.
 
+For helper-managed real camera smoke testing on the current hardware:
+
+```bash
+cd apps/macos-helper
+LEARN_TO_DRAW_PLOTTER_DRIVER=axidraw LEARN_TO_DRAW_AXIDRAW_MODEL=1 swift run LearnToDrawCameraHelper
+```
+
+In another shell:
+
+```bash
+curl http://127.0.0.1:8001/status
+curl -X POST http://127.0.0.1:8001/start
+curl http://127.0.0.1:8000/api/health
+curl http://127.0.0.1:8000/api/hardware/status
+curl -X POST http://127.0.0.1:8000/api/camera/capture
+curl http://127.0.0.1:8000/api/captures/latest
+```
+
+If camera index `0` fails, stop the helper-managed backend, relaunch the helper with an
+explicit camera index, and retry until one standalone capture succeeds:
+
+```bash
+export LEARN_TO_DRAW_OPENCV_CAMERA_INDEX=1
+```
+
+This smoke path is intentionally scoped to one real manual capture. It does not require a
+full plot run with capture.
+
+The helper is intended to run as a single app instance. During development, `/status` also
+includes a helper instance id and helper launch timestamp so repeated opens make it obvious
+whether you are still talking to the same helper process.
+
 ## Mock Vs Real Hardware
 
 For mock-backed local development:

--- a/apps/api/src/learn_to_draw_api/adapters/opencv_camera.py
+++ b/apps/api/src/learn_to_draw_api/adapters/opencv_camera.py
@@ -93,17 +93,19 @@ class OpenCVCamera:
             raise HardwareBusyError("Camera is busy.")
         self._busy = True
         self._error = None
+        self._last_read_result = "not_attempted"
+        self._last_resolution = None
         self._touch()
         try:
             newly_opened = self._ensure_open()
             if newly_opened:
                 self._warm_up_camera()
             frame = self._read_frame()
-            encoded = self._encode_frame(frame)
             height, width = self._frame_dimensions(frame)
+            self._last_resolution = f"{width}x{height}"
+            encoded = self._encode_frame(frame)
             capture_id = uuid4().hex
             self._last_capture_id = capture_id
-            self._last_resolution = f"{width}x{height}"
             self._touch()
             return CaptureArtifact(
                 capture_id=capture_id,
@@ -154,6 +156,7 @@ class OpenCVCamera:
         self._state = "ready"
         self._last_open_result = "opened"
         self._last_open_message = f"VideoCapture({self._camera_index}) opened successfully."
+        self._last_read_result = "not_attempted"
         self._last_backend_name = self._capture_backend_name(capture)
         self._error = None
         self._touch()
@@ -185,6 +188,9 @@ class OpenCVCamera:
         ok, encoded = cv2.imencode(".jpg", frame)
         if not ok:
             self._error = "OpenCV camera failed to encode a JPEG capture."
+            self._available = True
+            self._connected = self._capture is not None
+            self._state = "ready" if self._capture is not None else "unavailable"
             self._touch()
             raise HardwareOperationError(self._error)
         return encoded.tobytes()

--- a/apps/api/tests/test_camera_adapter.py
+++ b/apps/api/tests/test_camera_adapter.py
@@ -166,6 +166,8 @@ def test_opencv_camera_reports_unavailable_when_open_fails_on_capture(monkeypatc
     assert status.details["initialization_state"] == "unavailable"
     assert status.details["last_open_result"] == "failed"
     assert status.details["last_backend_name"] is None
+    assert status.details["last_read_result"] == "not_attempted"
+    assert status.details["resolution"] is None
     assert "VideoCapture(0) did not open" in status.details["last_open_message"]
     assert "permission was denied" in status.error
 
@@ -185,9 +187,13 @@ def test_opencv_camera_raises_when_frame_read_fails(monkeypatch):
     status = camera.get_status()
     assert status.details["last_open_result"] == "opened"
     assert status.details["last_read_result"] == "failed"
+    assert status.details["last_open_message"] == "VideoCapture(0) opened successfully."
+    assert status.details["resolution"] is None
+    assert status.available is False
+    assert status.connected is False
 
 
-def test_opencv_camera_raises_when_jpeg_encode_fails(monkeypatch):
+def test_opencv_camera_raises_when_jpeg_encode_fails_but_remains_retryable(monkeypatch):
     fake_capture = FakeVideoCapture()
     fake_cv2 = SimpleNamespace(
         VideoCapture=lambda index: fake_capture,
@@ -198,6 +204,15 @@ def test_opencv_camera_raises_when_jpeg_encode_fails(monkeypatch):
 
     with pytest.raises(HardwareOperationError, match="failed to encode a JPEG"):
         camera.capture()
+
+    status = camera.get_status()
+    assert status.available is True
+    assert status.connected is True
+    assert status.details["initialization_state"] == "ready"
+    assert status.details["last_open_result"] == "opened"
+    assert status.details["last_read_result"] == "succeeded"
+    assert status.details["resolution"] == "640x480"
+    assert status.error == "OpenCV camera failed to encode a JPEG capture."
 
 
 def test_opencv_camera_disconnect_releases_device(monkeypatch):

--- a/apps/macos-helper/README.md
+++ b/apps/macos-helper/README.md
@@ -57,6 +57,9 @@ The helper exposes:
 - `POST /stop`
 - `POST /restart`
 
+The helper is intended to run as a single app instance. Reopening the app or custom URL scheme
+should reuse the existing helper process rather than leaving multiple menu-bar helpers active.
+
 Example:
 
 ```sh
@@ -78,3 +81,14 @@ It forwards these optional camera environment variables from the helper process 
 The helper is plotter-neutral. It does not configure plotter mode, inject AxiDraw settings,
 or package plotter configuration into the app bundle. Plotter behavior remains owned by the
 backend's normal environment and configuration.
+
+For a repeatable real-camera smoke pass with the helper-managed backend:
+
+1. Launch the helper with the desired plotter environment and any optional `LEARN_TO_DRAW_OPENCV_CAMERA_INDEX` override already exported.
+2. Confirm `GET /status` reports the helper as reachable and `POST /start` moves it to `running`.
+3. Verify the backend on `127.0.0.1:8000` is healthy and inspect `/api/hardware/status` for the camera details.
+4. Trigger one `POST /api/camera/capture` and confirm `/api/captures/latest` returns the new JPEG metadata.
+5. Check the helper `instance_id` / `helper_instance_id` and `helper_launched_at` fields in `/status` while repeating opens to confirm you are still talking to the same helper process.
+
+This helper flow keeps camera index selection env-driven. If the default index is wrong, relaunch
+the helper with a different `LEARN_TO_DRAW_OPENCV_CAMERA_INDEX` value rather than adding runtime UI controls.

--- a/apps/macos-helper/Sources/CameraHelperCore/HelperController.swift
+++ b/apps/macos-helper/Sources/CameraHelperCore/HelperController.swift
@@ -7,6 +7,8 @@ public actor HelperController {
     private let healthChecker: HealthChecking
     private let pollIntervalNanoseconds: UInt64
     private let mode = "camera"
+    private let helperInstanceID: String
+    private let helperLaunchedAt: Date
 
     private var state: HelperState = .stopped
     private var backendHealth: BackendHealth = .unreachable
@@ -21,11 +23,15 @@ public actor HelperController {
         launchConfiguration: BackendLaunchConfiguration,
         launcher: BackendProcessLaunching,
         healthChecker: HealthChecking,
+        helperInstanceID: String = UUID().uuidString,
+        helperLaunchedAt: Date = Date(),
         pollIntervalNanoseconds: UInt64 = 250_000_000
     ) {
         self.launchConfiguration = launchConfiguration
         self.launcher = launcher
         self.healthChecker = healthChecker
+        self.helperInstanceID = helperInstanceID
+        self.helperLaunchedAt = helperLaunchedAt
         self.pollIntervalNanoseconds = pollIntervalNanoseconds
     }
 
@@ -35,6 +41,7 @@ public actor HelperController {
 
     public func start() async -> HelperStatus {
         if state == .starting || state == .running {
+            HelperLogger.log(instanceID: helperInstanceID, message: "start requested while already \(state.rawValue)")
             return currentStatus()
         }
 
@@ -42,10 +49,12 @@ public actor HelperController {
             state = .failed
             backendHealth = .healthy
             lastError = "Backend port 8000 is already healthy outside helper control."
+            HelperLogger.log(instanceID: helperInstanceID, message: "backend already healthy outside helper control")
             return currentStatus()
         }
 
         do {
+            HelperLogger.log(instanceID: helperInstanceID, message: "launching backend")
             let process = try launcher.launchBackend(configuration: launchConfiguration)
             stopRequested = false
             managedProcess = process
@@ -71,11 +80,13 @@ public actor HelperController {
             state = .failed
             backendHealth = .unreachable
             lastError = error.localizedDescription
+            HelperLogger.log(instanceID: helperInstanceID, message: "backend launch failed: \(error.localizedDescription)")
             return currentStatus()
         }
     }
 
     public func stop() async -> HelperStatus {
+        HelperLogger.log(instanceID: helperInstanceID, message: "stop requested")
         startupTask?.cancel()
         startupTask = nil
         stopRequested = true
@@ -84,6 +95,7 @@ public actor HelperController {
             state = .stopped
             backendHealth = .unreachable
             lastError = nil
+            HelperLogger.log(instanceID: helperInstanceID, message: "stop requested with no managed backend")
             return currentStatus()
         }
 
@@ -93,10 +105,12 @@ public actor HelperController {
         state = .stopped
         backendHealth = .unreachable
         lastError = nil
+        HelperLogger.log(instanceID: helperInstanceID, message: "backend stopped")
         return currentStatus()
     }
 
     public func restart() async -> HelperStatus {
+        HelperLogger.log(instanceID: helperInstanceID, message: "restart requested")
         _ = await stop()
         return await start()
     }
@@ -111,6 +125,7 @@ public actor HelperController {
                 if state == .starting && managedProcess?.processIdentifier == expectedPID {
                     state = .running
                     backendHealth = .healthy
+                    HelperLogger.log(instanceID: helperInstanceID, message: "backend became healthy pid=\(expectedPID)")
                 }
                 return
             }
@@ -153,6 +168,10 @@ public actor HelperController {
         managedProcess = nil
         lastExitCode = exit.exitCode
         backendHealth = .unreachable
+        HelperLogger.log(
+            instanceID: helperInstanceID,
+            message: "backend exited code=\(exit.exitCode) stderr=\(exit.stderrTail ?? "none")"
+        )
 
         if stopRequested {
             state = .stopped
@@ -165,6 +184,8 @@ public actor HelperController {
 
     private func currentStatus() -> HelperStatus {
         HelperStatus(
+            helperInstanceID: helperInstanceID,
+            helperLaunchedAt: helperLaunchedAt,
             state: state,
             backendHealth: backendHealth,
             mode: mode,

--- a/apps/macos-helper/Sources/CameraHelperCore/HelperLogging.swift
+++ b/apps/macos-helper/Sources/CameraHelperCore/HelperLogging.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public enum HelperLogger {
+    private static let formatter = ISO8601DateFormatter()
+
+    public static func log(instanceID: String, message: String) {
+        let timestamp = formatter.string(from: Date())
+        fputs("[LearnToDrawHelper instance=\(instanceID) at=\(timestamp)] \(message)\n", stderr)
+    }
+}

--- a/apps/macos-helper/Sources/CameraHelperCore/HelperSingleInstance.swift
+++ b/apps/macos-helper/Sources/CameraHelperCore/HelperSingleInstance.swift
@@ -1,0 +1,131 @@
+import AppKit
+import Darwin
+import Foundation
+
+public struct RunningHelperApp: Equatable, Sendable {
+    public let processIdentifier: Int32
+
+    public init(processIdentifier: Int32) {
+        self.processIdentifier = processIdentifier
+    }
+}
+
+public protocol RunningHelperAppQuerying: Sendable {
+    func runningApplications(bundleIdentifier: String) -> [RunningHelperApp]
+    @discardableResult
+    func activate(processIdentifier: Int32) -> Bool
+}
+
+public protocol HelperInstanceLocking: Sendable {
+    func tryAcquire() throws -> Bool
+}
+
+public struct AppKitRunningHelperApps: RunningHelperAppQuerying {
+    public init() {}
+
+    public func runningApplications(bundleIdentifier: String) -> [RunningHelperApp] {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).map {
+            RunningHelperApp(processIdentifier: $0.processIdentifier)
+        }
+    }
+
+    @discardableResult
+    public func activate(processIdentifier: Int32) -> Bool {
+        guard
+            let application = NSRunningApplication.runningApplications(
+                withBundleIdentifier: Bundle.main.bundleIdentifier ?? ""
+            ).first(where: { $0.processIdentifier == processIdentifier })
+        else {
+            return false
+        }
+
+        return application.activate(options: [.activateIgnoringOtherApps])
+    }
+}
+
+public final class HelperInstanceLock: HelperInstanceLocking, @unchecked Sendable {
+    private let lockFileURL: URL
+    private var fileDescriptor: Int32 = -1
+
+    public init(lockFileURL: URL) {
+        self.lockFileURL = lockFileURL
+    }
+
+    deinit {
+        if fileDescriptor >= 0 {
+            close(fileDescriptor)
+        }
+    }
+
+    public func tryAcquire() throws -> Bool {
+        if fileDescriptor >= 0 {
+            return true
+        }
+
+        let descriptor = open(lockFileURL.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        if flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+            let lockError = errno
+            close(descriptor)
+            if lockError == EWOULDBLOCK {
+                return false
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: lockError) ?? .EIO)
+        }
+
+        fileDescriptor = descriptor
+        return true
+    }
+}
+
+public struct HelperSingleInstanceCoordinator: Sendable {
+    private let bundleIdentifier: String
+    private let runningApplications: RunningHelperAppQuerying
+    private let instanceLock: HelperInstanceLocking
+
+    public init(
+        bundleIdentifier: String,
+        runningApplications: RunningHelperAppQuerying = AppKitRunningHelperApps(),
+        instanceLock: HelperInstanceLocking? = nil
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.runningApplications = runningApplications
+        self.instanceLock = instanceLock ?? HelperInstanceLock(
+            lockFileURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(bundleIdentifier).lock")
+        )
+    }
+
+    public func existingInstanceProcessIdentifier(currentProcessIdentifier: Int32) -> Int32? {
+        runningApplications
+            .runningApplications(bundleIdentifier: bundleIdentifier)
+            .map(\.processIdentifier)
+            .sorted()
+            .first(where: { $0 != currentProcessIdentifier })
+    }
+
+    @discardableResult
+    public func activateExistingInstanceIfNeeded(currentProcessIdentifier: Int32) -> Bool {
+        guard let existingPID = existingInstanceProcessIdentifier(
+            currentProcessIdentifier: currentProcessIdentifier
+        ) else {
+            return false
+        }
+
+        _ = runningApplications.activate(processIdentifier: existingPID)
+        return true
+    }
+
+    @discardableResult
+    public func handOffToExistingInstanceIfNeeded(currentProcessIdentifier: Int32) throws -> Bool {
+        guard try !instanceLock.tryAcquire() else {
+            return false
+        }
+
+        _ = activateExistingInstanceIfNeeded(currentProcessIdentifier: currentProcessIdentifier)
+        return true
+    }
+}

--- a/apps/macos-helper/Sources/CameraHelperCore/HelperStatus.swift
+++ b/apps/macos-helper/Sources/CameraHelperCore/HelperStatus.swift
@@ -14,6 +14,8 @@ public enum BackendHealth: String, Codable, Equatable, Sendable {
 }
 
 public struct HelperStatus: Equatable, Sendable {
+    public let helperInstanceID: String
+    public let helperLaunchedAt: Date
     public let state: HelperState
     public let backendHealth: BackendHealth
     public let mode: String
@@ -24,6 +26,8 @@ public struct HelperStatus: Equatable, Sendable {
     public let lastExitCode: Int32?
 
     public init(
+        helperInstanceID: String,
+        helperLaunchedAt: Date,
         state: HelperState,
         backendHealth: BackendHealth,
         mode: String,
@@ -33,6 +37,8 @@ public struct HelperStatus: Equatable, Sendable {
         lastError: String?,
         lastExitCode: Int32?
     ) {
+        self.helperInstanceID = helperInstanceID
+        self.helperLaunchedAt = helperLaunchedAt
         self.state = state
         self.backendHealth = backendHealth
         self.mode = mode
@@ -44,6 +50,8 @@ public struct HelperStatus: Equatable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
+        case helperInstanceID = "helper_instance_id"
+        case helperLaunchedAt = "helper_launched_at"
         case state
         case backendHealth = "backend_health"
         case mode
@@ -58,6 +66,8 @@ public struct HelperStatus: Equatable, Sendable {
 extension HelperStatus: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(helperInstanceID, forKey: .helperInstanceID)
+        try container.encode(helperLaunchedAt, forKey: .helperLaunchedAt)
         try container.encode(state, forKey: .state)
         try container.encode(backendHealth, forKey: .backendHealth)
         try container.encode(mode, forKey: .mode)

--- a/apps/macos-helper/Sources/CameraHelperCore/LocalHTTPServer.swift
+++ b/apps/macos-helper/Sources/CameraHelperCore/LocalHTTPServer.swift
@@ -3,6 +3,7 @@ import Network
 
 public final class LocalHTTPServer {
     private let controller: HelperController
+    private let helperInstanceID: String
     private let host: NWEndpoint.Host
     private let port: NWEndpoint.Port
     private let queue = DispatchQueue(label: "learn-to-draw.camera-helper.http")
@@ -11,10 +12,12 @@ public final class LocalHTTPServer {
 
     public init(
         controller: HelperController,
+        helperInstanceID: String,
         host: String = "127.0.0.1",
         port: UInt16 = 8001
     ) {
         self.controller = controller
+        self.helperInstanceID = helperInstanceID
         self.host = NWEndpoint.Host(host)
         self.port = NWEndpoint.Port(rawValue: port) ?? 8001
         let encoder = JSONEncoder()
@@ -33,16 +36,24 @@ public final class LocalHTTPServer {
         }
         listener.stateUpdateHandler = { state in
             if case .failed(let error) = state {
-                fputs("Helper HTTP listener failed: \(error)\n", stderr)
+                HelperLogger.log(
+                    instanceID: self.helperInstanceID,
+                    message: "helper HTTP listener failed: \(error)"
+                )
             }
         }
         listener.start(queue: queue)
         self.listener = listener
+        HelperLogger.log(
+            instanceID: helperInstanceID,
+            message: "helper HTTP listener started on \(host):\(port)"
+        )
     }
 
     public func stop() {
         listener?.cancel()
         listener = nil
+        HelperLogger.log(instanceID: helperInstanceID, message: "helper HTTP listener stopped")
     }
 
     private func handle(connection: NWConnection) {

--- a/apps/macos-helper/Sources/LearnToDrawCameraHelper/main.swift
+++ b/apps/macos-helper/Sources/LearnToDrawCameraHelper/main.swift
@@ -1,11 +1,14 @@
 import AppKit
 import CameraHelperCore
+import Darwin
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var helperServer: LocalHTTPServer?
     private var statusItem: NSStatusItem?
     private let controller: HelperController
     private let runtimeConfiguration: HelperRuntimeConfiguration
+    private let helperInstanceID: String
+    private let singleInstanceCoordinator: HelperSingleInstanceCoordinator
 
     override init() {
         let runtimeConfiguration: HelperRuntimeConfiguration
@@ -16,15 +19,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         self.runtimeConfiguration = runtimeConfiguration
+        self.helperInstanceID = UUID().uuidString
+        self.singleInstanceCoordinator = HelperSingleInstanceCoordinator(
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "com.learntodraw.CameraHelper"
+        )
         self.controller = HelperController(
             launchConfiguration: runtimeConfiguration.launchConfiguration,
             launcher: FoundationBackendProcessLauncher(),
-            healthChecker: URLSessionHealthChecker()
+            healthChecker: URLSessionHealthChecker(),
+            helperInstanceID: helperInstanceID
         )
         super.init()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        if handOffToExistingInstanceIfNeeded(reason: "launch") {
+            return
+        }
         installStatusItem()
         ensureHelperServerStarted()
     }
@@ -35,7 +46,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        if handOffToExistingInstanceIfNeeded(reason: "url-open") {
+            return
+        }
+
+        NSApp.activate(ignoringOtherApps: true)
         ensureHelperServerStarted()
+    }
+
+    private func handOffToExistingInstanceIfNeeded(reason: String) -> Bool {
+        let currentPID = Int32(ProcessInfo.processInfo.processIdentifier)
+        let shouldExit: Bool
+        do {
+            shouldExit = try singleInstanceCoordinator.handOffToExistingInstanceIfNeeded(
+                currentProcessIdentifier: currentPID
+            )
+        } catch {
+            HelperLogger.log(
+                instanceID: helperInstanceID,
+                message: "failed to evaluate single-instance handoff during \(reason): \(error.localizedDescription)"
+            )
+            return false
+        }
+
+        guard shouldExit else {
+            return false
+        }
+
+        HelperLogger.log(
+            instanceID: helperInstanceID,
+            message: "detected existing helper instance during \(reason); handing off and exiting"
+        )
+        fflush(stderr)
+        exit(EXIT_SUCCESS)
     }
 
     private func ensureHelperServerStarted() {
@@ -45,13 +88,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let server = LocalHTTPServer(
             controller: controller,
+            helperInstanceID: helperInstanceID,
             host: runtimeConfiguration.helperHost,
             port: runtimeConfiguration.helperPort
         )
         do {
             try server.start()
             helperServer = server
+            HelperLogger.log(instanceID: helperInstanceID, message: "helper app ready")
         } catch {
+            HelperLogger.log(instanceID: helperInstanceID, message: "helper app failed to start: \(error.localizedDescription)")
             let alert = NSAlert()
             alert.messageText = "LearnToDraw helper failed to start"
             alert.informativeText = error.localizedDescription

--- a/apps/macos-helper/Tests/CameraHelperCoreTests/HelperControllerTests.swift
+++ b/apps/macos-helper/Tests/CameraHelperCoreTests/HelperControllerTests.swift
@@ -75,6 +75,25 @@ final class HelperControllerTests: XCTestCase {
         XCTAssertEqual(launcher.launchCount, 1)
     }
 
+    func testRepeatedStartWhileHealthyReturnsExistingRunningStatus() async {
+        let launcher = MockLauncher()
+        let healthChecker = MockHealthChecker(results: [false, true])
+        let controller = makeController(
+            launcher: launcher,
+            healthChecker: healthChecker,
+            pollIntervalNanoseconds: 1_000_000
+        )
+
+        _ = await controller.start()
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let status = await controller.start()
+
+        XCTAssertEqual(status.state, .running)
+        XCTAssertEqual(status.backendHealth, .healthy)
+        XCTAssertEqual(status.managedPID, 4242)
+        XCTAssertEqual(launcher.launchCount, 1)
+    }
+
     func testStopReturnsToStoppedAndStopsManagedProcess() async {
         let launcher = MockLauncher()
         let controller = makeController(
@@ -146,9 +165,27 @@ final class HelperControllerTests: XCTestCase {
         XCTAssertTrue(launcher.launchedProcesses[0].stopCalled)
     }
 
+    func testStatusIncludesStableHelperInstanceIdentity() async {
+        let launchDate = Date(timeIntervalSince1970: 1_710_000_000)
+        let controller = makeController(
+            helperInstanceID: "helper-instance-test",
+            helperLaunchedAt: launchDate
+        )
+
+        let first = await controller.status()
+        let second = await controller.status()
+
+        XCTAssertEqual(first.helperInstanceID, "helper-instance-test")
+        XCTAssertEqual(first.helperLaunchedAt, launchDate)
+        XCTAssertEqual(second.helperInstanceID, "helper-instance-test")
+        XCTAssertEqual(second.helperLaunchedAt, launchDate)
+    }
+
     private func makeController(
         launcher: MockLauncher = MockLauncher(),
         healthChecker: MockHealthChecker = MockHealthChecker(results: []),
+        helperInstanceID: String = "test-helper-instance",
+        helperLaunchedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
         pollIntervalNanoseconds: UInt64 = 1_000_000
     ) -> HelperController {
         HelperController(
@@ -161,6 +198,8 @@ final class HelperControllerTests: XCTestCase {
             ),
             launcher: launcher,
             healthChecker: healthChecker,
+            helperInstanceID: helperInstanceID,
+            helperLaunchedAt: helperLaunchedAt,
             pollIntervalNanoseconds: pollIntervalNanoseconds
         )
     }

--- a/apps/macos-helper/Tests/CameraHelperCoreTests/HelperSingleInstanceTests.swift
+++ b/apps/macos-helper/Tests/CameraHelperCoreTests/HelperSingleInstanceTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import CameraHelperCore
+
+final class HelperSingleInstanceTests: XCTestCase {
+    func testReturnsNilWhenNoOtherHelperInstanceExists() {
+        let coordinator = HelperSingleInstanceCoordinator(
+            bundleIdentifier: "com.learntodraw.CameraHelper",
+            runningApplications: MockRunningHelperApps(processIdentifiers: [101]),
+            instanceLock: MockHelperInstanceLock(acquireResult: true)
+        )
+
+        let existingPID = coordinator.existingInstanceProcessIdentifier(
+            currentProcessIdentifier: 101
+        )
+
+        XCTAssertNil(existingPID)
+    }
+
+    func testActivatesExistingHelperInstanceWhenAnotherProcessIsRunning() {
+        let runningApps = MockRunningHelperApps(processIdentifiers: [101, 303])
+        let coordinator = HelperSingleInstanceCoordinator(
+            bundleIdentifier: "com.learntodraw.CameraHelper",
+            runningApplications: runningApps,
+            instanceLock: MockHelperInstanceLock(acquireResult: false)
+        )
+
+        let activated = coordinator.activateExistingInstanceIfNeeded(
+            currentProcessIdentifier: 303
+        )
+
+        XCTAssertTrue(activated)
+        XCTAssertEqual(runningApps.activatedProcessIdentifier, 101)
+    }
+
+    func testIgnoresCurrentProcessAndChoosesExistingHelperOwner() {
+        let runningApps = MockRunningHelperApps(processIdentifiers: [450, 900, 1200])
+        let coordinator = HelperSingleInstanceCoordinator(
+            bundleIdentifier: "com.learntodraw.CameraHelper",
+            runningApplications: runningApps,
+            instanceLock: MockHelperInstanceLock(acquireResult: true)
+        )
+
+        let existingPID = coordinator.existingInstanceProcessIdentifier(
+            currentProcessIdentifier: 900
+        )
+
+        XCTAssertEqual(existingPID, 450)
+    }
+
+    func testPrimaryInstanceAcquiresLockAndDoesNotHandOff() throws {
+        let runningApps = MockRunningHelperApps(processIdentifiers: [101])
+        let coordinator = HelperSingleInstanceCoordinator(
+            bundleIdentifier: "com.learntodraw.CameraHelper",
+            runningApplications: runningApps,
+            instanceLock: MockHelperInstanceLock(acquireResult: true)
+        )
+
+        let handedOff = try coordinator.handOffToExistingInstanceIfNeeded(
+            currentProcessIdentifier: 101
+        )
+
+        XCTAssertFalse(handedOff)
+        XCTAssertNil(runningApps.activatedProcessIdentifier)
+    }
+
+    func testSecondaryInstanceHandsOffWhenLockIsAlreadyHeld() throws {
+        let runningApps = MockRunningHelperApps(processIdentifiers: [101, 303])
+        let coordinator = HelperSingleInstanceCoordinator(
+            bundleIdentifier: "com.learntodraw.CameraHelper",
+            runningApplications: runningApps,
+            instanceLock: MockHelperInstanceLock(acquireResult: false)
+        )
+
+        let handedOff = try coordinator.handOffToExistingInstanceIfNeeded(
+            currentProcessIdentifier: 303
+        )
+
+        XCTAssertTrue(handedOff)
+        XCTAssertEqual(runningApps.activatedProcessIdentifier, 101)
+    }
+}
+
+private final class MockRunningHelperApps: RunningHelperAppQuerying, @unchecked Sendable {
+    let processIdentifiers: [Int32]
+    private(set) var activatedProcessIdentifier: Int32?
+
+    init(processIdentifiers: [Int32]) {
+        self.processIdentifiers = processIdentifiers
+    }
+
+    func runningApplications(bundleIdentifier: String) -> [RunningHelperApp] {
+        processIdentifiers.map(RunningHelperApp.init(processIdentifier:))
+    }
+
+    func activate(processIdentifier: Int32) -> Bool {
+        activatedProcessIdentifier = processIdentifier
+        return true
+    }
+}
+
+private struct MockHelperInstanceLock: HelperInstanceLocking {
+    let acquireResult: Bool
+
+    func tryAcquire() throws -> Bool {
+        acquireResult
+    }
+}

--- a/apps/web/src/types/helper.ts
+++ b/apps/web/src/types/helper.ts
@@ -2,6 +2,8 @@ export type HelperState = "stopped" | "starting" | "running" | "failed";
 export type HelperBackendHealth = "unreachable" | "starting" | "healthy";
 
 export interface HelperStatus {
+  helper_instance_id?: string;
+  helper_launched_at?: string;
   state: HelperState;
   backend_health: HelperBackendHealth;
   mode: string;


### PR DESCRIPTION
## Summary
- make the installed helper reuse a single running instance across repeated app and URL-scheme opens
- add stable helper instance id and launch timestamp observability to helper status and logs
- harden the helper-managed real camera path with clearer diagnostics and regression coverage

## Testing
- make api-test
- make api-lint
- make web-test
- make web-lint
- npm run build
- swift test
- packaged helper real-camera smoke pass on index 0 after macOS camera permission was granted