### PR TITLE
Add agent workflow playbook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,14 @@
 
 - What changed?
 - Why does it exist?
+- What was the slice plan or plan summary?
 
 ## Checks
 
 - [ ] `make api-test`
 - [ ] `make web-test`
 - [ ] `make web-build`
+- [ ] I listed the verification I actually ran in the PR body
 - [ ] I noted any checks I could not run and why
 
 ## Architecture
@@ -19,5 +21,6 @@
 ## Risk Review
 
 - [ ] I called out any hardware assumptions or undocumented behavior
+- [ ] I called out version-sensitive behavior when relevant
 - [ ] I updated docs or config notes if behavior changed
 - [ ] This PR is a narrow, reviewable slice

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ Write a narrow implementation plan before editing when work:
 - changes plot-run or artifact models
 - depends on undocumented or version-sensitive hardware behavior
 
+For Codex-driven work, use `docs/agent-workflow.md` as the execution playbook for the pre-edit plan format, the per-slice delivery loop, and the default verification expectations.
+
 ## Testing Expectations
 Before finishing substantial work:
 - backend: `make api-test`

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -1,0 +1,178 @@
+# Agent Workflow
+
+This document is the internal execution playbook for Codex-driven work in this repo. It complements [workflow.md](workflow.md), which stays focused on branch and PR hygiene.
+
+## Default Delivery Loop
+
+Use this loop for every implementation slice:
+
+1. Explore the relevant code, docs, and tests first.
+2. Write a short pre-edit plan.
+3. Implement one narrow slice on a short-lived `codex/<topic>` branch.
+4. Run the relevant verification.
+5. Summarize what changed, what was verified, and any remaining risk.
+
+Keep repo vocabulary aligned with `AGENTS.md`, the PR template, and `docs/workflow.md`. Do not create a second policy layer.
+
+## Mandatory Pre-Edit Plan
+
+Write this before editing any code or docs:
+
+```md
+Goal:
+
+In scope:
+- ...
+
+Out of scope:
+- ...
+
+Expected files or subsystems:
+- ...
+
+Verification:
+- ...
+
+Risks or assumptions:
+- ...
+```
+
+Every slice needs this short form. Expand it only when the work is higher risk.
+
+## When To Expand The Plan
+
+Use the short plan for simple backend-only or frontend-only slices. Write an expanded plan when work is:
+
+- cross-stack
+- hardware-facing
+- changing a data or artifact model
+- version-sensitive
+- relying on undocumented behavior
+
+An expanded plan should still stay brief, but it must also name:
+
+- interface or contract changes
+- data flow and state transitions affected
+- failure modes or edge cases worth verifying
+- tests or checks that prove the risky path still works
+
+## Primary Playbooks
+
+### Backend-Only Slice
+
+- Explore the affected route, service, adapter, and tests before editing.
+- Keep route handlers thin and put orchestration in services.
+- Keep hardware behavior in adapters and wrappers.
+- Extend existing backend-owned models instead of creating parallel flows unless the distinction matters architecturally.
+- Run `make api-test`.
+- Run `make api-lint` when touching backend validation, typing, lint-sensitive code, or shared backend plumbing.
+- Update docs or config notes when behavior, env vars, or hardware assumptions change.
+
+### Frontend-Only Slice
+
+- Explore the backend contract first so the UI stays dashboard-only and backend-owned.
+- Keep controls narrow, explicit, and reversible.
+- Poll existing HTTP endpoints; do not add browser-side hardware integration.
+- Prefer read-only hardware detail plus a few safe actions.
+- Run `make web-test`.
+- Run `make web-build` when changing app code, routing, state flow, or production build behavior.
+- Run `make web-lint` when touching frontend lint-sensitive code, project tooling, or shared UI plumbing.
+
+### Cross-Stack Slice
+
+- Write the expanded plan before editing.
+- Define the backend contract first, then update the frontend to consume it.
+- Keep the backend as the sole owner of hardware access, plot execution, and artifact persistence.
+- Call out any model, artifact, or state-transition changes explicitly in the plan and PR.
+- Run `make api-test`, `make web-test`, and `make web-build`.
+- Run the relevant lint checks when touching shared contracts, tooling, or quality-sensitive paths.
+
+## Secondary Checklists
+
+### Hardware-Sensitive Change Checklist
+
+- Confirm the behavior is documented by the official AxiDraw API before assuming it.
+- Keep AxiDraw-specific behavior inside adapters and wrappers.
+- Preserve mock adapter behavior and coverage unless the task intentionally changes it.
+- Treat `return_to_origin` as positioning semantics, not true homing.
+- Keep diagnostic actions fixed and narrow; do not expand them into a second plotting API.
+- Document new env vars, runtime-only tuning, hardware assumptions, or package-version differences.
+- Verify both the normal and diagnostic plot-run paths when hardware behavior changes.
+
+### PR Readiness / Review Cleanup Checklist
+
+- Branch is still a narrow `codex/<topic>` slice.
+- PR summary explains the behavioral or architectural change, not just the mechanics.
+- The short plan or expanded plan is reflected in the PR summary.
+- Relevant checks ran, and skipped checks are called out with reasons.
+- Hardware assumptions, undocumented behavior, and residual risk are called out when relevant.
+- Docs and config notes were updated if behavior changed.
+- Merged or stale local branches are cleaned up when the branch is no longer needed.
+
+## Done Means
+
+A slice is not done unless:
+
+- relevant automated tests passed, or the reason they were not run is stated clearly
+- docs or config notes were updated if behavior changed
+- mock adapters still work unless the task explicitly changed them
+- new env vars or hardware assumptions are documented
+- remaining uncertainty or risk is called out clearly
+
+## Dry-Run Examples
+
+### Backend-Only Example
+
+```md
+Goal:
+Add a backend-owned plot run status detail to the API response.
+
+In scope:
+- plot workflow service
+- response model
+- backend tests
+
+Out of scope:
+- dashboard UI changes
+- hardware behavior changes
+
+Expected files or subsystems:
+- apps/api route or model layer
+- plot workflow service
+- backend tests
+
+Verification:
+- make api-test
+
+Risks or assumptions:
+- Existing run-state transitions stay unchanged.
+```
+
+### Cross-Stack Example
+
+```md
+Goal:
+Expose a new workspace warning in the backend and render it in the dashboard.
+
+In scope:
+- backend response contract
+- frontend polling consumer
+- backend and frontend tests
+
+Out of scope:
+- plotter tuning changes
+- new hardware actions
+
+Expected files or subsystems:
+- backend workspace service or response models
+- frontend dashboard consumer and tests
+
+Verification:
+- make api-test
+- make web-test
+- make web-build
+
+Risks or assumptions:
+- Backend remains the sole owner of workspace validation.
+- Existing polling cadence remains unchanged.
+```

