### PR TITLE
Cancel superseded CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   api:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add workflow-level CI concurrency so superseded PR runs are cancelled instead of piling up
- keep the existing api and web jobs unchanged
- narrow issue #18 to the stale-run problem now that #20 already addressed the main timing-related frontend test noise

## Verification
- make web-test
- make web-lint
- make web-build

## Notes
- reassessed the current dashboard test selectors on main and did not find a small, clearly justified frontend assertion change to carry in this slice
- this PR is intended to close #18 once merged

Closes #18