### PR TITLE
Add prepared plot output preview

### DIFF
--- a/apps/api/src/learn_to_draw_api/api.py
+++ b/apps/api/src/learn_to_draw_api/api.py
@@ -72,7 +72,10 @@ def create_app(
         assets_dir=app_config.plot_assets_dir,
         assets_url_prefix=app_config.normalized_plot_assets_url_prefix,
     )
-    plot_run_store = PlotRunStore(runs_dir=app_config.plot_runs_dir)
+    plot_run_store = PlotRunStore(
+        runs_dir=app_config.plot_runs_dir,
+        artifacts_url_prefix=app_config.normalized_plot_run_artifacts_url_prefix,
+    )
     hardware_service = HardwareService(
         plotter=plotter_adapter,
         camera=camera_adapter,
@@ -122,6 +125,11 @@ def create_app(
         app_config.normalized_plot_assets_url_prefix,
         StaticFiles(directory=app_config.plot_assets_dir),
         name="plot-assets",
+    )
+    app.mount(
+        app_config.normalized_plot_run_artifacts_url_prefix,
+        StaticFiles(directory=app_config.plot_runs_dir),
+        name="plot-run-artifacts",
     )
 
     return app

--- a/apps/api/src/learn_to_draw_api/config.py
+++ b/apps/api/src/learn_to_draw_api/config.py
@@ -42,6 +42,7 @@ class AppConfig:
     camera_warmup_ms: int = 150
     camera_discard_frames: int = 2
     plot_assets_url_prefix: str = "/plot-assets"
+    plot_run_artifacts_url_prefix: str = "/plot-run-artifacts"
     cors_origins: tuple[str, ...] = (
         "http://127.0.0.1:5173",
         "http://localhost:5173",
@@ -133,6 +134,10 @@ class AppConfig:
             "LEARN_TO_DRAW_PLOT_ASSETS_URL_PREFIX",
             "/plot-assets",
         )
+        plot_run_artifacts_url_prefix = os.getenv(
+            "LEARN_TO_DRAW_PLOT_RUN_ARTIFACTS_URL_PREFIX",
+            "/plot-run-artifacts",
+        )
         return cls(
             captures_dir=captures_dir,
             plot_assets_dir=plot_assets_dir,
@@ -168,6 +173,7 @@ class AppConfig:
             camera_warmup_ms=camera_warmup_ms,
             camera_discard_frames=camera_discard_frames,
             plot_assets_url_prefix=plot_assets_url_prefix,
+            plot_run_artifacts_url_prefix=plot_run_artifacts_url_prefix,
         )
 
     def ensure_directories(self) -> None:
@@ -187,6 +193,13 @@ class AppConfig:
         return self._normalize_url_prefix(
             self.plot_assets_url_prefix,
             "/plot-assets",
+        )
+
+    @property
+    def normalized_plot_run_artifacts_url_prefix(self) -> str:
+        return self._normalize_url_prefix(
+            self.plot_run_artifacts_url_prefix,
+            "/plot-run-artifacts",
         )
 
     def _normalize_url_prefix(self, prefix: str, fallback: str) -> str:

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -66,6 +66,12 @@ class ObservedResultRecord(BaseModel):
     duration_ms: int
 
 
+class PreparedArtifactRecord(BaseModel):
+    file_path: str
+    public_url: str
+    mime_type: str = "image/svg+xml"
+
+
 class PlotDocument(BaseModel):
     asset_id: str
     name: str
@@ -201,6 +207,7 @@ class PlotRun(BaseModel):
     created_at: datetime
     updated_at: datetime
     asset: PlotAsset
+    prepared_artifact: Optional[PreparedArtifactRecord] = None
     capture: Optional[CaptureMetadata] = None
     observed_result: Optional[ObservedResultRecord] = None
     error: Optional[str] = None

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
@@ -62,7 +62,8 @@ class PlotRunExecutor:
                 workspace=workspace,
                 device_settings=device_settings,
             )