--- a/docs/history.md
+++ b/docs/history.md
@@ -68,4 +68,11 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Kept helper startup focused on OpenCV camera ownership while leaving plotter mode to the backend's normal environment and configuration
 - Added helper regression coverage to prevent future silent plotter overrides from creeping back into the helper layer
 
+## Bounded Agent Workflow Slice
+
+- Added an internal `docs/agent-workflow.md` playbook for Codex-driven feature delivery
+- Standardized a short pre-edit plan for every implementation slice, with expanded plans for riskier work
+- Linked repo workflow guidance and the PR template back to the same planning, verification, and risk language
+- Added a project-specific local Codex skill and a narrow PR-readiness automation plan to reduce execution drift before returning to feature work
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,6 +2,8 @@
 
 This repo should optimize for a stable `main`, short-lived branches, and small reviewable slices.
 
+For Codex-driven planning and execution details, use [agent-workflow.md](agent-workflow.md). This document stays focused on branch, PR, and cleanup hygiene.
+
 ## Core Rules
 
 - `main` stays releasable and should only move through reviewed pull requests.
@@ -39,6 +41,7 @@ git checkout -b codex/<short-topic>
 ## Pull Request Expectations
 
 - Explain the user-facing or architectural impact briefly.
+- Reflect the slice plan briefly in the PR summary when relevant.
 - Call out hardware-related assumptions or version-sensitive behavior explicitly.
 - State which checks were run and which were not.
 - Keep the PR narrow enough that it can be reviewed in one pass.


### PR DESCRIPTION
## Summary

- add `docs/agent-workflow.md` as the internal Codex execution playbook for LearnToDraw slices
- point `AGENTS.md`, `docs/workflow.md`, and the PR template at the same planning, verification, and risk language
- record the workflow slice in project history
- install a local LearnToDraw Codex skill and a local PR-readiness automation on this machine outside the repo

## Checks

- [ ] `make api-test`
- [ ] `make web-test`
- [ ] `make web-build`
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why

Verification actually run:
- reviewed the repo diff for the tracked workflow-doc changes
- verified the new repo doc, AGENTS guidance, workflow doc, and PR template use consistent planning, verification, and risk language
- verified the local skill payload and local automation payload after installation on this machine

Checks not run:
- `make api-test` not run because this slice does not change backend runtime code
- `make web-test` not run because this slice does not change frontend runtime code
- `make web-build` not run because this slice does not change frontend runtime code

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior
- [x] I called out version-sensitive behavior when relevant
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

Slice plan summary:
- add one internal agent workflow doc
- wire existing repo guidance to that doc
- keep README and product/runtime surfaces unchanged
- keep local Codex skill and automation as machine-local assets rather than repo-tracked files
