### PR TITLE
Speed up dashboard frontend tests

### DIFF
--- a/apps/web/src/features/hardware/useHardwareDashboard.ts
+++ b/apps/web/src/features/hardware/useHardwareDashboard.ts
@@ -22,7 +22,7 @@ import type {
 import { useHardwareSnapshotState } from "./useHardwareSnapshotState";
 
 
-const POLL_INTERVAL_MS = 2500;
+export const HARDWARE_DASHBOARD_POLL_INTERVAL_MS = 2500;
 
 
 export function useHardwareDashboard(): HardwareDashboardController {
@@ -76,7 +76,7 @@ export function useHardwareDashboard(): HardwareDashboardController {
 
     const poller = window.setInterval(() => {
       void refresh({ silent: true });
-    }, POLL_INTERVAL_MS);
+    }, HARDWARE_DASHBOARD_POLL_INTERVAL_MS);
 
     return () => {
       mountedRef.current = false;

--- a/apps/web/src/features/plot-workflow/usePlotWorkflow.ts
+++ b/apps/web/src/features/plot-workflow/usePlotWorkflow.ts
@@ -19,6 +19,8 @@ type NoticeTone = "info" | "success" | "error";
 type SelectionSource = "manual" | "run-derived" | null;
 
 const ACTIVE_RUN_STATUSES = new Set(["pending", "plotting", "capturing"]);
+export const PLOT_WORKFLOW_ACTIVE_POLL_INTERVAL_MS = 1200;
+export const PLOT_WORKFLOW_IDLE_POLL_INTERVAL_MS = 3500;
 
 export function usePlotWorkflow() {
   const [selectedAsset, setSelectedAsset] = useState<PlotAsset | null>(null);
@@ -192,7 +194,9 @@ export function usePlotWorkflow() {
       () => {
         void refresh({ silent: true });
       },
-      activeRun ? 1200 : 3500,
+      activeRun
+        ? PLOT_WORKFLOW_ACTIVE_POLL_INTERVAL_MS
+        : PLOT_WORKFLOW_IDLE_POLL_INTERVAL_MS,
     );
 
     return () => {

--- a/apps/web/tests/dashboard.test.tsx
+++ b/apps/web/tests/dashboard.test.tsx
@@ -1,9 +1,16 @@
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { App } from "../src/app/App";
 import { formatMm } from "../src/features/hardware/hardwareDashboardUtils";
 import type { HardwareStatus } from "../src/types/hardware";
 import type { HelperStatus } from "../src/types/helper";
+import {
+  advanceHardwareDashboardPoll,
+  advancePlotWorkflowActivePoll,
+  advancePlotWorkflowIdlePoll,
+  flushDashboardEffects,
+  useDashboardFakeTimers,
+} from "./hardwareDashboardTestUtils";
 
 const hardwareStatus = {
   plotter: {
@@ -922,24 +929,25 @@ describe("Hardware dashboard", () => {
   });
 
   it("returns to the backend-unavailable state after a later backend outage", async () => {
+    useDashboardFakeTimers();
+
     render(<App />);
+    await flushDashboardEffects();
 
     expect(
-      await screen.findByRole("heading", {
+      screen.getByRole("heading", {
         name: /learntodraw local control panel/i,
       }),
     ).toBeInTheDocument();
 
     backendReachable = false;
 
+    await advanceHardwareDashboardPoll();
+
     expect(
-      await screen.findByRole(
-        "heading",
-        { name: /local backend unavailable/i },
-        { timeout: 10000 },
-      ),
+      screen.getByRole("heading", { name: /local backend unavailable/i }),
     ).toBeInTheDocument();
-  }, 12000);
+  });
 
   it("shows a disengage motors button for axidraw and runs align mode", async () => {
     vi.restoreAllMocks();
@@ -1484,14 +1492,16 @@ describe("Hardware dashboard", () => {
   });
 
   it("creates a built-in pattern and completes a plot run", async () => {
-    render(<App />);
+    useDashboardFakeTimers();
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: /load test-grid/i }),
-    );
+    render(<App />);
+    await flushDashboardEffects();
+
+    fireEvent.click(screen.getByRole("button", { name: /load test-grid/i }));
+    await flushDashboardEffects();
 
     expect(
-      await screen.findByText(
+      screen.getByText(
         /built-in test-grid pattern is ready to plot with automatic drawable-area preparation\./i,
       ),
     ).toBeInTheDocument();
@@ -1501,20 +1511,18 @@ describe("Hardware dashboard", () => {
         name: /start plot run/i,
       }),
     );
+    await flushDashboardEffects();
 
-    expect(await screen.findByText(/plot run started\./i)).toBeInTheDocument();
+    expect(screen.getByText(/plot run started\./i)).toBeInTheDocument();
 
-    await waitFor(
-      () => {
-        expect(
-          screen.getByRole("img", { name: /prepared output for run run-001/i }),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole("img", { name: /observed output for run run-001/i }),
-        ).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await advancePlotWorkflowActivePoll(2);
+
+    expect(
+      screen.getByRole("img", { name: /prepared output for run run-001/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /observed output for run run-001/i }),
+    ).toBeInTheDocument();
 
     expect(screen.getAllByText(/test grid/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/completed/i).length).toBeGreaterThan(0);
@@ -2951,6 +2959,7 @@ describe("Hardware dashboard", () => {
 
   it("preserves a manual staged asset across refreshes and flags when latest run differs", async () => {
     vi.restoreAllMocks();
+    useDashboardFakeTimers();
     const manualAsset = {
       id: "asset-test-grid",
       kind: "built_in_pattern" as const,
@@ -3071,14 +3080,12 @@ describe("Hardware dashboard", () => {
     );
 
     render(<App />);
+    await flushDashboardEffects();
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: /load test-grid/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /load test-grid/i }));
+    await flushDashboardEffects();
 
-    expect(
-      await screen.findByText(/staged source: test grid/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/staged source: test grid/i)).toBeInTheDocument();
 
     latestRunResponse = {
       id: "run-diagnostic-002",
@@ -3157,14 +3164,11 @@ describe("Hardware dashboard", () => {
       camera_run_details: {},
     };
 
-    await act(async () => {
-      await new Promise((resolve) => window.setTimeout(resolve, 3600));
-    });
+    await advancePlotWorkflowIdlePoll();
 
     expect(screen.getByText(/staged source: test grid/i)).toBeInTheDocument();
     expect(
       screen.getByText(/latest run used a different source: double box\./i),
     ).toBeInTheDocument();
-
-  }, 10000);
+  });
 });

--- a/apps/web/tests/hardwareDashboardFocused.test.tsx
+++ b/apps/web/tests/hardwareDashboardFocused.test.tsx
@@ -188,17 +188,12 @@ describe("Hardware dashboard focused behaviors", () => {
     expect(screen.getByText(/^no camera selected$/i)).toBeInTheDocument();
 
     fireEvent.change(select, { target: { value: "camera-2" } });
-    await waitFor(() => {
-      expect(select).toHaveValue("camera-2");
-    });
+    expect(select).toHaveValue("camera-2");
     fireEvent.click(await screen.findByRole("button", { name: /save camera/i }));
 
     expect(await screen.findByText(/camera selection saved\./i)).toBeInTheDocument();
     expect(harness.cameraDeviceRequests).toEqual(["camera-2"]);
-
-    await waitFor(() => {
-      expect(captureButton).toBeEnabled();
-    });
+    expect(captureButton).toBeEnabled();
     expect(screen.getByText(/^ready to capture$/i)).toBeInTheDocument();
     expect(screen.getByText(/^desk camera$/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /save camera/i })).not.toBeInTheDocument();
@@ -253,22 +248,17 @@ describe("Hardware dashboard focused behaviors", () => {
     fireEvent.change(select, { target: { value: "camera-2" } });
 
     const saveButton = await screen.findByRole("button", { name: /save camera/i });
-    await waitFor(() => {
-      expect(select).toHaveValue("camera-2");
-      expect(saveButton).toBeEnabled();
-    });
+    expect(select).toHaveValue("camera-2");
+    expect(saveButton).toBeEnabled();
 
     fireEvent.click(saveButton);
 
     expect(await screen.findByText(/camera selection saved\./i)).toBeInTheDocument();
     expect(harness.cameraDeviceRequests).toEqual(["camera-2"]);
-
-    await waitFor(() => {
-      expect(screen.getByText(/^ready to capture$/i)).toBeInTheDocument();
-      expect(screen.getByText(/^desk camera$/i)).toBeInTheDocument();
-      expect(screen.queryByLabelText(/choose camera/i)).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
-    });
+    expect(screen.getByText(/^ready to capture$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^desk camera$/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/choose camera/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
   });
 
   it("keeps the camera editor open across prop refreshes", async () => {

--- a/apps/web/tests/hardwareDashboardTestUtils.ts
+++ b/apps/web/tests/hardwareDashboardTestUtils.ts
@@ -1,3 +1,10 @@
+import { act } from "@testing-library/react";
+
+import { HARDWARE_DASHBOARD_POLL_INTERVAL_MS } from "../src/features/hardware/useHardwareDashboard";
+import {
+  PLOT_WORKFLOW_ACTIVE_POLL_INTERVAL_MS,
+  PLOT_WORKFLOW_IDLE_POLL_INTERVAL_MS,
+} from "../src/features/plot-workflow/usePlotWorkflow";
 import type {
   CaptureMetadata,
   HardwareStatus,
@@ -265,6 +272,35 @@ export function createHardwareDashboardHarness(
     workspaceRequests: [],
     ...overrides,
   };
+}
+
+export function useDashboardFakeTimers() {
+  vi.useFakeTimers();
+}
+
+export async function flushDashboardEffects() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function advanceDashboardTimersBy(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+export async function advanceHardwareDashboardPoll(cycles = 1) {
+  await advanceDashboardTimersBy(HARDWARE_DASHBOARD_POLL_INTERVAL_MS * cycles);
+}
+
+export async function advancePlotWorkflowIdlePoll(cycles = 1) {
+  await advanceDashboardTimersBy(PLOT_WORKFLOW_IDLE_POLL_INTERVAL_MS * cycles);
+}
+
+export async function advancePlotWorkflowActivePoll(cycles = 1) {
+  await advanceDashboardTimersBy(PLOT_WORKFLOW_ACTIVE_POLL_INTERVAL_MS * cycles);
 }
 
 export function installHardwareDashboardFetchMock(


### PR DESCRIPTION
## Summary
- export the existing dashboard polling intervals so tests can drive the same timing deterministically
- add shared fake-timer helpers for hardware and plot-workflow polling in the dashboard test utilities
- replace the slow real-time waits in the dashboard suites with explicit timer advancement

## Verification
- cd apps/web && npm run test -- --reporter=verbose
- make web-build

## Notes
- local web test runtime dropped from about 9.8s to about 1.4s during verification