-            prepared_svg_path = self._run_store.save_prepared_svg(run.id, document.svg_text)
+            prepared_artifact = self._run_store.save_prepared_svg(run.id, document.svg_text)
+            run.prepared_artifact = prepared_artifact
             run = self._set_stage_state(
                 run,
                 stage="prepare",
@@ -84,7 +85,7 @@ class PlotRunExecutor:
             run.plotter_run_details = {
                 "driver": self._plotter.driver,
                 "document_id": plot_result.document_id,
-                "prepared_svg_path": str(prepared_svg_path),
+                "prepared_svg_path": prepared_artifact.file_path,
                 "preparation": preparation.model_dump(mode="json"),
                 "calibration": effective_calibration.model_dump(mode="json"),
                 "device": device_settings.model_dump(mode="json"),

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
@@ -3,16 +3,27 @@ from __future__ import annotations
 from pathlib import Path
 from threading import Lock
 from typing import Optional
+from urllib.parse import quote
 
-from learn_to_draw_api.models import AppNotFoundError, PlotRun, PlotRunListResponse, PlotRunSummary
+from learn_to_draw_api.models import (
+    AppNotFoundError,
+    PlotRun,
+    PlotRunListResponse,
+    PlotRunSummary,
+    PreparedArtifactRecord,
+)
 
 
 ACTIVE_RUN_STATUSES = {"pending", "plotting", "capturing"}
 
 
 class PlotRunStore:
-    def __init__(self, runs_dir: Path) -> None:
+    def __init__(self, runs_dir: Path, artifacts_url_prefix: str = "/plot-run-artifacts") -> None:
         self._runs_dir = runs_dir
+        normalized_prefix = artifacts_url_prefix.strip() or "/plot-run-artifacts"
+        if not normalized_prefix.startswith("/"):
+            normalized_prefix = f"/{normalized_prefix}"
+        self._artifacts_url_prefix = normalized_prefix.rstrip("/") or "/plot-run-artifacts"
         self._runs_dir.mkdir(parents=True, exist_ok=True)
         self._cache: dict[str, PlotRun] = {}
         self._lock = Lock()
@@ -24,11 +35,14 @@ class PlotRunStore:
             self._cache[run.id] = run
         return run
 
-    def save_prepared_svg(self, run_id: str, svg_text: str) -> Path:
+    def save_prepared_svg(self, run_id: str, svg_text: str) -> PreparedArtifactRecord:
         with self._lock:
             prepared_path = self._runs_dir / f"{run_id}-prepared.svg"
             prepared_path.write_text(svg_text, encoding="utf-8")
-        return prepared_path
+        return PreparedArtifactRecord(
+            file_path=str(prepared_path),
+            public_url=f"{self._artifacts_url_prefix}/{quote(prepared_path.name)}",
+        )
 
     def get(self, run_id: str) -> PlotRun:
         cached = self._cache.get(run_id)

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -567,7 +567,13 @@ def test_pattern_asset_and_plot_run_endpoints(tmp_path):
     assert completed["capture"]["public_url"].startswith("/captures/")
     assert completed["observed_result"]["capture"]["id"] == completed["capture"]["id"]
     assert completed["observed_result"]["camera_driver"] == "mock-camera"
+    assert completed["prepared_artifact"]["public_url"].startswith("/plot-run-artifacts/")
+    assert completed["prepared_artifact"]["mime_type"] == "image/svg+xml"
     assert completed["plotter_run_details"]["prepared_svg_path"].endswith("-prepared.svg")
+    prepared_artifact_response = client.get(completed["prepared_artifact"]["public_url"])
+    assert prepared_artifact_response.status_code == 200
+    assert prepared_artifact_response.headers["content-type"].startswith("image/svg+xml")
+    assert "<svg" in prepared_artifact_response.text
     assert completed["plotter_run_details"]["preparation"]["source_units"] == "mm"
     assert completed["plotter_run_details"]["calibration"]["driver_calibration"]["native_res_factor"] == 1016.0
     assert completed["plotter_run_details"]["preparation"]["page_width_mm"] == 210.0

--- a/apps/api/tests/test_plot_workflow_service.py
+++ b/apps/api/tests/test_plot_workflow_service.py
@@ -137,14 +137,18 @@ def test_plot_workflow_service_completes_pattern_run(tmp_path):
     assert completed.observed_result.capture.id == completed.capture.id
     assert completed.observed_result.camera_driver == "mock-camera"
     assert completed.observed_result.duration_ms >= 0
+    assert completed.prepared_artifact is not None
+    assert completed.prepared_artifact.public_url.endswith(f"/{completed.id}-prepared.svg")
+    assert completed.prepared_artifact.mime_type == "image/svg+xml"
     assert completed.stage_states["plot"].status == "completed"
     assert completed.stage_states["capture"].status == "completed"
     assert completed.plotter_run_details["document_id"] == asset.id
     assert completed.plotter_run_details["calibration"]["driver_calibration"]["native_res_factor"] == 1016.0
     assert completed.plotter_run_details["device"]["plotter_bounds_source"] == "config_default"
     assert completed.plotter_run_details["workspace"]["page_size_mm"]["width_mm"] == 210.0
-    prepared_svg_path = Path(completed.plotter_run_details["prepared_svg_path"])
+    prepared_svg_path = Path(completed.prepared_artifact.file_path)
     assert prepared_svg_path.exists()
+    assert completed.plotter_run_details["prepared_svg_path"] == completed.prepared_artifact.file_path
     prepared_svg_text = prepared_svg_path.read_text(encoding="utf-8")
     assert prepared_svg_text != Path(asset.file_path).read_text(encoding="utf-8")
     assert "<g transform=" in prepared_svg_text

--- a/apps/web/src/features/plot-workflow/PlotWorkflowPanel.tsx
+++ b/apps/web/src/features/plot-workflow/PlotWorkflowPanel.tsx
@@ -18,6 +18,20 @@ interface PlotWorkflowPanelProps {
   plotterWorkspace: PlotterWorkspace | null;
 }
 
+function resolvePreparedArtifactUrl(publicUrl: string) {
+  if (/^https?:\/\//.test(publicUrl)) {
+    return publicUrl;
+  }
+  if (typeof window === "undefined") {
+    return publicUrl;
+  }
+  const { protocol, hostname, port } = window.location;
+  if ((hostname === "127.0.0.1" || hostname === "localhost") && port !== "8000") {
+    return `${protocol}//${hostname}:8000${publicUrl}`;
+  }
+  return publicUrl;
+}
+
 export function PlotWorkflowPanel({
   hardwareStatus,
   plotterWorkspace,
@@ -161,6 +175,7 @@ export function PlotWorkflowPanel({
     displayRun && typeof displayRun.plotter_run_details.prepared_svg_path === "string"
       ? displayRun.plotter_run_details.prepared_svg_path
       : null;
+  const preparedArtifact = displayRun?.prepared_artifact ?? null;
   const observedCapture = displayRun?.observed_result?.capture ?? displayRun?.capture ?? null;
   const observedDurationMs = displayRun?.observed_result?.duration_ms ?? null;
   const observedCameraDriver = displayRun?.observed_result?.camera_driver ?? null;
@@ -409,15 +424,14 @@ export function PlotWorkflowPanel({
             <div>
               <h3>Prepared output</h3>
               <div className="preview-frame">
-                {displayRun ? (
-                  <div className="workflow-sizing-summary">
-                    <p className="footer-note">Prepared size: {preparedSize ?? "unknown"}</p>
-                    <p className="footer-note">
-                      Prepared SVG reference: {preparedSvgPath ?? "unavailable"}
-                    </p>
-                    {preparationStrategy ? (
-                      <p className="footer-note">Preparation strategy: {preparationStrategy}</p>
-                    ) : null}
+                {preparedArtifact ? (
+                  <img
+                    src={resolvePreparedArtifactUrl(preparedArtifact.public_url)}
+                    alt={`Prepared output for run ${displayRun?.id}`}
+                  />
+                ) : displayRun ? (
+                  <div className="empty-state">
+                    Prepared output preview is unavailable for this run.
                   </div>
                 ) : (
                   <div className="empty-state">
@@ -425,6 +439,23 @@ export function PlotWorkflowPanel({
                   </div>
                 )}
               </div>
+              {displayRun ? (
+                <div className="workflow-sizing-summary">
+                  <p className="footer-note">Prepared size: {preparedSize ?? "unknown"}</p>
+                  {preparedArtifact ? (
+                    <p className="footer-note">
+                      Prepared artifact: {preparedArtifact.mime_type}
+                    </p>
+                  ) : (
+                    <p className="footer-note">
+                      Prepared SVG reference: {preparedSvgPath ?? "unavailable"}
+                    </p>
+                  )}
+                  {preparationStrategy ? (
+                    <p className="footer-note">Preparation strategy: {preparationStrategy}</p>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
 
             <div>

--- a/apps/web/src/types/plotting.ts
+++ b/apps/web/src/types/plotting.ts
@@ -24,6 +24,11 @@ export interface PlotRun {
   created_at: string;
   updated_at: string;
   asset: PlotAsset;
+  prepared_artifact: {
+    file_path: string;
+    public_url: string;
+    mime_type: string;
+  } | null;
   capture: {
     id: string;
     timestamp: string;

--- a/apps/web/tests/dashboard.test.tsx
+++ b/apps/web/tests/dashboard.test.tsx
@@ -217,6 +217,11 @@ describe("Hardware dashboard", () => {
           public_url: string;
           mime_type: string;
         };
+        prepared_artifact: {
+          file_path: string;
+          public_url: string;
+          mime_type: string;
+        } | null;
         capture: typeof latestCapture;
         observed_result?: {
           capture: NonNullable<typeof latestCapture>;
@@ -651,12 +656,17 @@ describe("Hardware dashboard", () => {
             status: "pending",
             purpose: "normal",
             capture_mode: "auto",
-            created_at: "2026-03-15T20:04:00Z",
-            updated_at: "2026-03-15T20:04:00Z",
-            asset: patternAsset,
-            capture: null,
-            observed_result: null,
-            error: null,
+          created_at: "2026-03-15T20:04:00Z",
+          updated_at: "2026-03-15T20:04:00Z",
+          asset: patternAsset,
+          prepared_artifact: {
+            file_path: "/tmp/run-001-prepared.svg",
+            public_url: "/plot-run-artifacts/run-001-prepared.svg",
+            mime_type: "image/svg+xml",
+          },
+          capture: null,
+          observed_result: null,
+          error: null,
             stage_states: {
               prepare: {
                 status: "in_progress",
@@ -1464,6 +1474,9 @@ describe("Hardware dashboard", () => {
     await waitFor(
       () => {
         expect(
+          screen.getByRole("img", { name: /prepared output for run run-001/i }),
+        ).toBeInTheDocument();
+        expect(
           screen.getByRole("img", { name: /observed output for run run-001/i }),
         ).toBeInTheDocument();
       },
@@ -1498,6 +1511,7 @@ describe("Hardware dashboard", () => {
         public_url: "/plot-assets/unitless-upload.svg",
         mime_type: "image/svg+xml",
       },
+      prepared_artifact: null,
       capture: null,
       error: null,
       stage_states: {
@@ -2656,6 +2670,11 @@ describe("Hardware dashboard", () => {
           created_at: "2026-03-15T20:10:00Z",
           updated_at: "2026-03-15T20:10:10Z",
           asset: latestAsset,
+          prepared_artifact: {
+            file_path: "/tmp/run-latest-001-prepared.svg",
+            public_url: "/plot-run-artifacts/run-latest-001-prepared.svg",
+            mime_type: "image/svg+xml",
+          },
           capture: {
             id: "capture-latest-001",
             timestamp: "2026-03-15T20:10:10Z",
@@ -2755,6 +2774,11 @@ describe("Hardware dashboard", () => {
           created_at: "2026-03-15T19:50:00Z",
           updated_at: "2026-03-15T19:50:12Z",
           asset: olderAsset,
+          prepared_artifact: {
+            file_path: "/tmp/run-older-001-prepared.svg",
+            public_url: "/plot-run-artifacts/run-older-001-prepared.svg",
+            mime_type: "image/svg+xml",
+          },
           capture: {
             id: "capture-older-001",
             timestamp: "2026-03-15T19:50:12Z",
@@ -2882,7 +2906,7 @@ describe("Hardware dashboard", () => {
 
     expect(await screen.findByText(/planned asset: observed sketch/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/prepared svg reference: \/tmp\/run-older-001-prepared\.svg/i),
+      screen.getByRole("img", { name: /prepared output for run run-older-001/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/observed result: capture-/i),

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       "/api": "http://127.0.0.1:8000",
       "/captures": "http://127.0.0.1:8000",
       "/plot-assets": "http://127.0.0.1:8000",
+      "/plot-run-artifacts": "http://127.0.0.1:8000",
       "/local-helper": {
         target: "http://127.0.0.1:8001",
         rewrite: (path) => path.replace(/^\/local-helper/, ""),

--- a/docs/history.md
+++ b/docs/history.md
@@ -75,4 +75,11 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Linked repo workflow guidance and the PR template back to the same planning, verification, and risk language
 - Added a project-specific local Codex skill and a narrow PR-readiness automation plan to reduce execution drift before returning to feature work
 
+## Prepared Output Preview Slice
+
+- Added a backend-served prepared-artifact URL for plot runs instead of leaving prepared SVGs as disk-path-only metadata
+- Extended plot-run records so the dashboard can render the prepared SVG as a first-class artifact
+- Replaced the prepared-output path-only panel view with an actual preview in the existing planned/prepared/observed comparison flow
+- Added regression coverage for both the new plot-run artifact URL and the updated dashboard preview behavior
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- add a backend-served prepared artifact record for plot runs so prepared SVGs have a stable public URL instead of only a disk path
- render the prepared SVG as an actual preview in the Plot Workflow panel's planned/prepared/observed comparison flow
- keep the existing preparation metadata visible under the prepared preview
- update local dev routing so prepared previews render correctly while the dashboard runs on a different localhost port
- record the slice in project history

## Checks

- [x] `make api-test`
- [x] `make web-test`
- [x] `make web-build`
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why

Verification actually run:
- `make api-test`
- `make web-test`
- `make web-build`
- live local API check: created a real `test-grid` plot run and verified the completed run returned `prepared_artifact.public_url`
- live artifact check: fetched the prepared artifact URL directly from the backend and confirmed `200 OK` with `image/svg+xml`
- manual browser check: confirmed the prepared image renders in the dashboard after the dev-path fix

Checks not run:
- none

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior
- [x] I called out version-sensitive behavior when relevant
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

Slice plan summary:
- expose a prepared artifact public URL from the backend without changing plot preparation math or run state transitions
- replace the prepared-output path-only UI with a real preview while preserving the existing metadata and empty states
- verify both automated coverage and one live browser path through the local stack

Notes:
- the live local run used the current persisted workspace and device settings on this machine, which confirmed the prepared-artifact path works against the real local stack rather than only the test defaults
- the frontend resolves the prepared preview against the backend origin in local dev when the dashboard is running on a different localhost port so the preview does not depend on ambiguous dev-server static routing
