### PR TITLE
[codex] Add post-capture normalization review flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .pytest_cache/
+.playwright-mcp/
 .coverage
 .venv/
 __pycache__/

--- a/apps/api/scripts/replay_normalization_experiment.py
+++ b/apps/api/scripts/replay_normalization_experiment.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+def _configure_pythonpath() -> None:
+    script_path = Path(__file__).resolve()
+    src_dir = script_path.parents[1] / "src"
+    if str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+
+_configure_pythonpath()
+
+from learn_to_draw_api.services.capture_normalization import (  # noqa: E402
+    CaptureNormalizationService,
+    target_from_page_size,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Replay a saved capture through one normalization experiment.",
+    )
+    parser.add_argument("capture", type=Path, help="Path to the saved raster capture.")
+    parser.add_argument(
+        "--experiment",
+        choices=("region_v2", "contour_v3"),
+        default="region_v2",
+        help="Normalization experiment to run.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("default", "region_only"),
+        default="default",
+        help="Normalization mode to run.",
+    )
+    parser.add_argument(
+        "--page-width-mm",
+        type=float,
+        default=210.0,
+        help="Target page width in millimeters.",
+    )
+    parser.add_argument(
+        "--page-height-mm",
+        type=float,
+        default=200.0,
+        help="Target page height in millimeters.",
+    )
+    parser.add_argument(
+        "--frame-source",
+        choices=("prepared_svg", "workspace_drawable_area"),
+        default="prepared_svg",
+        help="Normalization target frame source.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("/tmp/learntodraw-normalization-experiment"),
+        help="Directory where replay artifacts should be written.",
+    )
+    return parser
+
+
+def _write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    capture_path = args.capture.resolve()
+    if not capture_path.exists():
+        parser.error(f"Capture does not exist: {capture_path}")
+
+    service = CaptureNormalizationService(
+        mode=args.mode,
+        experiment=args.experiment,
+    )
+    artifacts = service.normalize(
+        content=capture_path.read_bytes(),
+        target=target_from_page_size(
+            page_width_mm=args.page_width_mm,
+            page_height_mm=args.page_height_mm,
+            source=args.frame_source,
+        ),
+    )
+
+    output_root = (args.output_dir / args.experiment / capture_path.stem).resolve()
+    _write_bytes(output_root.with_name(f"{capture_path.stem}-rectified-color.png"), artifacts.rectified_color)
+    _write_bytes(
+        output_root.with_name(f"{capture_path.stem}-rectified-grayscale.png"),
+        artifacts.rectified_grayscale,
+    )
+    _write_bytes(
+        output_root.with_name(f"{capture_path.stem}-debug-overlay.png"),
+        artifacts.debug_overlay,
+    )
+
+    metadata = artifacts.metadata.model_dump(mode="json")
+    print(f"capture: {capture_path}")
+    print(f"experiment: {args.experiment}")
+    print(f"mode: {args.mode}")
+    print(f"method: {metadata['method']}")
+    print(f"confidence: {metadata['confidence']}")
+    frame = metadata.get("frame") or {}
+    print(f"frame: {frame.get('kind')} v{frame.get('version')}")
+    diagnostics = metadata.get("diagnostics") or {}
+    selected = diagnostics.get(args.experiment) or {}
+    print(f"primary_status: {selected.get('status')}")
+    print(f"primary_rejection_reason: {selected.get('rejection_reason')}")
+    print(f"output_dir: {output_root.parent}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/src/learn_to_draw_api/adapters/mock_camera.py
+++ b/apps/api/src/learn_to_draw_api/adapters/mock_camera.py
@@ -5,6 +5,9 @@ import time
 from typing import Optional
 from uuid import uuid4
 
+import cv2
+import numpy as np
+
 from learn_to_draw_api.adapters.camera import CaptureArtifact
 from learn_to_draw_api.models import (
     DeviceStatus,
@@ -89,9 +92,9 @@ class MockCamera:
             return CaptureArtifact(
                 capture_id=capture_id,
                 timestamp=timestamp,
-                filename=f"{capture_id}.svg",
-                content=self._build_svg(capture_id, timestamp).encode("utf-8"),
-                media_type="image/svg+xml",
+                filename=f"{capture_id}.png",
+                content=self._build_png(capture_id, timestamp),
+                media_type="image/png",
                 width=self._width,
                 height=self._height,
             )
@@ -99,22 +102,107 @@ class MockCamera:
             self._busy = False
             self._touch()
 
-    def _build_svg(self, capture_id: str, timestamp: datetime) -> str:
+    def _build_png(self, capture_id: str, timestamp: datetime) -> bytes:
         stamp = timestamp.isoformat()
-        return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{self._width}" height="{self._height}" viewBox="0 0 {self._width} {self._height}">
-  <rect width="100%" height="100%" fill="#f6f1e8" />
-  <g stroke="#1f2933" stroke-width="6" fill="none">
-    <path d="M 120 760 C 360 280, 620 280, 860 760" />
-    <path d="M 240 700 C 420 420, 560 420, 740 700" />
-    <line x1="950" y1="120" x2="1140" y2="310" />
-    <line x1="950" y1="310" x2="1140" y2="120" />
-  </g>
-  <g fill="#8b5e34" font-family="Menlo, monospace" font-size="32">
-    <text x="120" y="120">Mock Capture</text>
-    <text x="120" y="170">ID: {capture_id[:12]}</text>
-    <text x="120" y="220">Time: {stamp}</text>
-  </g>
-</svg>"""
+        frame = np.full((self._height, self._width, 3), (28, 32, 30), dtype=np.uint8)
+        paper_height = int(self._height * 0.72)
+        paper_width = int(paper_height * 0.75)
+        paper = np.full((paper_height, paper_width, 3), 244, dtype=np.uint8)
+        cv2.rectangle(paper, (0, 0), (paper_width - 1, paper_height - 1), (224, 219, 209), 6)
+        cv2.line(
+            paper,
+            (paper_width // 6, int(paper_height * 0.2)),
+            (paper_width - (paper_width // 6), int(paper_height * 0.2)),
+            (58, 66, 74),
+            8,
+        )
+        cv2.putText(
+            paper,
+            "Mock Capture",
+            (int(paper_width * 0.12), int(paper_height * 0.16)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1.0,
+            (78, 56, 33),
+            3,
+            cv2.LINE_AA,
+        )
+        cv2.putText(
+            paper,
+            capture_id[:12],
+            (int(paper_width * 0.12), int(paper_height * 0.24)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.7,
+            (78, 56, 33),
+            2,
+            cv2.LINE_AA,
+        )
+        cv2.putText(
+            paper,
+            stamp[:19],
+            (int(paper_width * 0.12), int(paper_height * 0.3)),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (78, 56, 33),
+            2,
+            cv2.LINE_AA,
+        )
+        cv2.polylines(
+            paper,
+            [
+                np.array(
+                    [
+                        (int(paper_width * 0.16), int(paper_height * 0.75)),
+                        (int(paper_width * 0.32), int(paper_height * 0.42)),
+                        (int(paper_width * 0.5), int(paper_height * 0.58)),
+                        (int(paper_width * 0.68), int(paper_height * 0.34)),
+                        (int(paper_width * 0.84), int(paper_height * 0.72)),
+                    ],
+                    dtype=np.int32,
+                )
+            ],
+            isClosed=False,
+            color=(31, 41, 51),
+            thickness=8,
+        )
+        cv2.rectangle(
+            paper,
+            (int(paper_width * 0.14), int(paper_height * 0.36)),
+            (int(paper_width * 0.82), int(paper_height * 0.84)),
+            (32, 40, 48),
+            6,
+        )
+
+        source = np.array(
+            [
+                [0.0, 0.0],
+                [float(paper_width - 1), 0.0],
+                [float(paper_width - 1), float(paper_height - 1)],
+                [0.0, float(paper_height - 1)],
+            ],
+            dtype=np.float32,
+        )
+        destination = np.array(
+            [
+                [self._width * 0.18, self._height * 0.12],
+                [self._width * 0.77, self._height * 0.08],
+                [self._width * 0.82, self._height * 0.88],
+                [self._width * 0.16, self._height * 0.9],
+            ],
+            dtype=np.float32,
+        )
+        matrix = cv2.getPerspectiveTransform(source, destination)
+        warped_paper = cv2.warpPerspective(paper, matrix, (self._width, self._height))
+        warped_mask = cv2.warpPerspective(
+            np.full((paper_height, paper_width), 255, dtype=np.uint8),
+            matrix,
+            (self._width, self._height),
+        )
+        mask = warped_mask > 0
+        frame[mask] = warped_paper[mask]
+        ok, encoded = cv2.imencode(".png", frame)
+        if not ok:
+            raise HardwareOperationError("Mock camera failed to encode the capture preview.")
+        return encoded.tobytes()
 
     def _ensure_ready(self) -> None:
         if not self.available:

--- a/apps/api/src/learn_to_draw_api/api.py
+++ b/apps/api/src/learn_to_draw_api/api.py
@@ -13,6 +13,9 @@ from learn_to_draw_api.adapters.plotter import PlotterAdapter
 from learn_to_draw_api.config import AppConfig
 from learn_to_draw_api.errors import register_exception_handlers
 from learn_to_draw_api.routes import build_api_router
+from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
+from learn_to_draw_api.services.capture_service import CaptureService
+from learn_to_draw_api.services.capture_review_memory import CaptureReviewMemoryStore
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.camera_device_settings import (
     CameraDeviceSettingsService,
@@ -77,6 +80,14 @@ def create_app(
         captures_dir=app_config.captures_dir,
         capture_url_prefix=app_config.normalized_capture_url_prefix,
     )
+    capture_service = CaptureService(
+        store=capture_store,
+        normalization_service=CaptureNormalizationService(
+            mode=app_config.normalization_mode,
+            experiment=app_config.normalization_experiment,
+        ),
+    )
+    capture_review_memory_store = CaptureReviewMemoryStore(app_config.workspace_dir)
     plot_asset_store = PlotAssetStore(
         assets_dir=app_config.plot_assets_dir,
         assets_url_prefix=app_config.normalized_plot_assets_url_prefix,
@@ -89,6 +100,7 @@ def create_app(
         plotter=plotter_adapter,
         camera=camera_adapter,
         capture_store=capture_store,
+        capture_service=capture_service,
         calibration_service=calibration_service,
         device_settings_service=device_settings_service,
         workspace_service=workspace_service,
@@ -97,6 +109,8 @@ def create_app(
         plotter=plotter_adapter,
         camera=camera_adapter,
         capture_store=capture_store,
+        capture_service=capture_service,
+        review_memory_store=capture_review_memory_store,
         asset_store=plot_asset_store,
         run_store=plot_run_store,
         calibration_service=calibration_service,

--- a/apps/api/src/learn_to_draw_api/config.py
+++ b/apps/api/src/learn_to_draw_api/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 
 @dataclass(frozen=True)
@@ -41,6 +41,8 @@ class AppConfig:
     opencv_camera_index: int = 0
     camera_warmup_ms: int = 150
     camera_discard_frames: int = 2
+    normalization_mode: Literal["default", "region_only"] = "default"
+    normalization_experiment: Literal["region_v2", "contour_v3"] = "region_v2"
     camerabridge_base_url: Optional[str] = None
     camerabridge_token_path: Optional[Path] = None
     camerabridge_owner_id: str = "learntodraw-api"
@@ -98,6 +100,14 @@ class AppConfig:
         camera_discard_frames = _read_optional_int(
             "LEARN_TO_DRAW_CAMERA_DISCARD_FRAMES",
             2,
+        )
+        normalization_mode = _read_normalization_mode(
+            "LEARN_TO_DRAW_NORMALIZATION_MODE",
+            "default",
+        )
+        normalization_experiment = _read_normalization_experiment(
+            "LEARN_TO_DRAW_NORMALIZATION_EXPERIMENT",
+            "region_v2",
         )
         camerabridge_base_url = _read_optional_text_or_none(
             "LEARN_TO_DRAW_CAMERABRIDGE_BASE_URL"
@@ -189,6 +199,8 @@ class AppConfig:
             opencv_camera_index=opencv_camera_index,
             camera_warmup_ms=camera_warmup_ms,
             camera_discard_frames=camera_discard_frames,
+            normalization_mode=normalization_mode,
+            normalization_experiment=normalization_experiment,
             camerabridge_base_url=camerabridge_base_url,
             camerabridge_token_path=camerabridge_token_path,
             camerabridge_owner_id=camerabridge_owner_id,
@@ -264,3 +276,29 @@ def _read_optional_text_or_none(env_name: str) -> Optional[str]:
         return None
     value = value.strip()
     return value or None
+
+
+def _read_normalization_mode(
+    env_name: str,
+    default: Literal["default", "region_only"],
+) -> Literal["default", "region_only"]:
+    value = os.getenv(env_name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"default", "region_only"}:
+        return normalized  # type: ignore[return-value]
+    return default
+
+
+def _read_normalization_experiment(
+    env_name: str,
+    default: Literal["region_v2", "contour_v3"],
+) -> Literal["region_v2", "contour_v3"]:
+    value = os.getenv(env_name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"region_v2", "contour_v3"}:
+        return normalized  # type: ignore[return-value]
+    return default

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -49,6 +49,103 @@ class HardwareStatus(BaseModel):
     camera: DeviceStatus
 
 
+class NormalizationCorners(BaseModel):
+    top_left: tuple[float, float]
+    top_right: tuple[float, float]
+    bottom_right: tuple[float, float]
+    bottom_left: tuple[float, float]
+
+
+class NormalizationTransform(BaseModel):
+    matrix: list[list[float]]
+
+
+class NormalizationOutput(BaseModel):
+    width: int
+    height: int
+    aspect_ratio: float = Field(gt=0)
+
+
+NormalizationMethod = Literal["paper_contour_v3", "paper_region_v2", "paper_edges_v1", "fallback_full_frame"]
+NormalizationTargetFrameSource = Literal["prepared_svg", "workspace_drawable_area"]
+NormalizationFrameKind = Literal["page_aligned"]
+
+
+class NormalizationFrame(BaseModel):
+    kind: NormalizationFrameKind
+    version: int = Field(ge=1)
+    page_width_mm: float = Field(gt=0)
+    page_height_mm: float = Field(gt=0)
+
+
+class NormalizationDiagnosticCandidate(BaseModel):
+    corners: Optional[NormalizationCorners] = None
+    bounds: Optional[tuple[int, int, int, int]] = None
+    component_area: Optional[float] = None
+    rect_area: Optional[float] = None
+    fill_ratio: Optional[float] = None
+    occupancy_score: Optional[float] = None
+    edge_support_score: Optional[float] = None
+    top_score: Optional[float] = None
+    right_score: Optional[float] = None
+    bottom_score: Optional[float] = None
+    left_score: Optional[float] = None
+    mean_border_support: Optional[float] = None
+    max_outward_expansion_px: Optional[float] = None
+    refined_area_ratio: Optional[float] = None
+    aspect_log_error: Optional[float] = None
+    score: Optional[float] = None
+    confidence: Optional[float] = None
+    rejection_reason: Optional[str] = None
+
+
+class NormalizationMethodDiagnostics(BaseModel):
+    status: Literal["used", "rejected", "not_run", "unavailable"]
+    rejection_reason: Optional[str] = None
+    candidate_count: int = Field(ge=0, default=0)
+    best_candidate: Optional[NormalizationDiagnosticCandidate] = None
+
+
+class NormalizationDiagnostics(BaseModel):
+    mode: Literal["default", "region_only"]
+    contour_v3: Optional[NormalizationMethodDiagnostics] = None
+    region_v2: NormalizationMethodDiagnostics
+    line_v1: NormalizationMethodDiagnostics
+
+
+class NormalizationMetadata(BaseModel):
+    method: NormalizationMethod
+    confidence: float = Field(ge=0, le=1)
+    corners: NormalizationCorners
+    transform: NormalizationTransform
+    output: NormalizationOutput
+    target_frame_source: NormalizationTargetFrameSource
+    frame: Optional[NormalizationFrame] = None
+    diagnostics: Optional[NormalizationDiagnostics] = None
+
+
+class NormalizedCaptureArtifacts(BaseModel):
+    rectified_color_url: str
+    rectified_grayscale_url: str
+    debug_overlay_url: str
+    metadata: NormalizationMetadata
+
+
+CaptureReviewStatus = Literal["pending", "confirmed"]
+CaptureReviewConfirmationSource = Literal["auto", "adjusted", "reused_last"]
+
+
+class CaptureReview(BaseModel):
+    review_required: bool
+    review_status: CaptureReviewStatus
+    proposed_corners: NormalizationCorners
+    confirmed_corners: Optional[NormalizationCorners] = None
+    confirmation_source: Optional[CaptureReviewConfirmationSource] = None
+    detector_method: NormalizationMethod
+    detector_confidence: float = Field(ge=0, le=1)
+    reuse_last_available: bool = False
+
+
 class CaptureMetadata(BaseModel):
     id: str
     timestamp: datetime
@@ -57,6 +154,8 @@ class CaptureMetadata(BaseModel):
     width: int
     height: int
     mime_type: str
+    review: Optional[CaptureReview] = None
+    normalized: Optional[NormalizedCaptureArtifacts] = None
 
 
 class ObservedResultRecord(BaseModel):
@@ -123,6 +222,7 @@ class PlotPreparationMetadata(BaseModel):
 
     class PreparationAudit(BaseModel):
         strategy: str
+        comparison_frame_version: int = Field(ge=1, default=1)
         fit_scale: Optional[float] = None
         prepared_within_drawable_area: bool
         overflow_x_mm: float
@@ -139,6 +239,10 @@ class PlotPreparationMetadata(BaseModel):
         prepared_viewbox_min_y: Optional[float] = None
         prepared_viewbox_width: Optional[float] = None
         prepared_viewbox_height: Optional[float] = None
+        source_content_left_ratio: Optional[float] = None
+        source_content_top_ratio: Optional[float] = None
+        source_content_width_ratio: Optional[float] = None
+        source_content_height_ratio: Optional[float] = None
 
     source_width: float
     source_height: float
@@ -168,6 +272,14 @@ class PlotResult(BaseModel):
 
 PlotRunPurpose = Literal["normal", "diagnostic"]
 PlotRunCaptureMode = Literal["auto", "skip"]
+PlotRunStatus = Literal[
+    "pending",
+    "plotting",
+    "capturing",
+    "awaiting_capture_review",
+    "completed",
+    "failed",
+]
 PlotterTestAction = Literal["raise_pen", "lower_pen", "cycle_pen", "align"]
 NominalPlotterBoundsSource = Literal["model_default", "config_override", "config_default"]
 PlotterBoundsSource = Literal["manual_override", "default_clearance", "config_default"]
@@ -201,7 +313,7 @@ class PlotStageState(BaseModel):
 
 class PlotRun(BaseModel):
     id: str
-    status: Literal["pending", "plotting", "capturing", "completed", "failed"]
+    status: PlotRunStatus
     purpose: PlotRunPurpose = "normal"
     capture_mode: PlotRunCaptureMode = "auto"
     created_at: datetime
@@ -218,7 +330,7 @@ class PlotRun(BaseModel):
 
 class PlotRunSummary(BaseModel):
     id: str
-    status: Literal["pending", "plotting", "capturing", "completed", "failed"]
+    status: PlotRunStatus
     purpose: PlotRunPurpose = "normal"
     created_at: datetime
     updated_at: datetime
@@ -266,6 +378,20 @@ class CameraCaptureResponse(CommandResponse):
 
 class CameraCommandResponse(CommandResponse):
     status: DeviceStatus
+
+
+class PlotRunCaptureReviewPayload(BaseModel):
+    run_id: str
+    capture: CaptureMetadata
+    review: CaptureReview
+
+
+class PlotRunCaptureReviewAdjustRequest(BaseModel):
+    corners: NormalizationCorners
+
+
+class PlotRunCaptureReviewResponse(CommandResponse):
+    run: PlotRun
 
 
 class LatestPlotRunResponse(BaseModel):

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -20,6 +20,9 @@ from learn_to_draw_api.models import (
     PlotterPenHeightsRequest,
     PlotterSafeBoundsRequest,
     PlotRun,
+    PlotRunCaptureReviewAdjustRequest,
+    PlotRunCaptureReviewPayload,
+    PlotRunCaptureReviewResponse,
     PlotRunCreateRequest,
     PlotRunListResponse,
     PlotterCommandResponse,
@@ -143,5 +146,35 @@ def build_api_router(
     @router.get("/api/plot-runs/{run_id}", response_model=PlotRun)
     def get_plot_run(run_id: str) -> PlotRun:
         return plot_workflow_service.get_run(run_id)
+
+    @router.get("/api/plot-runs/{run_id}/capture-review", response_model=PlotRunCaptureReviewPayload)
+    def get_plot_run_capture_review(run_id: str) -> PlotRunCaptureReviewPayload:
+        return plot_workflow_service.get_capture_review(run_id)
+
+    @router.post(
+        "/api/plot-runs/{run_id}/capture-review/accept",
+        response_model=PlotRunCaptureReviewResponse,
+    )
+    def post_plot_run_capture_review_accept(run_id: str) -> PlotRunCaptureReviewResponse:
+        return plot_workflow_service.accept_capture_review(run_id)
+
+    @router.post(
+        "/api/plot-runs/{run_id}/capture-review/adjust",
+        response_model=PlotRunCaptureReviewResponse,
+    )
+    def post_plot_run_capture_review_adjust(
+        run_id: str,
+        request: PlotRunCaptureReviewAdjustRequest,
+    ) -> PlotRunCaptureReviewResponse:
+        return plot_workflow_service.adjust_capture_review(run_id, request)
+
+    @router.post(
+        "/api/plot-runs/{run_id}/capture-review/reuse-last",
+        response_model=PlotRunCaptureReviewResponse,
+    )
+    def post_plot_run_capture_review_reuse_last(
+        run_id: str,
+    ) -> PlotRunCaptureReviewResponse:
+        return plot_workflow_service.reuse_last_capture_review(run_id)
 
     return router

--- a/apps/api/src/learn_to_draw_api/services/capture_normalization.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_normalization.py
@@ -1,0 +1,2469 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Literal, Optional
+
+import cv2
+import numpy as np
+
+from learn_to_draw_api.models import (
+    NormalizationDiagnosticCandidate,
+    NormalizationDiagnostics,
+    NormalizationCorners,
+    NormalizationFrame,
+    NormalizationMethodDiagnostics,
+    NormalizationMetadata,
+    NormalizationMethod,
+    NormalizationOutput,
+    NormalizationTargetFrameSource,
+    NormalizationTransform,
+)
+
+
+CANONICAL_LONG_SIDE_PX = 2048
+MAX_DETECTION_DIMENSION_PX = 1600
+MIN_QUAD_AREA_RATIO = 0.15
+LOW_CONFIDENCE_THRESHOLD = 0.55
+CANONICAL_PAGE_BACKGROUND_COLOR = (255, 255, 255)
+BRIGHT_REGION_FLOOR_LUMA = 104
+MIN_REGION_FILL_RATIO = 0.58
+MAX_DETECTION_MARGIN_RATIO = 0.06
+MAX_ASPECT_LOG_ERROR = math.log(1.8)
+REGION_BOX_QUANTILE = 5.0
+SNAP_BOX_QUANTILE = 2.0
+REGION_OUTWARD_EXPANSION_PX = 3.0
+REGION_INWARD_EXPANSION_PX = 18.0
+REGION_ALLOWED_OUTWARD_EXPANSION_PX = 2.0
+REGION_EDGE_ORTHOGONAL_BAND_PX = 12.0
+REGION_EDGE_SAMPLE_OFFSET_PX = 8.0
+REGION_MIN_SIDE_SCORE = 0.28
+REGION_MIN_MEAN_BORDER_SUPPORT = 0.45
+REGION_MAX_REFINED_AREA_RATIO = 1.12
+REGION_FINAL_INSET_PX = 4.0
+NormalizationMode = Literal["default", "region_only"]
+NormalizationExperiment = Literal["region_v2", "contour_v3"]
+
+
+@dataclass(frozen=True)
+class NormalizationTarget:
+    page_width_mm: float
+    page_height_mm: float
+    source: NormalizationTargetFrameSource
+
+    @property
+    def aspect_ratio(self) -> float:
+        return self.page_width_mm / self.page_height_mm
+
+
+@dataclass(frozen=True)
+class NormalizationArtifacts:
+    rectified_color: bytes
+    rectified_grayscale: bytes
+    debug_overlay: bytes
+    metadata: NormalizationMetadata
+
+
+@dataclass(frozen=True)
+class CaptureNormalizationProposal:
+    corners: NormalizationCorners
+    confidence: float
+    method: NormalizationMethod
+    diagnostics: NormalizationDiagnostics
+
+
+@dataclass(frozen=True)
+class DetectionCandidate:
+    corners: np.ndarray
+    confidence: float
+    method: NormalizationMethod
+
+
+@dataclass(frozen=True)
+class LineCandidate:
+    points: np.ndarray
+    length: float
+    midpoint_x: float
+    midpoint_y: float
+    angle_degrees: float
+
+
+@dataclass(frozen=True)
+class DetectorCandidateDiagnostics:
+    corners: Optional[np.ndarray] = None
+    bounds: Optional[tuple[int, int, int, int]] = None
+    component_area: Optional[float] = None
+    rect_area: Optional[float] = None
+    fill_ratio: Optional[float] = None
+    occupancy_score: Optional[float] = None
+    edge_support_score: Optional[float] = None
+    top_score: Optional[float] = None
+    right_score: Optional[float] = None
+    bottom_score: Optional[float] = None
+    left_score: Optional[float] = None
+    mean_border_support: Optional[float] = None
+    max_outward_expansion_px: Optional[float] = None
+    refined_area_ratio: Optional[float] = None
+    aspect_log_error: Optional[float] = None
+    score: Optional[float] = None
+    confidence: Optional[float] = None
+    rejection_reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DetectorRunDiagnostics:
+    status: Literal["used", "rejected", "not_run", "unavailable"]
+    rejection_reason: Optional[str] = None
+    candidate_count: int = 0
+    best_candidate: Optional[DetectorCandidateDiagnostics] = None
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    candidate: DetectionCandidate
+    diagnostics: NormalizationDiagnostics
+
+
+def _not_run_diagnostics() -> NormalizationMethodDiagnostics:
+    return NormalizationMethodDiagnostics(
+        status="not_run",
+        candidate_count=0,
+    )
+
+
+class CaptureNormalizationService:
+    def __init__(
+        self,
+        *,
+        mode: NormalizationMode = "default",
+        experiment: NormalizationExperiment = "region_v2",
+    ) -> None:
+        self._mode: NormalizationMode = (
+            "region_only" if mode == "region_only" else "default"
+        )
+        self._experiment: NormalizationExperiment = (
+            "contour_v3" if experiment == "contour_v3" else "region_v2"
+        )
+
+    def normalize(
+        self,
+        *,
+        content: bytes,
+        target: NormalizationTarget,
+    ) -> NormalizationArtifacts:
+        decoded = self._decode_image(content)
+        if decoded is None:
+            raise ValueError("Capture content is not a supported raster image.")
+
+        detection_result = self._detect_paper(decoded, target_aspect_ratio=target.aspect_ratio)
+        return self._normalize_from_detection_result(
+            decoded,
+            detection_result=detection_result,
+            target=target,
+        )
+
+    def inspect(
+        self,
+        *,
+        content: bytes,
+        target: NormalizationTarget,
+    ) -> CaptureNormalizationProposal:
+        decoded = self._decode_image(content)
+        if decoded is None:
+            raise ValueError("Capture content is not a supported raster image.")
+        detection_result = self._detect_paper(decoded, target_aspect_ratio=target.aspect_ratio)
+        detection = detection_result.candidate
+        return CaptureNormalizationProposal(
+            corners=self._to_corners(detection.corners),
+            confidence=float(round(detection.confidence, 6)),
+            method=detection.method,
+            diagnostics=detection_result.diagnostics,
+        )
+
+    def normalize_with_corners(
+        self,
+        *,
+        content: bytes,
+        target: NormalizationTarget,
+        corners: NormalizationCorners,
+        method: NormalizationMethod,
+        confidence: float,
+        diagnostics: Optional[NormalizationDiagnostics] = None,
+    ) -> NormalizationArtifacts:
+        decoded = self._decode_image(content)
+        if decoded is None:
+            raise ValueError("Capture content is not a supported raster image.")
+        detection_result = DetectionResult(
+            candidate=DetectionCandidate(
+                corners=self._corners_to_numpy(corners),
+                confidence=confidence,
+                method=method,
+            ),
+            diagnostics=diagnostics
+            or NormalizationDiagnostics(
+                mode=self._mode,
+                contour_v3=_not_run_diagnostics(),
+                region_v2=_not_run_diagnostics(),
+                line_v1=_not_run_diagnostics(),
+            ),
+        )
+        return self._normalize_from_detection_result(
+            decoded,
+            detection_result=detection_result,
+            target=target,
+        )
+
+    def _normalize_from_detection_result(
+        self,
+        decoded: np.ndarray,
+        *,
+        detection_result: DetectionResult,
+        target: NormalizationTarget,
+    ) -> NormalizationArtifacts:
+        detection = detection_result.candidate
+        rectified, matrix = self._rectify(decoded, detection.corners)
+        if detection.method != "fallback_full_frame":
+            rectified = self._trim_rectified_page(rectified)
+        oriented = self._apply_orientation(rectified, target.aspect_ratio)
+        resized = self._resize_to_canonical(oriented, target.aspect_ratio)
+        grayscale = cv2.cvtColor(resized, cv2.COLOR_BGR2GRAY)
+        debug_overlay = self._build_debug_overlay(
+            decoded,
+            detection,
+            diagnostics=detection_result.diagnostics,
+        )
+
+        rectified_color = self._encode_png(resized)
+        rectified_grayscale = self._encode_png(grayscale)
+        debug_overlay_png = self._encode_png(debug_overlay)
+        return NormalizationArtifacts(
+            rectified_color=rectified_color,
+            rectified_grayscale=rectified_grayscale,
+            debug_overlay=debug_overlay_png,
+            metadata=NormalizationMetadata(
+                method=detection.method,
+                confidence=float(round(detection.confidence, 6)),
+                corners=self._to_corners(detection.corners),
+                transform=NormalizationTransform(
+                    matrix=[
+                        [float(round(value, 6)) for value in row]
+                        for row in matrix.tolist()
+                    ]
+                ),
+                output=NormalizationOutput(
+                    width=int(resized.shape[1]),
+                    height=int(resized.shape[0]),
+                    aspect_ratio=float(round(target.aspect_ratio, 6)),
+                ),
+                target_frame_source=target.source,
+                diagnostics=detection_result.diagnostics,
+                frame=NormalizationFrame(
+                    kind="page_aligned",
+                    version=1,
+                    page_width_mm=float(round(target.page_width_mm, 3)),
+                    page_height_mm=float(round(target.page_height_mm, 3)),
+                ),
+            ),
+        )
+
+    def _decode_image(self, content: bytes) -> Optional[np.ndarray]:
+        buffer = np.frombuffer(content, dtype=np.uint8)
+        if buffer.size == 0:
+            return None
+        image = cv2.imdecode(buffer, cv2.IMREAD_COLOR)
+        return image
+
+    def _detect_paper(
+        self,
+        image: np.ndarray,
+        *,
+        target_aspect_ratio: float,
+    ) -> DetectionResult:
+        scaled, scale = self._downscale_for_detection(image)
+        image_area = float(scaled.shape[0] * scaled.shape[1])
+        expected_shape_aspect_ratio = self._shape_aspect_ratio(target_aspect_ratio)
+        contour_diagnostics = DetectorRunDiagnostics(status="not_run")
+        region_diagnostics = DetectorRunDiagnostics(status="not_run")
+
+        if self._experiment == "contour_v3":
+            primary_candidate, contour_diagnostics = self._detect_contour_quad(
+                scaled,
+                image_area=image_area,
+                expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+            )
+            primary_method: NormalizationMethod = "paper_contour_v3"
+        else:
+            primary_candidate, region_diagnostics = self._detect_region_quad(
+                scaled,
+                image_area=image_area,
+                expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+            )
+            primary_method = "paper_region_v2"
+
+        if primary_candidate is not None:
+            ordered = self._order_corners(primary_candidate.corners / scale)
+            return DetectionResult(
+                candidate=DetectionCandidate(
+                    corners=ordered,
+                    confidence=float(max(0.0, min(1.0, primary_candidate.confidence))),
+                    method=primary_method,
+                ),
+                diagnostics=NormalizationDiagnostics(
+                    mode=self._mode,
+                    contour_v3=(
+                        self._to_method_diagnostics(contour_diagnostics, status="used")
+                        if self._experiment == "contour_v3"
+                        else _not_run_diagnostics()
+                    ),
+                    region_v2=(
+                        self._to_method_diagnostics(region_diagnostics, status="used")
+                        if self._experiment == "region_v2"
+                        else _not_run_diagnostics()
+                    ),
+                    line_v1=_not_run_diagnostics(),
+                ),
+            )
+
+        if self._mode == "region_only":
+            return DetectionResult(
+                candidate=DetectionCandidate(
+                    corners=self._full_frame_corners(image),
+                    confidence=0.0,
+                    method="fallback_full_frame",
+                ),
+                diagnostics=NormalizationDiagnostics(
+                    mode=self._mode,
+                    contour_v3=(
+                        self._to_method_diagnostics(
+                            contour_diagnostics,
+                            status="rejected" if contour_diagnostics.candidate_count > 0 else "unavailable",
+                        )
+                        if self._experiment == "contour_v3"
+                        else _not_run_diagnostics()
+                    ),
+                    region_v2=(
+                        self._to_method_diagnostics(
+                            region_diagnostics,
+                            status="rejected" if region_diagnostics.candidate_count > 0 else "unavailable",
+                        )
+                        if self._experiment == "region_v2"
+                        else _not_run_diagnostics()
+                    ),
+                    line_v1=NormalizationMethodDiagnostics(
+                        status="not_run",
+                        rejection_reason="disabled_in_region_only_mode",
+                        candidate_count=0,
+                    ),
+                ),
+            )
+
+        line_candidate, line_diagnostics = self._detect_line_quad(
+            scaled,
+            image_area=image_area,
+            expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+        )
+        if line_candidate is not None:
+            ordered = self._order_corners(line_candidate.corners / scale)
+            return DetectionResult(
+                candidate=DetectionCandidate(
+                    corners=ordered,
+                    confidence=float(max(0.0, min(1.0, line_candidate.confidence))),
+                    method="paper_edges_v1",
+                ),
+                diagnostics=NormalizationDiagnostics(
+                    mode=self._mode,
+                    contour_v3=(
+                        self._to_method_diagnostics(
+                            contour_diagnostics,
+                            status="rejected" if contour_diagnostics.candidate_count > 0 else "unavailable",
+                        )
+                        if self._experiment == "contour_v3"
+                        else _not_run_diagnostics()
+                    ),
+                    region_v2=(
+                        self._to_method_diagnostics(
+                            region_diagnostics,
+                            status="rejected" if region_diagnostics.candidate_count > 0 else "unavailable",
+                        )
+                        if self._experiment == "region_v2"
+                        else _not_run_diagnostics()
+                    ),
+                    line_v1=self._to_method_diagnostics(
+                        line_diagnostics,
+                        status="used",
+                    ),
+                ),
+            )
+
+        return DetectionResult(
+            candidate=DetectionCandidate(
+                corners=self._full_frame_corners(image),
+                confidence=0.0,
+                method="fallback_full_frame",
+            ),
+            diagnostics=NormalizationDiagnostics(
+                mode=self._mode,
+                contour_v3=(
+                    self._to_method_diagnostics(
+                        contour_diagnostics,
+                        status="rejected" if contour_diagnostics.candidate_count > 0 else "unavailable",
+                    )
+                    if self._experiment == "contour_v3"
+                    else _not_run_diagnostics()
+                ),
+                region_v2=(
+                    self._to_method_diagnostics(
+                        region_diagnostics,
+                        status="rejected" if region_diagnostics.candidate_count > 0 else "unavailable",
+                    )
+                    if self._experiment == "region_v2"
+                    else _not_run_diagnostics()
+                ),
+                line_v1=self._to_method_diagnostics(
+                    line_diagnostics,
+                    status="rejected" if line_diagnostics.candidate_count > 0 else "unavailable",
+                ),
+            ),
+        )
+
+    def _detect_region_quad(
+        self,
+        image: np.ndarray,
+        *,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+    ) -> tuple[Optional[DetectionCandidate], DetectorRunDiagnostics]:
+        luma = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)[:, :, 0]
+        blurred = cv2.GaussianBlur(luma, (7, 7), 0)
+        gradient = self._gradient_magnitude(blurred)
+        threshold_value, _ = cv2.threshold(
+            blurred,
+            0,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        clamped_threshold = max(float(threshold_value), float(BRIGHT_REGION_FLOOR_LUMA))
+        _, bright_mask = cv2.threshold(
+            blurred,
+            clamped_threshold,
+            255,
+            cv2.THRESH_BINARY,
+        )
+        bright_mask = cv2.morphologyEx(
+            bright_mask,
+            cv2.MORPH_CLOSE,
+            np.ones((7, 7), dtype=np.uint8),
+            iterations=1,
+        )
+        bright_mask = cv2.morphologyEx(
+            bright_mask,
+            cv2.MORPH_OPEN,
+            np.ones((5, 5), dtype=np.uint8),
+            iterations=1,
+        )
+
+        contours, _ = cv2.findContours(
+            bright_mask,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_SIMPLE,
+        )
+        if not contours:
+            return None, DetectorRunDiagnostics(
+                status="unavailable",
+                rejection_reason="no_region_contours",
+                candidate_count=0,
+            )
+
+        minimum_area = image_area * MIN_QUAD_AREA_RATIO
+        best_candidate: Optional[DetectionCandidate] = None
+        best_score = -1.0
+        best_rejected: Optional[DetectorCandidateDiagnostics] = None
+        best_rejected_rank: tuple[int, float] = (-1, -1.0)
+        candidate_count = 0
+        height, width = image.shape[:2]
+        for contour in contours:
+            contour_bounds = cv2.boundingRect(contour)
+            diagnostics = DetectorCandidateDiagnostics(bounds=contour_bounds)
+            if self._touches_too_many_borders(
+                contour_bounds,
+                width=width,
+                height=height,
+            ):
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    rejection_reason="touches_too_many_borders",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(0, 0.0),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            contour_mask = np.zeros(luma.shape, dtype=np.uint8)
+            cv2.drawContours(contour_mask, [contour], -1, 255, thickness=-1)
+            component_area = float(cv2.countNonZero(cv2.bitwise_and(contour_mask, bright_mask)))
+            diagnostics = DetectorCandidateDiagnostics(
+                bounds=contour_bounds,
+                component_area=component_area,
+            )
+            if component_area < minimum_area:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    rejection_reason="component_area_below_minimum",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(1, component_area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            candidate_count += 1
+            if self._is_oversized_top_band_region(
+                contour_bounds,
+                component_area=component_area,
+                image_area=image_area,
+                image_height=height,
+            ):
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    rejection_reason="oversized_top_band_region",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(2, component_area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            candidate_corners = self._fit_region_candidate_corners(contour)
+            rect_width = float(np.linalg.norm(candidate_corners[1] - candidate_corners[0]))
+            rect_height = float(np.linalg.norm(candidate_corners[3] - candidate_corners[0]))
+            if rect_width <= 2.0 or rect_height <= 2.0:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=candidate_corners,
+                    rejection_reason="candidate_side_too_small",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(3, component_area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            rect_area = float(rect_width * rect_height)
+            if rect_area <= 0.0:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=candidate_corners,
+                    rejection_reason="candidate_rect_area_non_positive",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(3, component_area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            fill_ratio = component_area / rect_area
+            if fill_ratio < MIN_REGION_FILL_RATIO:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=candidate_corners,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    rejection_reason="fill_ratio_too_low",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(4, fill_ratio),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            refined, border_metrics = self._refine_region_rectangle(
+                gray=blurred,
+                gradient=gradient,
+                contour=contour,
+                corners=candidate_corners,
+            )
+            if not self._corners_within_margin(
+                refined,
+                width=width,
+                height=height,
+                margin_ratio=MAX_DETECTION_MARGIN_RATIO,
+            ):
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason="corners_outside_margin",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(5, border_metrics["mean_border_support"]),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            area = abs(cv2.contourArea(refined.astype(np.float32)))
+            if area < minimum_area:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason="candidate_area_below_minimum",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(6, area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            side_scores = [
+                ("weak_top_border", border_metrics["top_score"]),
+                ("weak_right_border", border_metrics["right_score"]),
+                ("weak_bottom_border", border_metrics["bottom_score"]),
+                ("weak_left_border", border_metrics["left_score"]),
+            ]
+            weak_side_reason = next(
+                (reason for reason, score in side_scores if score < REGION_MIN_SIDE_SCORE),
+                None,
+            )
+            if weak_side_reason is not None:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason=weak_side_reason,
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(7, border_metrics["mean_border_support"]),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            if border_metrics["mean_border_support"] < REGION_MIN_MEAN_BORDER_SUPPORT:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason="mean_border_support_too_low",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(8, border_metrics["mean_border_support"]),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            if border_metrics["outward_side_count"] >= 2:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason="excessive_outward_expansion",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(9, 1.0 - min(1.0, border_metrics["max_outward_expansion_px"] / max(REGION_OUTWARD_EXPANSION_PX, 1.0))),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            if border_metrics["refined_area_ratio"] > REGION_MAX_REFINED_AREA_RATIO:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason="refined_box_too_large_for_region",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(10, 1.0 - min(1.0, border_metrics["refined_area_ratio"] / REGION_MAX_REFINED_AREA_RATIO)),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            candidate_shape_aspect_ratio = self._shape_aspect_ratio(
+                self._quadrilateral_aspect_ratio(refined),
+            )
+            occupancy_score = self._polygon_occupancy_score(bright_mask, refined)
+            if occupancy_score < 0.58:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    occupancy_score=occupancy_score,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    rejection_reason="occupancy_score_too_low",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(11, occupancy_score),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            aspect_log_error = self._aspect_log_error(
+                candidate_shape_aspect_ratio,
+                expected_shape_aspect_ratio,
+            )
+            if aspect_log_error > MAX_ASPECT_LOG_ERROR:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    occupancy_score=occupancy_score,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    aspect_log_error=aspect_log_error,
+                    rejection_reason="aspect_ratio_out_of_range",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(12, 1.0 - min(1.0, aspect_log_error / MAX_ASPECT_LOG_ERROR)),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            score = self._score_region_candidate(
+                luma=blurred,
+                bright_mask=bright_mask,
+                contour_mask=contour_mask,
+                corners=refined,
+                component_area=component_area,
+                rect_area=rect_area,
+                image_area=image_area,
+                expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+                edge_support_score=border_metrics["mean_border_support"],
+                occupancy_score=occupancy_score,
+            )
+            if score > best_score:
+                best_score = score
+                best_candidate = DetectionCandidate(
+                    corners=refined,
+                    confidence=float(score),
+                    method="paper_region_v2",
+                )
+                best_rejected = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=refined,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    occupancy_score=occupancy_score,
+                    edge_support_score=border_metrics["mean_border_support"],
+                    top_score=border_metrics["top_score"],
+                    right_score=border_metrics["right_score"],
+                    bottom_score=border_metrics["bottom_score"],
+                    left_score=border_metrics["left_score"],
+                    mean_border_support=border_metrics["mean_border_support"],
+                    max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                    refined_area_ratio=border_metrics["refined_area_ratio"],
+                    aspect_log_error=aspect_log_error,
+                    score=score,
+                    confidence=score,
+                )
+                best_rejected_rank = (13, score)
+
+        if best_candidate is not None:
+            return best_candidate, DetectorRunDiagnostics(
+                status="used",
+                candidate_count=candidate_count,
+                best_candidate=best_rejected,
+            )
+        return None, DetectorRunDiagnostics(
+            status="rejected" if candidate_count > 0 else "unavailable",
+            rejection_reason=(
+                best_rejected.rejection_reason
+                if best_rejected is not None and best_rejected.rejection_reason is not None
+                else ("no_region_candidate_survived_scoring" if candidate_count > 0 else "no_plausible_region_candidate")
+            ),
+            candidate_count=candidate_count,
+            best_candidate=best_rejected,
+        )
+
+    def _detect_contour_quad(
+        self,
+        image: np.ndarray,
+        *,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+    ) -> tuple[Optional[DetectionCandidate], DetectorRunDiagnostics]:
+        normalized_gray = self._illumination_normalized_gray(image)
+        blurred = cv2.GaussianBlur(normalized_gray, (5, 5), 0)
+        gradient = self._gradient_magnitude(blurred)
+        edges = cv2.Canny(blurred, 40, 120)
+        edges = cv2.morphologyEx(
+            edges,
+            cv2.MORPH_CLOSE,
+            np.ones((5, 5), dtype=np.uint8),
+            iterations=1,
+        )
+        edges = cv2.dilate(edges, np.ones((3, 3), dtype=np.uint8), iterations=1)
+        contours, _ = cv2.findContours(
+            edges,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_SIMPLE,
+        )
+        if not contours:
+            return None, DetectorRunDiagnostics(
+                status="unavailable",
+                rejection_reason="no_contour_edges",
+                candidate_count=0,
+            )
+
+        minimum_area = image_area * MIN_QUAD_AREA_RATIO
+        best_candidate: Optional[DetectionCandidate] = None
+        best_score = -1.0
+        best_rejected: Optional[DetectorCandidateDiagnostics] = None
+        best_rejected_rank: tuple[int, float] = (-1, -1.0)
+        candidate_count = 0
+        height, width = image.shape[:2]
+        for contour in contours:
+            hull = cv2.convexHull(contour)
+            contour_bounds = cv2.boundingRect(hull)
+            diagnostics = DetectorCandidateDiagnostics(bounds=contour_bounds)
+            if self._touches_too_many_borders(
+                contour_bounds,
+                width=width,
+                height=height,
+            ):
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    rejection_reason="touches_too_many_borders",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(0, 0.0),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            component_area = float(abs(cv2.contourArea(hull.astype(np.float32))))
+            diagnostics = DetectorCandidateDiagnostics(
+                bounds=contour_bounds,
+                component_area=component_area,
+            )
+            if component_area < minimum_area:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    rejection_reason="component_area_below_minimum",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(1, component_area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            candidate_count += 1
+
+            candidate_corners = self._fit_region_candidate_corners(hull)
+            rect_width = float(np.linalg.norm(candidate_corners[1] - candidate_corners[0]))
+            rect_height = float(np.linalg.norm(candidate_corners[3] - candidate_corners[0]))
+            if rect_width <= 2.0 or rect_height <= 2.0:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=candidate_corners,
+                    rejection_reason="candidate_side_too_small",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(2, component_area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            rect_area = float(rect_width * rect_height)
+            fill_ratio = component_area / max(rect_area, 1.0)
+            if fill_ratio < 0.52:
+                diagnostics = DetectorCandidateDiagnostics(
+                    bounds=contour_bounds,
+                    component_area=component_area,
+                    corners=candidate_corners,
+                    rect_area=rect_area,
+                    fill_ratio=fill_ratio,
+                    rejection_reason="fill_ratio_too_low",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(3, fill_ratio),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            refined, border_metrics = self._refine_region_rectangle(
+                gray=blurred,
+                gradient=gradient,
+                contour=hull,
+                corners=candidate_corners,
+            )
+            diagnostics_common = dict(
+                bounds=contour_bounds,
+                component_area=component_area,
+                corners=refined,
+                rect_area=rect_area,
+                fill_ratio=fill_ratio,
+                edge_support_score=border_metrics["mean_border_support"],
+                top_score=border_metrics["top_score"],
+                right_score=border_metrics["right_score"],
+                bottom_score=border_metrics["bottom_score"],
+                left_score=border_metrics["left_score"],
+                mean_border_support=border_metrics["mean_border_support"],
+                max_outward_expansion_px=border_metrics["max_outward_expansion_px"],
+                refined_area_ratio=border_metrics["refined_area_ratio"],
+            )
+            if not self._corners_within_margin(
+                refined,
+                width=width,
+                height=height,
+                margin_ratio=MAX_DETECTION_MARGIN_RATIO,
+            ):
+                diagnostics = DetectorCandidateDiagnostics(
+                    **diagnostics_common,
+                    rejection_reason="corners_outside_margin",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(4, border_metrics["mean_border_support"]),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            area = abs(cv2.contourArea(refined.astype(np.float32)))
+            if area < minimum_area:
+                diagnostics = DetectorCandidateDiagnostics(
+                    **diagnostics_common,
+                    rejection_reason="candidate_area_below_minimum",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(5, area),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            side_scores = [
+                ("weak_top_border", border_metrics["top_score"]),
+                ("weak_right_border", border_metrics["right_score"]),
+                ("weak_bottom_border", border_metrics["bottom_score"]),
+                ("weak_left_border", border_metrics["left_score"]),
+            ]
+            weak_side_reason = next(
+                (reason for reason, score in side_scores if score < REGION_MIN_SIDE_SCORE),
+                None,
+            )
+            if weak_side_reason is not None:
+                diagnostics = DetectorCandidateDiagnostics(
+                    **diagnostics_common,
+                    rejection_reason=weak_side_reason,
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(6, border_metrics["mean_border_support"]),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+            if border_metrics["mean_border_support"] < REGION_MIN_MEAN_BORDER_SUPPORT:
+                diagnostics = DetectorCandidateDiagnostics(
+                    **diagnostics_common,
+                    rejection_reason="mean_border_support_too_low",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(7, border_metrics["mean_border_support"]),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            candidate_shape_aspect_ratio = self._shape_aspect_ratio(
+                self._quadrilateral_aspect_ratio(refined),
+            )
+            aspect_log_error = self._aspect_log_error(
+                candidate_shape_aspect_ratio,
+                expected_shape_aspect_ratio,
+            )
+            if aspect_log_error > MAX_ASPECT_LOG_ERROR:
+                diagnostics = DetectorCandidateDiagnostics(
+                    **diagnostics_common,
+                    aspect_log_error=aspect_log_error,
+                    rejection_reason="aspect_ratio_out_of_range",
+                )
+                best_rejected, best_rejected_rank = self._consider_rejected_candidate(
+                    diagnostics,
+                    rank=(8, 1.0 - min(1.0, aspect_log_error / MAX_ASPECT_LOG_ERROR)),
+                    current=best_rejected,
+                    current_rank=best_rejected_rank,
+                )
+                continue
+
+            score = self._score_contour_candidate(
+                corners=refined,
+                component_area=component_area,
+                rect_area=rect_area,
+                image_area=image_area,
+                expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+                border_support_score=border_metrics["mean_border_support"],
+                fill_ratio=fill_ratio,
+            )
+            if score > best_score:
+                best_score = score
+                best_candidate = DetectionCandidate(
+                    corners=refined,
+                    confidence=float(score),
+                    method="paper_contour_v3",
+                )
+                best_rejected = DetectorCandidateDiagnostics(
+                    **diagnostics_common,
+                    aspect_log_error=aspect_log_error,
+                    score=score,
+                    confidence=score,
+                )
+                best_rejected_rank = (9, score)
+
+        if best_candidate is not None:
+            return best_candidate, DetectorRunDiagnostics(
+                status="used",
+                candidate_count=candidate_count,
+                best_candidate=best_rejected,
+            )
+        return None, DetectorRunDiagnostics(
+            status="rejected" if candidate_count > 0 else "unavailable",
+            rejection_reason=(
+                best_rejected.rejection_reason
+                if best_rejected is not None and best_rejected.rejection_reason is not None
+                else ("no_contour_candidate_survived_scoring" if candidate_count > 0 else "no_plausible_contour_candidate")
+            ),
+            candidate_count=candidate_count,
+            best_candidate=best_rejected,
+        )
+
+    def _detect_line_quad(
+        self,
+        image: np.ndarray,
+        *,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+    ) -> tuple[Optional[DetectionCandidate], DetectorRunDiagnostics]:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+        edges = cv2.Canny(blurred, 50, 150)
+        min_line_length = int(round(max(image.shape[0], image.shape[1]) * 0.12))
+        lines = cv2.HoughLinesP(
+            edges,
+            1,
+            np.pi / 180,
+            threshold=90,
+            minLineLength=max(60, min_line_length),
+            maxLineGap=30,
+        )
+        if lines is None:
+            return None, DetectorRunDiagnostics(
+                status="unavailable",
+                rejection_reason="no_hough_lines",
+                candidate_count=0,
+            )
+
+        parsed_lines = [self._build_line_candidate(line[0]) for line in lines]
+        height, width = image.shape[:2]
+        left = self._select_vertical_line(
+            parsed_lines,
+            width=width,
+            band_min=0.05,
+            band_max=0.55,
+            prefer_right=False,
+        )
+        right = self._select_vertical_line(
+            parsed_lines,
+            width=width,
+            band_min=0.45,
+            band_max=0.9,
+            prefer_right=True,
+        )
+        if left is None or right is None:
+            return None, DetectorRunDiagnostics(
+                status="rejected",
+                rejection_reason="missing_vertical_edges",
+                candidate_count=len(parsed_lines),
+            )
+        bottom = self._select_horizontal_line(
+            parsed_lines,
+            gray=gray,
+            width=width,
+            height=height,
+            band_min=0.55,
+            band_max=0.98,
+            prefer_lower=True,
+            expect_below_brighter=False,
+        )
+        if bottom is None:
+            return None, DetectorRunDiagnostics(
+                status="rejected",
+                rejection_reason="missing_bottom_edge",
+                candidate_count=len(parsed_lines),
+            )
+        top = self._select_top_line(
+            parsed_lines,
+            gray=gray,
+            width=width,
+            height=height,
+            image_area=image_area,
+            expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+            left=left,
+            right=right,
+            bottom=bottom,
+        )
+        if top is None:
+            return None, DetectorRunDiagnostics(
+                status="rejected",
+                rejection_reason="missing_top_edge",
+                candidate_count=len(parsed_lines),
+            )
+
+        corners = np.array(
+            [
+                self._line_intersection(top.points, left.points),
+                self._line_intersection(top.points, right.points),
+                self._line_intersection(bottom.points, right.points),
+                self._line_intersection(bottom.points, left.points),
+            ],
+            dtype=np.float32,
+        )
+        if np.isnan(corners).any():
+            return None, DetectorRunDiagnostics(
+                status="rejected",
+                rejection_reason="line_intersections_invalid",
+                candidate_count=len(parsed_lines),
+            )
+        ordered = self._order_corners(corners)
+        area = abs(cv2.contourArea(ordered.astype(np.float32)))
+        if area < image_area * MIN_QUAD_AREA_RATIO:
+            return None, DetectorRunDiagnostics(
+                status="rejected",
+                rejection_reason="line_quad_area_below_minimum",
+                candidate_count=len(parsed_lines),
+                best_candidate=DetectorCandidateDiagnostics(
+                    corners=ordered,
+                ),
+            )
+
+        margin = 0.08 * max(height, width)
+        min_x = float(np.min(ordered[:, 0]))
+        max_x = float(np.max(ordered[:, 0]))
+        min_y = float(np.min(ordered[:, 1]))
+        max_y = float(np.max(ordered[:, 1]))
+        if min_x < -margin or min_y < -margin or max_x > (width - 1 + margin) or max_y > (height - 1 + margin):
+            return None, DetectorRunDiagnostics(
+                status="rejected",
+                rejection_reason="line_quad_outside_margin",
+                candidate_count=len(parsed_lines),
+                best_candidate=DetectorCandidateDiagnostics(
+                    corners=ordered,
+                ),
+            )
+
+        line_strength = (
+            top.length + bottom.length + left.length + right.length
+        ) / (2.0 * (width + height))
+        geometry_score = self._score_quadrilateral(
+            ordered,
+            area=area,
+            image_area=image_area,
+            expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+        )
+        confidence = (min(1.0, line_strength) * 0.45) + (geometry_score * 0.55)
+        candidate = DetectionCandidate(
+            corners=ordered,
+            confidence=float(confidence),
+            method="paper_edges_v1",
+        )
+        return candidate, DetectorRunDiagnostics(
+            status="used",
+            candidate_count=len(parsed_lines),
+            best_candidate=DetectorCandidateDiagnostics(
+                corners=ordered,
+                confidence=confidence,
+                score=confidence,
+            ),
+        )
+
+    def _downscale_for_detection(self, image: np.ndarray) -> tuple[np.ndarray, float]:
+        height, width = image.shape[:2]
+        longest_side = max(height, width)
+        if longest_side <= MAX_DETECTION_DIMENSION_PX:
+            return image.copy(), 1.0
+        scale = MAX_DETECTION_DIMENSION_PX / float(longest_side)
+        resized = cv2.resize(
+            image,
+            (
+                max(1, int(round(width * scale))),
+                max(1, int(round(height * scale))),
+            ),
+            interpolation=cv2.INTER_AREA,
+        )
+        return resized, scale
+
+    def _score_quadrilateral(
+        self,
+        corners: np.ndarray,
+        *,
+        area: float,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+    ) -> float:
+        ordered = self._order_corners(corners)
+        side_lengths = [
+            float(np.linalg.norm(ordered[1] - ordered[0])),
+            float(np.linalg.norm(ordered[2] - ordered[1])),
+            float(np.linalg.norm(ordered[3] - ordered[2])),
+            float(np.linalg.norm(ordered[0] - ordered[3])),
+        ]
+        if min(side_lengths) <= 0:
+            return 0.0
+        angle_penalty = 0.0
+        for index in range(4):
+            previous = ordered[index - 1] - ordered[index]
+            following = ordered[(index + 1) % 4] - ordered[index]
+            cosine = abs(
+                np.dot(previous, following)
+                / (np.linalg.norm(previous) * np.linalg.norm(following))
+            )
+            angle_penalty += cosine
+        angle_score = max(0.0, 1.0 - (angle_penalty / 4.0))
+        area_score = min(1.0, area / image_area)
+        side_balance = min(side_lengths) / max(side_lengths)
+        candidate_aspect_ratio = self._shape_aspect_ratio(
+            self._quadrilateral_aspect_ratio(ordered),
+        )
+        aspect_score = self._aspect_score(
+            candidate_aspect_ratio,
+            expected_shape_aspect_ratio,
+        )
+        score = (
+            (area_score * 0.35)
+            + (angle_score * 0.25)
+            + (side_balance * 0.15)
+            + (aspect_score * 0.25)
+        )
+        return float(score)
+
+    def _score_region_candidate(
+        self,
+        *,
+        luma: np.ndarray,
+        bright_mask: np.ndarray,
+        contour_mask: np.ndarray,
+        corners: np.ndarray,
+        component_area: float,
+        rect_area: float,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+        edge_support_score: float,
+        occupancy_score: float,
+    ) -> float:
+        inside_values = luma[contour_mask > 0]
+        if inside_values.size == 0:
+            return 0.0
+
+        band_kernel = np.ones((15, 15), dtype=np.uint8)
+        outer_ring_mask = cv2.dilate(contour_mask, band_kernel, iterations=1)
+        outer_ring_mask = cv2.subtract(outer_ring_mask, contour_mask)
+        outer_values = luma[outer_ring_mask > 0]
+
+        area_score = min(1.0, component_area / max(1.0, image_area * 0.45))
+        candidate_aspect_ratio = self._shape_aspect_ratio(
+            self._quadrilateral_aspect_ratio(corners),
+        )
+        aspect_score = self._aspect_score(
+            candidate_aspect_ratio,
+            expected_shape_aspect_ratio,
+        )
+        rectangularity_score = max(
+            0.0,
+            min(1.0, (component_area / max(rect_area, 1.0) - 0.55) / 0.45),
+        )
+        rectangularity_score *= occupancy_score
+        inside_mean = float(np.mean(inside_values))
+        inside_std = float(np.std(inside_values))
+        brightness_score = max(0.0, min(1.0, (inside_mean - BRIGHT_REGION_FLOOR_LUMA) / 80.0))
+        variance_score = max(0.0, min(1.0, 1.0 - (inside_std / 38.0)))
+        interior_uniformity_score = (brightness_score * 0.35) + (variance_score * 0.65)
+        if outer_values.size > 0:
+            contrast_score = max(
+                0.0,
+                min(1.0, ((inside_mean - float(np.mean(outer_values))) + 10.0) / 55.0),
+            )
+        else:
+            contrast_score = brightness_score
+        return float(
+            (aspect_score * 0.2)
+            + (rectangularity_score * 0.15)
+            + (edge_support_score * 0.35)
+            + (contrast_score * 0.1)
+            + (area_score * 0.05)
+            + (interior_uniformity_score * 0.05)
+            + (occupancy_score * 0.1)
+        )
+
+    def _score_contour_candidate(
+        self,
+        *,
+        corners: np.ndarray,
+        component_area: float,
+        rect_area: float,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+        border_support_score: float,
+        fill_ratio: float,
+    ) -> float:
+        candidate_aspect_ratio = self._shape_aspect_ratio(
+            self._quadrilateral_aspect_ratio(corners),
+        )
+        aspect_score = self._aspect_score(
+            candidate_aspect_ratio,
+            expected_shape_aspect_ratio,
+        )
+        area_score = min(1.0, component_area / max(1.0, image_area * 0.45))
+        rectangularity_score = max(
+            0.0,
+            min(1.0, (fill_ratio - 0.5) / 0.45),
+        )
+        geometry_score = self._score_quadrilateral(
+            corners,
+            area=abs(cv2.contourArea(corners.astype(np.float32))),
+            image_area=image_area,
+            expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+        )
+        return float(
+            (aspect_score * 0.3)
+            + (border_support_score * 0.4)
+            + (rectangularity_score * 0.15)
+            + (geometry_score * 0.1)
+            + (area_score * 0.05)
+        )
+
+    def _consider_rejected_candidate(
+        self,
+        diagnostics: DetectorCandidateDiagnostics,
+        *,
+        rank: tuple[int, float],
+        current: Optional[DetectorCandidateDiagnostics],
+        current_rank: tuple[int, float],
+    ) -> tuple[Optional[DetectorCandidateDiagnostics], tuple[int, float]]:
+        if rank > current_rank:
+            return diagnostics, rank
+        return current, current_rank
+
+    def _to_method_diagnostics(
+        self,
+        diagnostics: DetectorRunDiagnostics,
+        *,
+        status: Literal["used", "rejected", "not_run", "unavailable"],
+    ) -> NormalizationMethodDiagnostics:
+        return NormalizationMethodDiagnostics(
+            status=status,
+            rejection_reason=diagnostics.rejection_reason,
+            candidate_count=diagnostics.candidate_count,
+            best_candidate=self._to_diagnostic_candidate(diagnostics.best_candidate),
+        )
+
+    def _to_diagnostic_candidate(
+        self,
+        candidate: Optional[DetectorCandidateDiagnostics],
+    ) -> Optional[NormalizationDiagnosticCandidate]:
+        if candidate is None:
+            return None
+        return NormalizationDiagnosticCandidate(
+            corners=self._to_corners(candidate.corners) if candidate.corners is not None else None,
+            bounds=(
+                tuple(int(value) for value in candidate.bounds)
+                if candidate.bounds is not None
+                else None
+            ),
+            component_area=(
+                float(round(candidate.component_area, 6))
+                if candidate.component_area is not None
+                else None
+            ),
+            rect_area=(
+                float(round(candidate.rect_area, 6))
+                if candidate.rect_area is not None
+                else None
+            ),
+            fill_ratio=(
+                float(round(candidate.fill_ratio, 6))
+                if candidate.fill_ratio is not None
+                else None
+            ),
+            occupancy_score=(
+                float(round(candidate.occupancy_score, 6))
+                if candidate.occupancy_score is not None
+                else None
+            ),
+            edge_support_score=(
+                float(round(candidate.edge_support_score, 6))
+                if candidate.edge_support_score is not None
+                else None
+            ),
+            top_score=(
+                float(round(candidate.top_score, 6))
+                if candidate.top_score is not None
+                else None
+            ),
+            right_score=(
+                float(round(candidate.right_score, 6))
+                if candidate.right_score is not None
+                else None
+            ),
+            bottom_score=(
+                float(round(candidate.bottom_score, 6))
+                if candidate.bottom_score is not None
+                else None
+            ),
+            left_score=(
+                float(round(candidate.left_score, 6))
+                if candidate.left_score is not None
+                else None
+            ),
+            mean_border_support=(
+                float(round(candidate.mean_border_support, 6))
+                if candidate.mean_border_support is not None
+                else None
+            ),
+            max_outward_expansion_px=(
+                float(round(candidate.max_outward_expansion_px, 6))
+                if candidate.max_outward_expansion_px is not None
+                else None
+            ),
+            refined_area_ratio=(
+                float(round(candidate.refined_area_ratio, 6))
+                if candidate.refined_area_ratio is not None
+                else None
+            ),
+            aspect_log_error=(
+                float(round(candidate.aspect_log_error, 6))
+                if candidate.aspect_log_error is not None
+                else None
+            ),
+            score=(
+                float(round(candidate.score, 6))
+                if candidate.score is not None
+                else None
+            ),
+            confidence=(
+                float(round(candidate.confidence, 6))
+                if candidate.confidence is not None
+                else None
+            ),
+            rejection_reason=candidate.rejection_reason,
+        )
+
+    def _refine_region_rectangle(
+        self,
+        gray: np.ndarray,
+        gradient: np.ndarray,
+        contour: np.ndarray,
+        corners: np.ndarray,
+    ) -> tuple[np.ndarray, dict[str, float]]:
+        ordered = self._order_corners(corners)
+        width_vector = ordered[1] - ordered[0]
+        height_vector = ordered[3] - ordered[0]
+        width_length = float(np.linalg.norm(width_vector))
+        height_length = float(np.linalg.norm(height_vector))
+        if width_length <= 1.0 or height_length <= 1.0:
+            return ordered, {
+                "top_score": 0.0,
+                "right_score": 0.0,
+                "bottom_score": 0.0,
+                "left_score": 0.0,
+                "mean_border_support": 0.0,
+                "max_outward_expansion_px": 0.0,
+                "outward_side_count": 0.0,
+                "refined_area_ratio": 1.0,
+            }
+
+        center = np.mean(ordered, axis=0).astype(np.float32)
+        u = width_vector / width_length
+        v = height_vector / height_length
+        contour_points = contour.reshape(-1, 2).astype(np.float32)
+        relative_points = contour_points - center
+        width_projections = relative_points @ u
+        height_projections = relative_points @ v
+
+        left_anchor = float(np.percentile(width_projections, SNAP_BOX_QUANTILE))
+        right_anchor = float(np.percentile(width_projections, 100.0 - SNAP_BOX_QUANTILE))
+        top_anchor = float(np.percentile(height_projections, SNAP_BOX_QUANTILE))
+        bottom_anchor = float(np.percentile(height_projections, 100.0 - SNAP_BOX_QUANTILE))
+        anchor_width = max(1.0, right_anchor - left_anchor)
+        anchor_height = max(1.0, bottom_anchor - top_anchor)
+        anchor_area = anchor_width * anchor_height
+
+        top_pos, top_metrics = self._snap_region_edge_position(
+            gray=gray,
+            gradient=gradient,
+            center=center,
+            u=u,
+            v=v,
+            contour_points=contour_points,
+            contour_parallel=width_projections,
+            contour_orthogonal=height_projections,
+            fixed_axis="horizontal",
+            anchor_position=top_anchor,
+            span=anchor_width / 2.0,
+            min_delta=-REGION_OUTWARD_EXPANSION_PX,
+            max_delta=REGION_INWARD_EXPANSION_PX,
+            inward_sign=1.0,
+        )
+        bottom_pos, bottom_metrics = self._snap_region_edge_position(
+            gray=gray,
+            gradient=gradient,
+            center=center,
+            u=u,
+            v=v,
+            contour_points=contour_points,
+            contour_parallel=width_projections,
+            contour_orthogonal=height_projections,
+            fixed_axis="horizontal",
+            anchor_position=bottom_anchor,
+            span=anchor_width / 2.0,
+            min_delta=-REGION_INWARD_EXPANSION_PX,
+            max_delta=REGION_OUTWARD_EXPANSION_PX,
+            inward_sign=-1.0,
+        )
+        left_pos, left_metrics = self._snap_region_edge_position(
+            gray=gray,
+            gradient=gradient,
+            center=center,
+            u=u,
+            v=v,
+            contour_points=contour_points,
+            contour_parallel=height_projections,
+            contour_orthogonal=width_projections,
+            fixed_axis="vertical",
+            anchor_position=left_anchor,
+            span=anchor_height / 2.0,
+            min_delta=-REGION_OUTWARD_EXPANSION_PX,
+            max_delta=REGION_INWARD_EXPANSION_PX,
+            inward_sign=1.0,
+        )
+        right_pos, right_metrics = self._snap_region_edge_position(
+            gray=gray,
+            gradient=gradient,
+            center=center,
+            u=u,
+            v=v,
+            contour_points=contour_points,
+            contour_parallel=height_projections,
+            contour_orthogonal=width_projections,
+            fixed_axis="vertical",
+            anchor_position=right_anchor,
+            span=anchor_height / 2.0,
+            min_delta=-REGION_INWARD_EXPANSION_PX,
+            max_delta=REGION_OUTWARD_EXPANSION_PX,
+            inward_sign=-1.0,
+        )
+
+        snapped_area = max(1.0, (right_pos - left_pos) * (bottom_pos - top_pos))
+        refined_area_ratio = float(snapped_area / max(anchor_area, 1.0))
+        outward_expansions = [
+            max(0.0, top_anchor - top_pos),
+            max(0.0, right_pos - right_anchor),
+            max(0.0, bottom_pos - bottom_anchor),
+            max(0.0, left_anchor - left_pos),
+        ]
+        outward_side_count = float(
+            sum(
+                1
+                for expansion in outward_expansions
+                if expansion > REGION_ALLOWED_OUTWARD_EXPANSION_PX
+            )
+        )
+        max_outward_expansion_px = float(max(outward_expansions))
+        mean_border_support = float(
+            np.mean(
+                [
+                    top_metrics["score"],
+                    right_metrics["score"],
+                    bottom_metrics["score"],
+                    left_metrics["score"],
+                ]
+            )
+        )
+
+        inset = min(
+            REGION_FINAL_INSET_PX,
+            max(1.0, min(right_pos - left_pos, bottom_pos - top_pos) * 0.005),
+        )
+        top_pos += inset
+        bottom_pos -= inset
+        left_pos += inset
+        right_pos -= inset
+
+        refined = np.array(
+            [
+                center + (left_pos * u) + (top_pos * v),
+                center + (right_pos * u) + (top_pos * v),
+                center + (right_pos * u) + (bottom_pos * v),
+                center + (left_pos * u) + (bottom_pos * v),
+            ],
+            dtype=np.float32,
+        )
+        return self._order_corners(refined), {
+            "top_score": top_metrics["score"],
+            "right_score": right_metrics["score"],
+            "bottom_score": bottom_metrics["score"],
+            "left_score": left_metrics["score"],
+            "mean_border_support": max(0.0, min(1.0, mean_border_support)),
+            "max_outward_expansion_px": max_outward_expansion_px,
+            "outward_side_count": outward_side_count,
+            "refined_area_ratio": refined_area_ratio,
+        }
+
+    def _fit_region_candidate_corners(self, contour: np.ndarray) -> np.ndarray:
+        rect = cv2.minAreaRect(contour)
+        base = self._order_corners(cv2.boxPoints(rect).astype(np.float32))
+        width_vector = base[1] - base[0]
+        height_vector = base[3] - base[0]
+        width_length = float(np.linalg.norm(width_vector))
+        height_length = float(np.linalg.norm(height_vector))
+        if width_length <= 1.0 or height_length <= 1.0:
+            return base
+
+        u = width_vector / width_length
+        v = height_vector / height_length
+        center = np.mean(base, axis=0).astype(np.float32)
+        contour_points = contour.reshape(-1, 2).astype(np.float32)
+        relative_points = contour_points - center
+        width_projections = relative_points @ u
+        height_projections = relative_points @ v
+
+        left = float(np.percentile(width_projections, REGION_BOX_QUANTILE))
+        right = float(np.percentile(width_projections, 100.0 - REGION_BOX_QUANTILE))
+        top = float(np.percentile(height_projections, REGION_BOX_QUANTILE))
+        bottom = float(np.percentile(height_projections, 100.0 - REGION_BOX_QUANTILE))
+        clipped = np.array(
+            [
+                center + (left * u) + (top * v),
+                center + (right * u) + (top * v),
+                center + (right * u) + (bottom * v),
+                center + (left * u) + (bottom * v),
+            ],
+            dtype=np.float32,
+        )
+        return self._order_corners(clipped)
+
+    def _snap_region_edge_position(
+        self,
+        *,
+        gray: np.ndarray,
+        gradient: np.ndarray,
+        center: np.ndarray,
+        u: np.ndarray,
+        v: np.ndarray,
+        contour_points: np.ndarray,
+        contour_parallel: np.ndarray,
+        contour_orthogonal: np.ndarray,
+        fixed_axis: Literal["horizontal", "vertical"],
+        anchor_position: float,
+        span: float,
+        min_delta: float,
+        max_delta: float,
+        inward_sign: float,
+    ) -> tuple[float, dict[str, float]]:
+        best_position = anchor_position
+        best_score = -1.0
+        best_metrics = {
+            "score": 0.0,
+            "contour_coverage_score": 0.0,
+            "border_contrast_score": 0.0,
+            "gradient_score": 0.0,
+        }
+        for delta in np.linspace(min_delta, max_delta, 13):
+            position = anchor_position + float(delta)
+            metrics = self._sample_region_border_metrics(
+                gray=gray,
+                gradient=gradient,
+                center=center,
+                u=u,
+                v=v,
+                contour_points=contour_points,
+                contour_parallel=contour_parallel,
+                contour_orthogonal=contour_orthogonal,
+                fixed_axis=fixed_axis,
+                position=position,
+                span=span,
+                inward_sign=inward_sign,
+            )
+            score = metrics["score"] - (max(0.0, abs(float(delta)) - 2.0) / max(max_delta - min_delta, 1.0) * 0.03)
+            if score > best_score:
+                best_score = score
+                best_position = position
+                best_metrics = metrics
+        return best_position, best_metrics
+
+    def _sample_region_border_metrics(
+        self,
+        *,
+        gray: np.ndarray,
+        gradient: np.ndarray,
+        center: np.ndarray,
+        u: np.ndarray,
+        v: np.ndarray,
+        contour_points: np.ndarray,
+        contour_parallel: np.ndarray,
+        contour_orthogonal: np.ndarray,
+        fixed_axis: Literal["horizontal", "vertical"],
+        position: float,
+        span: float,
+        inward_sign: float,
+    ) -> dict[str, float]:
+        usable_span = max(6.0, span * 0.88)
+        sample_count = max(14, min(48, int(round(usable_span / 18.0))))
+        offset = REGION_EDGE_SAMPLE_OFFSET_PX
+        gradient_values: list[float] = []
+        inside_values: list[float] = []
+        outside_values: list[float] = []
+
+        for index in range(sample_count):
+            t = ((index + 0.5) / sample_count * 2.0) - 1.0
+            along = float(t * usable_span)
+            if fixed_axis == "horizontal":
+                point = center + (along * u) + (position * v)
+                inside_point = center + (along * u) + ((position + (inward_sign * offset)) * v)
+                outside_point = center + (along * u) + ((position - (inward_sign * offset)) * v)
+            else:
+                point = center + (position * u) + (along * v)
+                inside_point = center + ((position + (inward_sign * offset)) * u) + (along * v)
+                outside_point = center + ((position - (inward_sign * offset)) * u) + (along * v)
+
+            px, py = self._clip_point(gray, point)
+            ix, iy = self._clip_point(gray, inside_point)
+            ox, oy = self._clip_point(gray, outside_point)
+            gradient_values.append(float(gradient[py, px]))
+            inside_values.append(float(gray[iy, ix]))
+            outside_values.append(float(gray[oy, ox]))
+
+        mean_gradient = float(np.mean(gradient_values))
+        mean_inside = float(np.mean(inside_values))
+        mean_outside = float(np.mean(outside_values))
+        gradient_score = max(0.0, min(1.0, mean_gradient / 38.0))
+        contrast_score = max(0.0, min(1.0, ((mean_inside - mean_outside) + 8.0) / 36.0))
+        contour_band = REGION_EDGE_ORTHOGONAL_BAND_PX
+        contour_mask = (np.abs(contour_orthogonal - position) <= contour_band) & (
+            np.abs(contour_parallel) <= usable_span
+        )
+        contour_hits = float(np.count_nonzero(contour_mask))
+        expected_hits = max(3.0, usable_span / 60.0)
+        contour_coverage_score = max(0.0, min(1.0, contour_hits / expected_hits))
+        score = (
+            contour_coverage_score * 0.5
+            + contrast_score * 0.3
+            + gradient_score * 0.2
+        )
+        return {
+            "score": max(0.0, min(1.0, score)),
+            "contour_coverage_score": contour_coverage_score,
+            "border_contrast_score": contrast_score,
+            "gradient_score": gradient_score,
+        }
+
+    def _gradient_magnitude(self, gray: np.ndarray) -> np.ndarray:
+        grad_x = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
+        grad_y = cv2.Sobel(gray, cv2.CV_32F, 0, 1, ksize=3)
+        return cv2.magnitude(grad_x, grad_y)
+
+    def _illumination_normalized_gray(self, image: np.ndarray) -> np.ndarray:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        clahe = cv2.createCLAHE(clipLimit=2.2, tileGridSize=(8, 8))
+        normalized = clahe.apply(gray)
+        background = cv2.GaussianBlur(normalized, (0, 0), sigmaX=21, sigmaY=21)
+        leveled = cv2.addWeighted(normalized, 1.6, background, -0.6, 8.0)
+        return np.clip(leveled, 0, 255).astype(np.uint8)
+
+    def _trim_rectified_page(self, image: np.ndarray) -> np.ndarray:
+        luma = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)[:, :, 0]
+        blurred = cv2.GaussianBlur(luma, (5, 5), 0)
+        threshold_value, _ = cv2.threshold(
+            blurred,
+            0,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        clamped_threshold = max(float(threshold_value), float(BRIGHT_REGION_FLOOR_LUMA))
+        _, mask = cv2.threshold(blurred, clamped_threshold, 255, cv2.THRESH_BINARY)
+        points = cv2.findNonZero(mask)
+        if points is None:
+            return image
+        x, y, width, height = cv2.boundingRect(points)
+        if width < image.shape[1] * 0.7 or height < image.shape[0] * 0.7:
+            return image
+        pad = 2
+        x0 = max(0, x - pad)
+        y0 = max(0, y - pad)
+        x1 = min(image.shape[1], x + width + pad)
+        y1 = min(image.shape[0], y + height + pad)
+        return image[y0:y1, x0:x1]
+
+    def _clip_point(self, image: np.ndarray, point: np.ndarray) -> tuple[int, int]:
+        x = int(round(max(0.0, min(float(image.shape[1] - 1), float(point[0])))))
+        y = int(round(max(0.0, min(float(image.shape[0] - 1), float(point[1])))))
+        return x, y
+
+    def _quadrilateral_aspect_ratio(self, corners: np.ndarray) -> float:
+        ordered = self._order_corners(corners)
+        width = (
+            float(np.linalg.norm(ordered[1] - ordered[0]))
+            + float(np.linalg.norm(ordered[2] - ordered[3]))
+        ) / 2.0
+        height = (
+            float(np.linalg.norm(ordered[3] - ordered[0]))
+            + float(np.linalg.norm(ordered[2] - ordered[1]))
+        ) / 2.0
+        if width <= 0.0 or height <= 0.0:
+            return 1.0
+        return width / height
+
+    def _shape_aspect_ratio(self, aspect_ratio: float) -> float:
+        if aspect_ratio <= 0.0:
+            return 1.0
+        return aspect_ratio if aspect_ratio >= 1.0 else (1.0 / aspect_ratio)
+
+    def _aspect_log_error(self, candidate: float, expected: float) -> float:
+        safe_candidate = max(candidate, 1e-6)
+        safe_expected = max(expected, 1e-6)
+        return abs(math.log(safe_candidate / safe_expected))
+
+    def _aspect_score(self, candidate: float, expected: float) -> float:
+        error = self._aspect_log_error(candidate, expected)
+        return max(0.0, min(1.0, 1.0 - (error / MAX_ASPECT_LOG_ERROR)))
+
+    def _corners_within_margin(
+        self,
+        corners: np.ndarray,
+        *,
+        width: int,
+        height: int,
+        margin_ratio: float,
+    ) -> bool:
+        margin = max(width, height) * margin_ratio
+        min_x = float(np.min(corners[:, 0]))
+        max_x = float(np.max(corners[:, 0]))
+        min_y = float(np.min(corners[:, 1]))
+        max_y = float(np.max(corners[:, 1]))
+        return (
+            min_x >= -margin
+            and min_y >= -margin
+            and max_x <= (width - 1 + margin)
+            and max_y <= (height - 1 + margin)
+        )
+
+    def _polygon_occupancy_score(self, bright_mask: np.ndarray, corners: np.ndarray) -> float:
+        polygon_mask = np.zeros(bright_mask.shape, dtype=np.uint8)
+        cv2.fillConvexPoly(polygon_mask, self._order_corners(corners).astype(np.int32), 255)
+        polygon_pixels = cv2.countNonZero(polygon_mask)
+        if polygon_pixels <= 0:
+            return 0.0
+
+        overlap_pixels = cv2.countNonZero(cv2.bitwise_and(bright_mask, polygon_mask))
+        overlap_score = float(overlap_pixels / polygon_pixels)
+        row_scores: list[float] = []
+        column_scores: list[float] = []
+
+        for y in range(bright_mask.shape[0]):
+            row = polygon_mask[y] > 0
+            if row.any():
+                row_scores.append(float(np.count_nonzero((bright_mask[y] > 0) & row) / np.count_nonzero(row)))
+        for x in range(bright_mask.shape[1]):
+            column = polygon_mask[:, x] > 0
+            if column.any():
+                column_scores.append(
+                    float(
+                        np.count_nonzero((bright_mask[:, x] > 0) & column)
+                        / np.count_nonzero(column)
+                    )
+                )
+
+        if not row_scores or not column_scores:
+            return max(0.0, min(1.0, overlap_score))
+        row_score = float(np.percentile(row_scores, 5))
+        column_score = float(np.percentile(column_scores, 5))
+        continuity_score = (row_score * 0.55) + (column_score * 0.45)
+        return max(
+            0.0,
+            min(1.0, (overlap_score * 0.7) + (continuity_score * 0.3)),
+        )
+
+    def _touches_too_many_borders(
+        self,
+        bounds: tuple[int, int, int, int],
+        *,
+        width: int,
+        height: int,
+    ) -> bool:
+        x, y, box_width, box_height = bounds
+        margin = max(4, int(round(min(width, height) * 0.012)))
+        touches = 0
+        if x <= margin:
+            touches += 1
+        if y <= margin:
+            touches += 1
+        if (x + box_width) >= (width - margin):
+            touches += 1
+        if (y + box_height) >= (height - margin):
+            touches += 1
+        return touches >= 2
+
+    def _is_oversized_top_band_region(
+        self,
+        bounds: tuple[int, int, int, int],
+        *,
+        component_area: float,
+        image_area: float,
+        image_height: int,
+    ) -> bool:
+        _, y, _, _ = bounds
+        return y <= (image_height * 0.08) and component_area >= (image_area * 0.55)
+
+    def _build_line_candidate(self, line: np.ndarray) -> LineCandidate:
+        x1, y1, x2, y2 = [float(value) for value in line.tolist()]
+        dx = x2 - x1
+        dy = y2 - y1
+        angle = abs(math.degrees(math.atan2(dy, dx)))
+        if angle > 90.0:
+            angle = 180.0 - angle
+        return LineCandidate(
+            points=np.array([[x1, y1], [x2, y2]], dtype=np.float32),
+            length=float(math.hypot(dx, dy)),
+            midpoint_x=(x1 + x2) / 2.0,
+            midpoint_y=(y1 + y2) / 2.0,
+            angle_degrees=angle,
+        )
+
+    def _select_horizontal_line(
+        self,
+        lines: list[LineCandidate],
+        *,
+        gray: np.ndarray,
+        width: int,
+        height: int,
+        band_min: float,
+        band_max: float,
+        prefer_lower: bool,
+        expect_below_brighter: bool,
+    ) -> Optional[LineCandidate]:
+        candidates = [
+            line
+            for line in lines
+            if line.angle_degrees <= 15.0
+            and (height * band_min) <= line.midpoint_y <= (height * band_max)
+        ]
+        if not candidates:
+            return None
+
+        def score(line: LineCandidate) -> float:
+            length_score = min(1.0, line.length / max(1.0, width * 0.45))
+            center_score = max(0.0, 1.0 - abs(line.midpoint_x - (width / 2.0)) / (width / 2.0))
+            vertical_fraction = line.midpoint_y / max(1.0, float(height))
+            position_score = vertical_fraction if prefer_lower else (1.0 - vertical_fraction)
+            contrast_score = self._horizontal_edge_polarity_score(
+                gray,
+                line,
+                expect_below_brighter=expect_below_brighter,
+            )
+            return (
+                (length_score * 0.4)
+                + (center_score * 0.1)
+                + (position_score * 0.15)
+                + (contrast_score * 0.35)
+            )
+
+        return max(candidates, key=score)
+
+    def _select_top_line(
+        self,
+        lines: list[LineCandidate],
+        *,
+        gray: np.ndarray,
+        width: int,
+        height: int,
+        image_area: float,
+        expected_shape_aspect_ratio: float,
+        left: LineCandidate,
+        right: LineCandidate,
+        bottom: LineCandidate,
+    ) -> Optional[LineCandidate]:
+        candidates = [
+            line
+            for line in lines
+            if line.angle_degrees <= 15.0
+            and (height * 0.12) <= line.midpoint_y <= (height * 0.55)
+        ]
+        if not candidates:
+            return None
+
+        best_line: Optional[LineCandidate] = None
+        best_score = -1.0
+        left_top_y = min(float(left.points[0][1]), float(left.points[1][1]))
+        right_top_y = min(float(right.points[0][1]), float(right.points[1][1]))
+        extension_budget = max(40.0, height * 0.22)
+
+        for line in candidates:
+            top_left = self._line_intersection(line.points, left.points)
+            top_right = self._line_intersection(line.points, right.points)
+            bottom_right = self._line_intersection(bottom.points, right.points)
+            bottom_left = self._line_intersection(bottom.points, left.points)
+            corners = np.array(
+                [top_left, top_right, bottom_right, bottom_left],
+                dtype=np.float32,
+            )
+            if np.isnan(corners).any():
+                continue
+            ordered = self._order_corners(corners)
+            if ordered[0][0] >= ordered[1][0]:
+                continue
+            if ordered[0][1] >= ordered[3][1] or ordered[1][1] >= ordered[2][1]:
+                continue
+
+            area = abs(cv2.contourArea(ordered.astype(np.float32)))
+            if area < image_area * MIN_QUAD_AREA_RATIO:
+                continue
+
+            contrast_score = self._horizontal_edge_polarity_score(
+                gray,
+                line,
+                expect_below_brighter=True,
+            )
+            length_score = min(1.0, line.length / max(1.0, width * 0.4))
+            geometry_score = self._score_quadrilateral(
+                ordered,
+                area=area,
+                image_area=image_area,
+                expected_shape_aspect_ratio=expected_shape_aspect_ratio,
+            )
+            left_extension = max(0.0, left_top_y - float(ordered[0][1]))
+            right_extension = max(0.0, right_top_y - float(ordered[1][1]))
+            extension_score = max(
+                0.0,
+                1.0
+                - (
+                    ((left_extension * 0.35) + (right_extension * 0.65))
+                    / extension_budget
+                ),
+            )
+            top_width = float(np.linalg.norm(ordered[1] - ordered[0]))
+            bottom_width = float(np.linalg.norm(ordered[2] - ordered[3]))
+            width_ratio = top_width / max(bottom_width, 1.0)
+            width_score = max(0.0, 1.0 - abs(width_ratio - 0.78) / 0.32)
+            score = (
+                (contrast_score * 0.35)
+                + (extension_score * 0.3)
+                + (geometry_score * 0.2)
+                + (width_score * 0.1)
+                + (length_score * 0.05)
+            )
+            if score > best_score:
+                best_score = score
+                best_line = line
+
+        return best_line
+
+    def _select_vertical_line(
+        self,
+        lines: list[LineCandidate],
+        *,
+        width: int,
+        band_min: float,
+        band_max: float,
+        prefer_right: bool,
+    ) -> Optional[LineCandidate]:
+        candidates = [
+            line
+            for line in lines
+            if 55.0 <= line.angle_degrees <= 89.0
+            and (width * band_min) <= line.midpoint_x <= (width * band_max)
+        ]
+        if not candidates:
+            return None
+
+        def score(line: LineCandidate) -> float:
+            length_score = min(1.0, line.length / max(1.0, width * 0.2))
+            horizontal_fraction = line.midpoint_x / max(1.0, float(width))
+            ideal_fraction = 0.75 if prefer_right else 0.25
+            position_score = max(
+                0.0,
+                1.0 - (abs(horizontal_fraction - ideal_fraction) / 0.25),
+            )
+            return (length_score * 0.7) + (position_score * 0.3)
+
+        return max(candidates, key=score)
+
+    def _line_intersection(self, first: np.ndarray, second: np.ndarray) -> tuple[float, float]:
+        x1, y1 = first[0]
+        x2, y2 = first[1]
+        x3, y3 = second[0]
+        x4, y4 = second[1]
+        denominator = ((x1 - x2) * (y3 - y4)) - ((y1 - y2) * (x3 - x4))
+        if abs(denominator) < 1e-6:
+            return (float("nan"), float("nan"))
+        determinant_first = (x1 * y2) - (y1 * x2)
+        determinant_second = (x3 * y4) - (y3 * x4)
+        x = (
+            (determinant_first * (x3 - x4))
+            - ((x1 - x2) * determinant_second)
+        ) / denominator
+        y = (
+            (determinant_first * (y3 - y4))
+            - ((y1 - y2) * determinant_second)
+        ) / denominator
+        return (float(x), float(y))
+
+    def _horizontal_edge_polarity_score(
+        self,
+        gray: np.ndarray,
+        line: LineCandidate,
+        *,
+        expect_below_brighter: bool,
+    ) -> float:
+        sample_count = max(12, min(40, int(round(line.length / 30.0))))
+        offset = max(6.0, min(24.0, gray.shape[0] * 0.012))
+        above_values: list[float] = []
+        below_values: list[float] = []
+        for index in range(sample_count):
+            t = (index + 0.5) / sample_count
+            x = float(line.points[0][0] + ((line.points[1][0] - line.points[0][0]) * t))
+            y = float(line.points[0][1] + ((line.points[1][1] - line.points[0][1]) * t))
+            xi = int(round(max(0.0, min(gray.shape[1] - 1.0, x))))
+            above_y = int(round(max(0.0, min(gray.shape[0] - 1.0, y - offset))))
+            below_y = int(round(max(0.0, min(gray.shape[0] - 1.0, y + offset))))
+            above_values.append(float(gray[above_y, xi]))
+            below_values.append(float(gray[below_y, xi]))
+
+        mean_above = float(np.mean(above_values))
+        mean_below = float(np.mean(below_values))
+        contrast = (mean_below - mean_above) if expect_below_brighter else (mean_above - mean_below)
+        return max(0.0, min(1.0, (contrast + 12.0) / 48.0))
+
+    def _full_frame_corners(self, image: np.ndarray) -> np.ndarray:
+        height, width = image.shape[:2]
+        return np.array(
+            [
+                [0.0, 0.0],
+                [float(width - 1), 0.0],
+                [float(width - 1), float(height - 1)],
+                [0.0, float(height - 1)],
+            ],
+            dtype=np.float32,
+        )
+
+    def _order_corners(self, corners: np.ndarray) -> np.ndarray:
+        ordered = np.zeros((4, 2), dtype=np.float32)
+        sums = corners.sum(axis=1)
+        diffs = np.diff(corners, axis=1).reshape(-1)
+        ordered[0] = corners[np.argmin(sums)]
+        ordered[2] = corners[np.argmax(sums)]
+        ordered[1] = corners[np.argmin(diffs)]
+        ordered[3] = corners[np.argmax(diffs)]
+        return ordered
+
+    def _rectify(self, image: np.ndarray, corners: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        ordered = self._order_corners(corners)
+        width_top = np.linalg.norm(ordered[1] - ordered[0])
+        width_bottom = np.linalg.norm(ordered[2] - ordered[3])
+        height_right = np.linalg.norm(ordered[2] - ordered[1])
+        height_left = np.linalg.norm(ordered[3] - ordered[0])
+        width = max(2, int(round(max(width_top, width_bottom))))
+        height = max(2, int(round(max(height_right, height_left))))
+        destination = np.array(
+            [
+                [0.0, 0.0],
+                [float(width - 1), 0.0],
+                [float(width - 1), float(height - 1)],
+                [0.0, float(height - 1)],
+            ],
+            dtype=np.float32,
+        )
+        matrix = cv2.getPerspectiveTransform(ordered, destination)
+        rectified = cv2.warpPerspective(
+            image,
+            matrix,
+            (width, height),
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=CANONICAL_PAGE_BACKGROUND_COLOR,
+        )
+        return rectified, matrix
+
+    def _apply_orientation(self, image: np.ndarray, target_aspect_ratio: float) -> np.ndarray:
+        oriented = image
+        if oriented.shape[0] > oriented.shape[1]:
+            oriented = cv2.rotate(oriented, cv2.ROTATE_90_CLOCKWISE)
+        target_is_portrait = target_aspect_ratio < 1
+        if target_is_portrait and oriented.shape[1] >= oriented.shape[0]:
+            oriented = cv2.rotate(oriented, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        if not target_is_portrait and oriented.shape[0] > oriented.shape[1]:
+            oriented = cv2.rotate(oriented, cv2.ROTATE_90_CLOCKWISE)
+        return oriented
+
+    def _resize_to_canonical(self, image: np.ndarray, aspect_ratio: float) -> np.ndarray:
+        if aspect_ratio >= 1:
+            target_width = CANONICAL_LONG_SIDE_PX
+            target_height = max(1, int(round(target_width / aspect_ratio)))
+        else:
+            target_height = CANONICAL_LONG_SIDE_PX
+            target_width = max(1, int(round(target_height * aspect_ratio)))
+        return cv2.resize(image, (target_width, target_height), interpolation=cv2.INTER_AREA)
+
+    def _build_debug_overlay(
+        self,
+        image: np.ndarray,
+        detection: DetectionCandidate,
+        *,
+        diagnostics: NormalizationDiagnostics,
+    ) -> np.ndarray:
+        overlay = image.copy()
+        rejected_contour = diagnostics.contour_v3.best_candidate if diagnostics.contour_v3 is not None else None
+        if (
+            detection.method != "paper_contour_v3"
+            and rejected_contour is not None
+            and rejected_contour.corners is not None
+        ):
+            contour_corners = np.array(
+                [
+                    rejected_contour.corners.top_left,
+                    rejected_contour.corners.top_right,
+                    rejected_contour.corners.bottom_right,
+                    rejected_contour.corners.bottom_left,
+                ],
+                dtype=np.int32,
+            )
+            contour_polygon = contour_corners.reshape((-1, 1, 2))
+            cv2.polylines(
+                overlay,
+                [contour_polygon],
+                isClosed=True,
+                color=(255, 0, 255),
+                thickness=2,
+                lineType=cv2.LINE_AA,
+            )
+            contour_rejection = (
+                rejected_contour.rejection_reason
+                or diagnostics.contour_v3.rejection_reason
+                or "rejected"
+            )
+            cv2.putText(
+                overlay,
+                f"contour_v3 rejected: {contour_rejection}",
+                (24, 104),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.68,
+                (255, 0, 255),
+                2,
+                cv2.LINE_AA,
+            )
+        rejected_region = diagnostics.region_v2.best_candidate
+        if (
+            detection.method != "paper_region_v2"
+            and rejected_region is not None
+            and rejected_region.corners is not None
+        ):
+            rejected_corners = np.array(
+                [
+                    rejected_region.corners.top_left,
+                    rejected_region.corners.top_right,
+                    rejected_region.corners.bottom_right,
+                    rejected_region.corners.bottom_left,
+                ],
+                dtype=np.int32,
+            )
+            rejected_polygon = rejected_corners.reshape((-1, 1, 2))
+            cv2.polylines(
+                overlay,
+                [rejected_polygon],
+                isClosed=True,
+                color=(255, 255, 0),
+                thickness=2,
+                lineType=cv2.LINE_AA,
+            )
+            rejection_text = rejected_region.rejection_reason or diagnostics.region_v2.rejection_reason or "rejected"
+            cv2.putText(
+                overlay,
+                f"region_v2 rejected: {rejection_text}",
+                (24, 76),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.68,
+                (255, 255, 0),
+                2,
+                cv2.LINE_AA,
+            )
+        polygon = detection.corners.astype(np.int32).reshape((-1, 1, 2))
+        color = (60, 210, 240) if detection.confidence >= LOW_CONFIDENCE_THRESHOLD else (0, 170, 255)
+        cv2.polylines(overlay, [polygon], isClosed=True, color=color, thickness=4)
+        labels = [
+            ("TL", detection.corners[0]),
+            ("TR", detection.corners[1]),
+            ("BR", detection.corners[2]),
+            ("BL", detection.corners[3]),
+        ]
+        for label, point in labels:
+            x, y = int(point[0]), int(point[1])
+            cv2.circle(overlay, (x, y), 10, (255, 120, 80), thickness=-1)
+            cv2.putText(
+                overlay,
+                label,
+                (x + 12, y - 12),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.7,
+                (255, 255, 255),
+                2,
+                cv2.LINE_AA,
+            )
+        cv2.putText(
+            overlay,
+            f"{detection.method}  confidence={detection.confidence:.2f}",
+            (24, 40),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.9,
+            (255, 255, 255),
+            2,
+            cv2.LINE_AA,
+        )
+        return overlay
+
+    def _encode_png(self, image: np.ndarray) -> bytes:
+        ok, encoded = cv2.imencode(".png", image)
+        if not ok:
+            raise ValueError("Failed to encode normalization artifact.")
+        return encoded.tobytes()
+
+    def _to_corners(self, corners: np.ndarray) -> NormalizationCorners:
+        return NormalizationCorners(
+            top_left=(float(round(corners[0][0], 3)), float(round(corners[0][1], 3))),
+            top_right=(float(round(corners[1][0], 3)), float(round(corners[1][1], 3))),
+            bottom_right=(float(round(corners[2][0], 3)), float(round(corners[2][1], 3))),
+            bottom_left=(float(round(corners[3][0], 3)), float(round(corners[3][1], 3))),
+        )
+
+    def _corners_to_numpy(self, corners: NormalizationCorners) -> np.ndarray:
+        return np.array(
+            [
+                corners.top_left,
+                corners.top_right,
+                corners.bottom_right,
+                corners.bottom_left,
+            ],
+            dtype=np.float32,
+        )
+
+
+def target_from_page_size(
+    *,
+    page_width_mm: float,
+    page_height_mm: float,
+    source: Literal["prepared_svg", "workspace_drawable_area"],
+) -> NormalizationTarget:
+    if page_width_mm <= 0 or page_height_mm <= 0:
+        raise ValueError("Normalization target page size must be positive.")
+    return NormalizationTarget(
+        page_width_mm=page_width_mm,
+        page_height_mm=page_height_mm,
+        source=source,
+    )

--- a/apps/api/src/learn_to_draw_api/services/capture_review_memory.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_review_memory.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from learn_to_draw_api.models import NormalizationCorners
+
+
+class CaptureReviewMemoryRecord(BaseModel):
+    scope_key: str
+    camera_driver: str
+    camera_device_id: str
+    page_width_mm: float = Field(gt=0)
+    page_height_mm: float = Field(gt=0)
+    margin_left_mm: float = Field(ge=0)
+    margin_top_mm: float = Field(ge=0)
+    margin_right_mm: float = Field(ge=0)
+    margin_bottom_mm: float = Field(ge=0)
+    capture_id: str
+    confirmed_corners: NormalizationCorners
+    updated_at: datetime
+
+
+class CaptureReviewMemoryStore:
+    def __init__(self, workspace_dir: Path) -> None:
+        self._path = workspace_dir / "capture_review_memory.json"
+        self._lock = Lock()
+
+    def get(self, scope_key: str) -> Optional[CaptureReviewMemoryRecord]:
+        with self._lock:
+            payload = self._load()
+            record = payload.get(scope_key)
+            if record is None:
+                return None
+            return CaptureReviewMemoryRecord.model_validate(record)
+
+    def save(self, record: CaptureReviewMemoryRecord) -> CaptureReviewMemoryRecord:
+        with self._lock:
+            payload = self._load()
+            payload[record.scope_key] = record.model_dump(mode="json")
+            self._path.write_text(
+                CaptureReviewMemoryPayload(records=payload).model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+            return record
+
+    def build_scope_key(
+        self,
+        *,
+        camera_driver: str,
+        camera_device_id: str,
+        page_width_mm: float,
+        page_height_mm: float,
+        margin_left_mm: float,
+        margin_top_mm: float,
+        margin_right_mm: float,
+        margin_bottom_mm: float,
+    ) -> str:
+        return "|".join(
+            [
+                camera_driver,
+                camera_device_id,
+                f"{page_width_mm:.3f}",
+                f"{page_height_mm:.3f}",
+                f"{margin_left_mm:.3f}",
+                f"{margin_top_mm:.3f}",
+                f"{margin_right_mm:.3f}",
+                f"{margin_bottom_mm:.3f}",
+            ]
+        )
+
+    def create_record(
+        self,
+        *,
+        scope_key: str,
+        camera_driver: str,
+        camera_device_id: str,
+        page_width_mm: float,
+        page_height_mm: float,
+        margin_left_mm: float,
+        margin_top_mm: float,
+        margin_right_mm: float,
+        margin_bottom_mm: float,
+        capture_id: str,
+        confirmed_corners: NormalizationCorners,
+    ) -> CaptureReviewMemoryRecord:
+        return CaptureReviewMemoryRecord(
+            scope_key=scope_key,
+            camera_driver=camera_driver,
+            camera_device_id=camera_device_id,
+            page_width_mm=page_width_mm,
+            page_height_mm=page_height_mm,
+            margin_left_mm=margin_left_mm,
+            margin_top_mm=margin_top_mm,
+            margin_right_mm=margin_right_mm,
+            margin_bottom_mm=margin_bottom_mm,
+            capture_id=capture_id,
+            confirmed_corners=confirmed_corners,
+            updated_at=datetime.now(timezone.utc),
+        )
+
+    def _load(self) -> dict[str, dict]:
+        if not self._path.exists():
+            return {}
+        return CaptureReviewMemoryPayload.model_validate_json(
+            self._path.read_text(encoding="utf-8")
+        ).records
+
+
+class CaptureReviewMemoryPayload(BaseModel):
+    records: dict[str, dict] = Field(default_factory=dict)
+

--- a/apps/api/src/learn_to_draw_api/services/capture_service.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_service.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import logging
+from threading import Thread
+from typing import Optional
+
+from learn_to_draw_api.adapters.camera import CaptureArtifact
+from learn_to_draw_api.models import (
+    CaptureMetadata,
+    CaptureReview,
+    NormalizationCorners,
+    NormalizationDiagnostics,
+    NormalizationMethod,
+    NormalizedCaptureArtifacts,
+)
+from learn_to_draw_api.services.capture_normalization import (
+    CaptureNormalizationProposal,
+    CaptureNormalizationService,
+    NormalizationTarget,
+)
+from learn_to_draw_api.services.captures import CaptureStore
+
+
+logger = logging.getLogger(__name__)
+
+
+class CaptureService:
+    def __init__(
+        self,
+        *,
+        store: CaptureStore,
+        normalization_service: CaptureNormalizationService,
+    ) -> None:
+        self._store = store
+        self._normalization_service = normalization_service
+
+    def persist_raw_capture(self, artifact: CaptureArtifact) -> CaptureMetadata:
+        return self._store.save(artifact)
+
+    def persist_capture(
+        self,
+        artifact: CaptureArtifact,
+        *,
+        normalization_target: Optional[NormalizationTarget],
+        background: bool,
+    ) -> CaptureMetadata:
+        metadata = self._store.save(artifact)
+        if normalization_target is None:
+            return metadata
+        if background:
+            worker = Thread(
+                target=self._normalize_and_store,
+                kwargs={
+                    "capture_id": metadata.id,
+                    "content": artifact.content,
+                    "normalization_target": normalization_target,
+                },
+                daemon=True,
+            )
+            worker.start()
+            return metadata
+        return self._normalize_and_store(
+            capture_id=metadata.id,
+            content=artifact.content,
+            normalization_target=normalization_target,
+        )
+
+    def _normalize_and_store(
+        self,
+        *,
+        capture_id: str,
+        content: bytes,
+        normalization_target: NormalizationTarget,
+    ) -> CaptureMetadata:
+        try:
+            normalized = self._normalization_service.normalize(
+                content=content,
+                target=normalization_target,
+            )
+            return self._store_normalized_artifacts(
+                capture_id,
+                normalized=normalized,
+            )
+        except Exception:
+            logger.exception("Capture normalization failed for '%s'.", capture_id)
+            metadata = self._store.get(capture_id)
+            if metadata is None:
+                raise
+            return metadata
+
+    def inspect_capture(
+        self,
+        *,
+        content: bytes,
+        normalization_target: NormalizationTarget,
+    ) -> CaptureNormalizationProposal:
+        return self._normalization_service.inspect(
+            content=content,
+            target=normalization_target,
+        )
+
+    def save_capture_review(
+        self,
+        capture_id: str,
+        *,
+        review: CaptureReview,
+    ) -> CaptureMetadata:
+        return self._store.save_review(capture_id, review)
+
+    def finalize_capture_with_review(
+        self,
+        *,
+        capture_id: str,
+        content: bytes,
+        normalization_target: NormalizationTarget,
+        corners: NormalizationCorners,
+        method: NormalizationMethod,
+        confidence: float,
+        diagnostics: Optional[NormalizationDiagnostics],
+        review: CaptureReview,
+    ) -> CaptureMetadata:
+        normalized = self._normalization_service.normalize_with_corners(
+            content=content,
+            target=normalization_target,
+            corners=corners,
+            method=method,
+            confidence=confidence,
+            diagnostics=diagnostics,
+        )
+        return self._store_normalized_artifacts(
+            capture_id,
+            normalized=normalized,
+            review=review,
+        )
+
+    def _store_normalized_artifacts(
+        self,
+        capture_id: str,
+        *,
+        normalized,
+        review: Optional[CaptureReview] = None,
+    ) -> CaptureMetadata:
+        stored_artifacts = NormalizedCaptureArtifacts(
+            rectified_color_url=self._store.public_url_for_filename(
+                f"{capture_id}-rectified-color.png"
+            ),
+            rectified_grayscale_url=self._store.public_url_for_filename(
+                f"{capture_id}-rectified-grayscale.png"
+            ),
+            debug_overlay_url=self._store.public_url_for_filename(
+                f"{capture_id}-debug-overlay.png"
+            ),
+            metadata=normalized.metadata,
+        )
+        return self._store.save_normalized(
+            capture_id,
+            rectified_color=normalized.rectified_color,
+            rectified_grayscale=normalized.rectified_grayscale,
+            debug_overlay=normalized.debug_overlay,
+            normalized=stored_artifacts,
+            review=review,
+        )

--- a/apps/api/src/learn_to_draw_api/services/captures.py
+++ b/apps/api/src/learn_to_draw_api/services/captures.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Lock
 from typing import Optional
 from urllib.parse import quote
 
 from learn_to_draw_api.adapters.camera import CaptureArtifact
-from learn_to_draw_api.models import CaptureMetadata
+from learn_to_draw_api.models import CaptureMetadata, CaptureReview, NormalizedCaptureArtifacts
 
 
 class CaptureStore:
@@ -17,35 +18,95 @@ class CaptureStore:
         self._capture_url_prefix = normalized_prefix.rstrip("/") or "/captures"
         self._captures_dir.mkdir(parents=True, exist_ok=True)
         self._latest: Optional[CaptureMetadata] = None
+        self._lock = Lock()
 
     def save(self, artifact: CaptureArtifact) -> CaptureMetadata:
         safe_filename = Path(artifact.filename).name
         file_path = self._captures_dir / safe_filename
-        metadata_path = self._captures_dir / f"{artifact.capture_id}.json"
-        file_path.write_bytes(artifact.content)
-
         metadata = CaptureMetadata(
             id=artifact.capture_id,
             timestamp=artifact.timestamp,
             file_path=str(file_path),
-            public_url=f"{self._capture_url_prefix}/{quote(safe_filename)}",
+            public_url=self.public_url_for_filename(safe_filename),
             width=artifact.width,
             height=artifact.height,
             mime_type=artifact.media_type,
         )
-        metadata_path.write_text(metadata.model_dump_json(indent=2), encoding="utf-8")
-        self._latest = metadata
+        with self._lock:
+            file_path.write_bytes(artifact.content)
+            self._write_metadata(metadata)
+            self._latest = metadata
         return metadata
 
+    def get(self, capture_id: str) -> Optional[CaptureMetadata]:
+        metadata_path = self._metadata_path(capture_id)
+        if not metadata_path.exists():
+            return None
+        return CaptureMetadata.model_validate_json(metadata_path.read_text(encoding="utf-8"))
+
+    def save_normalized(
+        self,
+        capture_id: str,
+        *,
+        rectified_color: bytes,
+        rectified_grayscale: bytes,
+        debug_overlay: bytes,
+        normalized: NormalizedCaptureArtifacts,
+        review: Optional[CaptureReview] = None,
+    ) -> CaptureMetadata:
+        with self._lock:
+            metadata = self.get(capture_id)
+            if metadata is None:
+                raise FileNotFoundError(f"Capture '{capture_id}' was not found.")
+            (self._captures_dir / f"{capture_id}-rectified-color.png").write_bytes(rectified_color)
+            (self._captures_dir / f"{capture_id}-rectified-grayscale.png").write_bytes(
+                rectified_grayscale
+            )
+            (self._captures_dir / f"{capture_id}-debug-overlay.png").write_bytes(debug_overlay)
+            update_fields: dict[str, object] = {"normalized": normalized}
+            if review is not None:
+                update_fields["review"] = review
+            updated = metadata.model_copy(update=update_fields)
+            self._write_metadata(updated)
+            if self._latest is not None and self._latest.id == capture_id:
+                self._latest = updated
+            return updated
+
+    def save_review(self, capture_id: str, review: CaptureReview) -> CaptureMetadata:
+        with self._lock:
+            metadata = self.get(capture_id)
+            if metadata is None:
+                raise FileNotFoundError(f"Capture '{capture_id}' was not found.")
+            updated = metadata.model_copy(update={"review": review})
+            self._write_metadata(updated)
+            if self._latest is not None and self._latest.id == capture_id:
+                self._latest = updated
+            return updated
+
     def latest(self) -> Optional[CaptureMetadata]:
-        if self._latest is None:
-            self._latest = self._load_latest()
-        return self._latest
+        with self._lock:
+            if self._latest is None:
+                self._latest = self._load_latest()
+            return self._latest
+
+    def public_url_for_filename(self, filename: str) -> str:
+        return f"{self._capture_url_prefix}/{quote(filename)}"
 
     def _load_latest(self) -> Optional[CaptureMetadata]:
         latest: Optional[CaptureMetadata] = None
         for metadata_path in sorted(self._captures_dir.glob("*.json")):
-            candidate = CaptureMetadata.model_validate_json(metadata_path.read_text())
+            candidate = CaptureMetadata.model_validate_json(
+                metadata_path.read_text(encoding="utf-8")
+            )
             if latest is None or candidate.timestamp > latest.timestamp:
                 latest = candidate
         return latest
+
+    def _metadata_path(self, capture_id: str) -> Path:
+        return self._captures_dir / f"{capture_id}.json"
+
+    def _write_metadata(self, metadata: CaptureMetadata) -> None:
+        self._metadata_path(metadata.id).write_text(
+            metadata.model_dump_json(indent=2),
+            encoding="utf-8",
+        )

--- a/apps/api/src/learn_to_draw_api/services/hardware.py
+++ b/apps/api/src/learn_to_draw_api/services/hardware.py
@@ -24,6 +24,8 @@ from learn_to_draw_api.models import (
     PlotterWorkspaceRequest,
     PlotterWorkspaceResponse,
 )
+from learn_to_draw_api.services.capture_normalization import target_from_page_size
+from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.plotter_calibration import PlotterCalibrationService
 from learn_to_draw_api.services.plotter_device_settings import PlotterDeviceSettingsService
@@ -37,6 +39,7 @@ class HardwareService:
         plotter: PlotterAdapter,
         camera: CameraAdapter,
         capture_store: CaptureStore,
+        capture_service: CaptureService,
         calibration_service: PlotterCalibrationService,
         device_settings_service: PlotterDeviceSettingsService,
         workspace_service: PlotterWorkspaceService,
@@ -44,6 +47,7 @@ class HardwareService:
         self._plotter = plotter
         self._camera = camera
         self._capture_store = capture_store
+        self._capture_service = capture_service
         self._calibration_service = calibration_service
         self._device_settings_service = device_settings_service
         self._workspace_service = workspace_service
@@ -185,7 +189,21 @@ class HardwareService:
             raise HardwareBusyError("Camera is busy.")
         try:
             artifact = self._camera.capture()
-            metadata = self._capture_store.save(artifact)
+            workspace = self._workspace_service.current()
+            normalization_target = None
+            page_width = workspace.page_size_mm.width_mm
+            page_height = workspace.page_size_mm.height_mm
+            if page_width > 0 and page_height > 0:
+                normalization_target = target_from_page_size(
+                    page_width_mm=page_width,
+                    page_height_mm=page_height,
+                    source="workspace_drawable_area",
+                )
+            metadata = self._capture_service.persist_capture(
+                artifact,
+                normalization_target=normalization_target,
+                background=True,
+            )
             return CameraCaptureResponse(
                 message="Image captured.",
                 status=self._camera.get_status(),

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow.py
@@ -15,11 +15,16 @@ from learn_to_draw_api.models import (
     PatternAssetCreateRequest,
     PlotAsset,
     PlotRun,
+    PlotRunCaptureReviewAdjustRequest,
+    PlotRunCaptureReviewPayload,
     PlotRunCaptureMode,
+    PlotRunCaptureReviewResponse,
     PlotRunListResponse,
     PlotRunPurpose,
     PlotStageState,
 )
+from learn_to_draw_api.services.capture_service import CaptureService
+from learn_to_draw_api.services.capture_review_memory import CaptureReviewMemoryStore
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.plotter_calibration import PlotterCalibrationService
 from learn_to_draw_api.services.plotter_device_settings import PlotterDeviceSettingsService
@@ -38,6 +43,8 @@ class PlotWorkflowService:
         plotter: PlotterAdapter,
         camera: CameraAdapter,
         capture_store: CaptureStore,
+        capture_service: CaptureService,
+        review_memory_store: CaptureReviewMemoryStore,
         asset_store: PlotAssetStore,
         run_store: PlotRunStore,
         calibration_service: PlotterCalibrationService,
@@ -47,6 +54,8 @@ class PlotWorkflowService:
         self._plotter = plotter
         self._camera = camera
         self._capture_store = capture_store
+        self._capture_service = capture_service
+        self._review_memory_store = review_memory_store
         self._asset_store = asset_store
         self._run_store = run_store
         self._calibration_service = calibration_service
@@ -57,7 +66,8 @@ class PlotWorkflowService:
         self._executor = PlotRunExecutor(
             plotter=plotter,
             camera=camera,
-            capture_store=capture_store,
+            capture_service=capture_service,
+            review_memory_store=review_memory_store,
             run_store=run_store,
             calibration_service=calibration_service,
             device_settings_service=device_settings_service,
@@ -124,6 +134,7 @@ class PlotWorkflowService:
                 "prepare": PlotStageState(status="pending"),
                 "plot": PlotStageState(status="pending"),
                 "capture": PlotStageState(status="pending"),
+                "capture_review": PlotStageState(status="pending"),
             },
         )
         with self._lock:
@@ -145,12 +156,71 @@ class PlotWorkflowService:
     def get_run(self, run_id: str) -> PlotRun:
         return self._run_store.get(run_id)
 
+    def get_capture_review(self, run_id: str) -> PlotRunCaptureReviewPayload:
+        run = self._run_store.get(run_id)
+        if run.capture is None or run.capture.review is None:
+            raise AppNotFoundError(f"Plot run '{run_id}' has no pending capture review.")
+        return PlotRunCaptureReviewPayload(
+            run_id=run.id,
+            capture=run.capture,
+            review=run.capture.review,
+        )
+
+    def accept_capture_review(self, run_id: str) -> PlotRunCaptureReviewResponse:
+        run = self._confirm_capture_review(
+            run_id,
+            corners=None,
+            source="auto",
+        )
+        return PlotRunCaptureReviewResponse(
+            message="Capture review accepted. Finalizing normalization.",
+            run=run,
+        )
+
+    def adjust_capture_review(
+        self,
+        run_id: str,
+        request: PlotRunCaptureReviewAdjustRequest,
+    ) -> PlotRunCaptureReviewResponse:
+        run = self._confirm_capture_review(
+            run_id,
+            corners=request.corners,
+            source="adjusted",
+        )
+        return PlotRunCaptureReviewResponse(
+            message="Adjusted capture corners saved. Finalizing normalization.",
+            run=run,
+        )
+
+    def reuse_last_capture_review(self, run_id: str) -> PlotRunCaptureReviewResponse:
+        run = self._run_store.get(run_id)
+        scope_key = self._executor._build_review_scope_key_from_run(run)
+        record = self._review_memory_store.get(scope_key) if scope_key is not None else None
+        if record is None:
+            raise AppConflictError("No previously confirmed quad is available for this setup.")
+        updated_run = self._confirm_capture_review(
+            run_id,
+            corners=record.confirmed_corners,
+            source="reused_last",
+        )
+        return PlotRunCaptureReviewResponse(
+            message="Reused the last confirmed quad for this setup.",
+            run=updated_run,
+        )
+
     def _execute_run_in_thread(self, run_id: str) -> None:
         try:
             self._executor.execute_run(run_id)
         finally:
             with self._lock:
                 if self._active_run_id == run_id:
+                    try:
+                        run = self._run_store.get(run_id)
+                    except AppNotFoundError:
+                        self._active_run_id = None
+                        return
+                    if run.status in ACTIVE_RUN_STATUSES:
+                        return
                     self._active_run_id = None
 
     def _get_active_run_locked(self) -> Optional[PlotRun]:
@@ -165,6 +235,66 @@ class PlotWorkflowService:
             self._active_run_id = None
             return None
         return active_run
+
+    def _confirm_capture_review(
+        self,
+        run_id: str,
+        *,
+        corners,
+        source,
+    ) -> PlotRun:
+        with self._lock:
+            run = self._run_store.get(run_id)
+            if run.status != "awaiting_capture_review":
+                raise AppConflictError("This plot run is not awaiting capture review.")
+            if run.capture is None or run.capture.review is None:
+                raise AppConflictError("This plot run does not have a capture review payload.")
+            review = run.capture.review
+            confirmed_corners = corners or review.proposed_corners
+            updated_review = review.model_copy(
+                update={
+                    "review_status": "confirmed",
+                    "confirmed_corners": confirmed_corners,
+                    "confirmation_source": source,
+                }
+            )
+            updated_capture = self._capture_service.save_capture_review(
+                run.capture.id,
+                review=updated_review,
+            )
+            run.capture = updated_capture
+            if run.observed_result is not None:
+                run.observed_result = run.observed_result.model_copy(
+                    update={"capture": updated_capture}
+                )
+            run.status = "capturing"
+            run.updated_at = datetime.now(timezone.utc)
+            run.stage_states["capture_review"] = PlotStageState(
+                status="in_progress",
+                started_at=run.stage_states["capture_review"].started_at or datetime.now(timezone.utc),
+                completed_at=None,
+                message="Applying confirmed capture quad.",
+            )
+            self._run_store.save(run)
+            worker = Thread(target=self._finalize_capture_review_in_thread, args=(run.id,), daemon=True)
+            worker.start()
+            return run
+
+    def _finalize_capture_review_in_thread(self, run_id: str) -> None:
+        try:
+            self._executor.finalize_capture_review(run_id)
+        except Exception as exc:
+            run = self._run_store.get(run_id)
+            run.status = "failed"
+            run.error = str(exc)
+            run.updated_at = datetime.now(timezone.utc)
+            run.stage_states["capture_review"] = PlotStageState(
+                status="failed",
+                started_at=run.stage_states["capture_review"].started_at,
+                completed_at=datetime.now(timezone.utc),
+                message=str(exc),
+            )
+            self._run_store.save(run)
 
 
 __all__ = ["PlotAssetStore", "PlotRunStore", "PlotWorkflowService"]

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 from learn_to_draw_api.adapters.camera import CameraAdapter
 from learn_to_draw_api.adapters.plotter import PlotterAdapter
 from learn_to_draw_api.models import (
+    CaptureReview,
     ObservedResultRecord,
     PlotRun,
     PlotStageState,
     PlotterDeviceSettings,
     PlotterWorkspace,
 )
-from learn_to_draw_api.services.captures import CaptureStore
+from learn_to_draw_api.services.capture_normalization import (
+    LOW_CONFIDENCE_THRESHOLD,
+    target_from_page_size,
+)
+from learn_to_draw_api.services.capture_service import CaptureService
+from learn_to_draw_api.services.capture_review_memory import CaptureReviewMemoryStore
 from learn_to_draw_api.services.plotter_calibration import PlotterCalibrationService
 from learn_to_draw_api.services.plotter_device_settings import PlotterDeviceSettingsService
 from learn_to_draw_api.services.plotter_workspace import PlotterWorkspaceService
@@ -27,7 +34,8 @@ class PlotRunExecutor:
         *,
         plotter: PlotterAdapter,
         camera: CameraAdapter,
-        capture_store: CaptureStore,
+        capture_service: CaptureService,
+        review_memory_store: CaptureReviewMemoryStore,
         run_store: PlotRunStore,
         calibration_service: PlotterCalibrationService,
         device_settings_service: PlotterDeviceSettingsService,
@@ -35,7 +43,8 @@ class PlotRunExecutor:
     ) -> None:
         self._plotter = plotter
         self._camera = camera
-        self._capture_store = capture_store
+        self._capture_service = capture_service
+        self._review_memory_store = review_memory_store
         self._run_store = run_store
         self._calibration_service = calibration_service
         self._device_settings_service = device_settings_service
@@ -126,7 +135,43 @@ class PlotRunExecutor:
                 capture_started = datetime.now(timezone.utc)
                 capture_artifact = self._camera.capture()
                 capture_completed = datetime.now(timezone.utc)
-                capture_metadata = self._capture_store.save(capture_artifact)
+                normalization_target = target_from_page_size(
+                    page_width_mm=preparation.page_width_mm,
+                    page_height_mm=preparation.page_height_mm,
+                    source="prepared_svg",
+                )
+                capture_metadata = self._capture_service.persist_raw_capture(capture_artifact)
+                proposal = self._capture_service.inspect_capture(
+                    content=capture_artifact.content,
+                    normalization_target=normalization_target,
+                )
+                scope_key = self._build_review_scope_key(
+                    workspace=workspace,
+                    camera_driver=self._camera.driver,
+                )
+                reuse_last_available = (
+                    self._review_memory_store.get(scope_key) is not None
+                    if scope_key is not None
+                    else False
+                )
+                review_required = (
+                    proposal.method == "fallback_full_frame"
+                    or proposal.confidence < LOW_CONFIDENCE_THRESHOLD
+                )
+                review = CaptureReview(
+                    review_required=review_required,
+                    review_status="pending" if review_required else "confirmed",
+                    proposed_corners=proposal.corners,
+                    confirmed_corners=None if review_required else proposal.corners,
+                    confirmation_source=None if review_required else "auto",
+                    detector_method=proposal.method,
+                    detector_confidence=proposal.confidence,
+                    reuse_last_available=reuse_last_available,
+                )
+                capture_metadata = self._capture_service.save_capture_review(
+                    capture_metadata.id,
+                    review=review,
+                )
                 run.capture = capture_metadata
                 capture_duration_ms = duration_ms(capture_started, capture_completed)
                 run.observed_result = ObservedResultRecord(
@@ -147,11 +192,38 @@ class PlotRunExecutor:
                     status="completed",
                     message="Capture completed.",
                 )
+                if review_required:
+                    run.status = "awaiting_capture_review"
+                    run.updated_at = datetime.now(timezone.utc)
+                    run.camera_run_details = {
+                        **run.camera_run_details,
+                        "capture_review_required": True,
+                    }
+                    run = self._set_stage_state(
+                        run,
+                        stage="capture_review",
+                        status="in_progress",
+                        message="Review the detected page corners before normalization.",
+                    )
+                    return
 
-            run.status = "completed"
-            run.error = None
-            run.updated_at = datetime.now(timezone.utc)
-            self._run_store.save(run)
+                run = self._set_stage_state(
+                    run,
+                    stage="capture_review",
+                    status="in_progress",
+                    message="Finalizing normalized capture.",
+                )
+                run = self._finalize_capture_review(
+                    run,
+                    normalization_target=normalization_target,
+                    persist_review_memory=False,
+                )
+
+            if run.status != "completed":
+                run.status = "completed"
+                run.error = None
+                run.updated_at = datetime.now(timezone.utc)
+                self._run_store.save(run)
         except Exception as exc:
             if (
                 current_stage == "prepare"
@@ -184,6 +256,136 @@ class PlotRunExecutor:
                 )
             else:
                 self._run_store.save(run)
+
+    def finalize_capture_review(self, run_id: str, *, persist_review_memory: bool = True) -> PlotRun:
+        run = self._run_store.get(run_id)
+        preparation = run.plotter_run_details.get("preparation", {})
+        normalization_target = target_from_page_size(
+            page_width_mm=float(preparation["page_width_mm"]),
+            page_height_mm=float(preparation["page_height_mm"]),
+            source="prepared_svg",
+        )
+        return self._finalize_capture_review(
+            run,
+            normalization_target=normalization_target,
+            persist_review_memory=persist_review_memory,
+        )
+
+    def _finalize_capture_review(
+        self,
+        run: PlotRun,
+        *,
+        normalization_target,
+        persist_review_memory: bool,
+    ) -> PlotRun:
+        if run.capture is None or run.capture.review is None:
+            raise ValueError("Capture review is not available for this run.")
+        review = run.capture.review
+        confirmed_corners = review.confirmed_corners
+        if confirmed_corners is None:
+            raise ValueError("Capture review has not been confirmed.")
+        content = Path(run.capture.file_path).read_bytes()
+        updated_capture = self._capture_service.finalize_capture_with_review(
+            capture_id=run.capture.id,
+            content=content,
+            normalization_target=normalization_target,
+            corners=confirmed_corners,
+            method=review.detector_method,
+            confidence=review.detector_confidence,
+            diagnostics=None,
+            review=review,
+        )
+        run.capture = updated_capture
+        if run.observed_result is not None:
+            run.observed_result = run.observed_result.model_copy(
+                update={"capture": updated_capture}
+            )
+        if persist_review_memory and review.confirmation_source in {"adjusted", "reused_last"}:
+            scope_key = self._build_review_scope_key_from_run(run)
+            if scope_key is not None:
+                workspace = run.plotter_run_details["workspace"]
+                self._review_memory_store.save(
+                    self._review_memory_store.create_record(
+                        scope_key=scope_key,
+                        camera_driver=self._camera.driver,
+                        camera_device_id=self._camera_device_id(),
+                        page_width_mm=float(workspace["page_size_mm"]["width_mm"]),
+                        page_height_mm=float(workspace["page_size_mm"]["height_mm"]),
+                        margin_left_mm=float(workspace["margins_mm"]["left_mm"]),
+                        margin_top_mm=float(workspace["margins_mm"]["top_mm"]),
+                        margin_right_mm=float(workspace["margins_mm"]["right_mm"]),
+                        margin_bottom_mm=float(workspace["margins_mm"]["bottom_mm"]),
+                        capture_id=updated_capture.id,
+                        confirmed_corners=confirmed_corners,
+                    )
+                )
+        run = self._set_stage_state(
+            run,
+            stage="capture_review",
+            status="completed",
+            message="Capture review confirmed.",
+        )
+        run.status = "completed"
+        run.error = None
+        run.updated_at = datetime.now(timezone.utc)
+        self._run_store.save(run)
+        return run
+
+    def _build_review_scope_key(
+        self,
+        *,
+        workspace: PlotterWorkspace,
+        camera_driver: str,
+    ) -> Optional[str]:
+        camera_device_id = self._camera_device_id()
+        if camera_device_id is None:
+            return None
+        return self._review_memory_store.build_scope_key(
+            camera_driver=camera_driver,
+            camera_device_id=camera_device_id,
+            page_width_mm=workspace.page_size_mm.width_mm,
+            page_height_mm=workspace.page_size_mm.height_mm,
+            margin_left_mm=workspace.margins_mm.left_mm,
+            margin_top_mm=workspace.margins_mm.top_mm,
+            margin_right_mm=workspace.margins_mm.right_mm,
+            margin_bottom_mm=workspace.margins_mm.bottom_mm,
+        )
+
+    def _build_review_scope_key_from_run(self, run: PlotRun) -> Optional[str]:
+        workspace = run.plotter_run_details.get("workspace")
+        if not isinstance(workspace, dict):
+            return None
+        page_size = workspace.get("page_size_mm")
+        margins = workspace.get("margins_mm")
+        if not isinstance(page_size, dict) or not isinstance(margins, dict):
+            return None
+        camera_device_id = self._camera_device_id()
+        if camera_device_id is None:
+            return None
+        return self._review_memory_store.build_scope_key(
+            camera_driver=self._camera.driver,
+            camera_device_id=camera_device_id,
+            page_width_mm=float(page_size["width_mm"]),
+            page_height_mm=float(page_size["height_mm"]),
+            margin_left_mm=float(margins["left_mm"]),
+            margin_top_mm=float(margins["top_mm"]),
+            margin_right_mm=float(margins["right_mm"]),
+            margin_bottom_mm=float(margins["bottom_mm"]),
+        )
+
+    def _camera_device_id(self) -> Optional[str]:
+        details = self._camera.get_status().details
+        if not isinstance(details, dict):
+            return None
+        for key in (
+            "effective_selected_device_id",
+            "active_device_id",
+            "persisted_selected_device_id",
+        ):
+            value = details.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return self._camera.driver
 
     def _set_stage_state(
         self,

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_preparation.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_preparation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from dataclasses import dataclass
 import math
 from pathlib import Path
 import re
@@ -23,8 +24,27 @@ PATTERNS_DIR = Path(__file__).resolve().parent.parent / "assets" / "patterns"
 PREPARATION_EPSILON_MM = 0.001
 NORMAL_PREPARATION_STRATEGY = "fit_top_left"
 DIAGNOSTIC_PREPARATION_STRATEGY = "diagnostic_passthrough"
+PREPARED_PAGE_BACKGROUND_FILL = "#ffffff"
 
 ET.register_namespace("", "http://www.w3.org/2000/svg")
+
+SVG_SHAPE_TAGS = {"path", "rect", "circle", "ellipse", "line", "polyline", "polygon"}
+
+
+@dataclass(frozen=True)
+class Bounds:
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+
+    @property
+    def width(self) -> float:
+        return self.max_x - self.min_x
+
+    @property
+    def height(self) -> float:
+        return self.max_y - self.min_y
 
 
 def parse_svg_root(svg_text: str) -> ET.Element:
@@ -126,6 +146,7 @@ def prepare_svg_for_plotting(
     device_settings: PlotterDeviceSettings,
 ) -> tuple[str, PlotPreparationMetadata]:
     source_box = extract_source_box(root)
+    source_content_ratios = extract_source_content_ratios(root, source_box=source_box)
     source_units = classify_source_units(root)
     units_inferred = source_units in {"unitless", "px", "unknown"}
     strategy = (
@@ -154,6 +175,7 @@ def prepare_svg_for_plotting(
             placement_origin_x_mm=0.0,
             placement_origin_y_mm=0.0,
             prepared_view_box=None,
+            source_content_ratios=source_content_ratios,
         )
         validate_preparation_consistency(
             prepared_width_mm=prepared_width_mm,
@@ -208,6 +230,7 @@ def prepare_svg_for_plotting(
             placement_origin_x_mm=plot_area.margin_left_mm,
             placement_origin_y_mm=plot_area.margin_top_mm,
             prepared_view_box=(0.0, 0.0, plot_area.page_width_mm, plot_area.page_height_mm),
+            source_content_ratios=source_content_ratios,
         )
         validate_preparation_consistency(
             prepared_width_mm=prepared_width_mm,
@@ -324,6 +347,333 @@ def extract_source_box(root: ET.Element) -> SourceBox:
     )
 
 
+def extract_source_content_ratios(
+    root: ET.Element,
+    *,
+    source_box: SourceBox,
+) -> Optional[tuple[float, float, float, float]]:
+    if source_box.view_box_width <= 0 or source_box.view_box_height <= 0:
+        return None
+
+    bounds = _element_bounds(
+        root,
+        matrix=_identity_matrix(),
+        source_box=source_box,
+    )
+    if bounds is None or bounds.width <= 0 or bounds.height <= 0:
+        return None
+
+    left_ratio = (bounds.min_x - source_box.view_box_min_x) / source_box.view_box_width
+    top_ratio = (bounds.min_y - source_box.view_box_min_y) / source_box.view_box_height
+    width_ratio = bounds.width / source_box.view_box_width
+    height_ratio = bounds.height / source_box.view_box_height
+    ratios = (left_ratio, top_ratio, width_ratio, height_ratio)
+    if not all(math.isfinite(value) for value in ratios):
+        return None
+    if width_ratio <= 0 or height_ratio <= 0:
+        return None
+    return tuple(max(0.0, min(1.0, value)) for value in ratios)
+
+
+def _element_bounds(
+    element: ET.Element,
+    *,
+    matrix: list[list[float]],
+    source_box: SourceBox,
+) -> Optional[Bounds]:
+    tag = element.tag.rsplit("}", 1)[-1]
+    local_matrix = _compose_matrices(matrix, _parse_transform(element.attrib.get("transform")))
+
+    if tag == "svg":
+        child_bounds = [
+            _element_bounds(child, matrix=local_matrix, source_box=source_box)
+            for child in list(element)
+        ]
+        return _union_bounds([bound for bound in child_bounds if bound is not None])
+
+    if tag == "g":
+        child_bounds = [
+            _element_bounds(child, matrix=local_matrix, source_box=source_box)
+            for child in list(element)
+        ]
+        return _union_bounds([bound for bound in child_bounds if bound is not None])
+
+    if tag not in SVG_SHAPE_TAGS:
+        return None
+
+    if tag == "rect" and is_full_page_background_rect(element, source_box=source_box):
+        return None
+
+    points = _shape_points(element)
+    if not points:
+        return None
+    transformed = [_apply_matrix(local_matrix, point) for point in points]
+    return _bounds_from_points(transformed)
+
+
+def _shape_points(element: ET.Element) -> list[tuple[float, float]]:
+    tag = element.tag.rsplit("}", 1)[-1]
+    if tag == "rect":
+        x = _parse_float(element.attrib.get("x"), 0.0)
+        y = _parse_float(element.attrib.get("y"), 0.0)
+        width = _parse_float(element.attrib.get("width"))
+        height = _parse_float(element.attrib.get("height"))
+        if width is None or height is None:
+            return []
+        return [
+            (x, y),
+            (x + width, y),
+            (x + width, y + height),
+            (x, y + height),
+        ]
+    if tag == "circle":
+        cx = _parse_float(element.attrib.get("cx"), 0.0)
+        cy = _parse_float(element.attrib.get("cy"), 0.0)
+        radius = _parse_float(element.attrib.get("r"))
+        if radius is None:
+            return []
+        return [
+            (cx - radius, cy - radius),
+            (cx + radius, cy - radius),
+            (cx + radius, cy + radius),
+            (cx - radius, cy + radius),
+        ]
+    if tag == "ellipse":
+        cx = _parse_float(element.attrib.get("cx"), 0.0)
+        cy = _parse_float(element.attrib.get("cy"), 0.0)
+        rx = _parse_float(element.attrib.get("rx"))
+        ry = _parse_float(element.attrib.get("ry"))
+        if rx is None or ry is None:
+            return []
+        return [
+            (cx - rx, cy - ry),
+            (cx + rx, cy - ry),
+            (cx + rx, cy + ry),
+            (cx - rx, cy + ry),
+        ]
+    if tag == "line":
+        x1 = _parse_float(element.attrib.get("x1"))
+        y1 = _parse_float(element.attrib.get("y1"))
+        x2 = _parse_float(element.attrib.get("x2"))
+        y2 = _parse_float(element.attrib.get("y2"))
+        if None in {x1, y1, x2, y2}:
+            return []
+        return [(x1, y1), (x2, y2)]
+    if tag in {"polyline", "polygon"}:
+        return _parse_points_list(element.attrib.get("points", ""))
+    if tag == "path":
+        return _parse_path_points(element.attrib.get("d", ""))
+    return []
+
+
+def _parse_float(value: Optional[str], default: Optional[float] = None) -> Optional[float]:
+    if value is None:
+        return default
+    match = re.match(r"^\s*([+-]?[0-9]+(?:\.[0-9]+)?)", value)
+    if not match:
+        return default
+    return float(match.group(1))
+
+
+def _parse_points_list(value: str) -> list[tuple[float, float]]:
+    numbers = re.findall(r"[+-]?(?:\d*\.\d+|\d+)", value)
+    if len(numbers) < 2 or len(numbers) % 2 != 0:
+        return []
+    coords = [float(number) for number in numbers]
+    return [(coords[index], coords[index + 1]) for index in range(0, len(coords), 2)]
+
+
+def _parse_path_points(value: str) -> list[tuple[float, float]]:
+    tokens = re.findall(r"[A-Za-z]|[+-]?(?:\d*\.\d+|\d+)", value)
+    if not tokens:
+        return []
+
+    points: list[tuple[float, float]] = []
+    index = 0
+    command = None
+    current_x = 0.0
+    current_y = 0.0
+    start_x = 0.0
+    start_y = 0.0
+
+    while index < len(tokens):
+        token = tokens[index]
+        if re.match(r"[A-Za-z]", token):
+            command = token
+            index += 1
+            if command in {"Z", "z"}:
+                current_x, current_y = start_x, start_y
+                points.append((current_x, current_y))
+            continue
+        if command is None:
+            return []
+
+        if command in {"M", "L"}:
+            if index + 1 >= len(tokens):
+                break
+            current_x = float(tokens[index])
+            current_y = float(tokens[index + 1])
+            if command == "M":
+                start_x, start_y = current_x, current_y
+                command = "L"
+            points.append((current_x, current_y))
+            index += 2
+            continue
+        if command in {"m", "l"}:
+            if index + 1 >= len(tokens):
+                break
+            current_x += float(tokens[index])
+            current_y += float(tokens[index + 1])
+            if command == "m":
+                start_x, start_y = current_x, current_y
+                command = "l"
+            points.append((current_x, current_y))
+            index += 2
+            continue
+        if command == "H":
+            current_x = float(tokens[index])
+            points.append((current_x, current_y))
+            index += 1
+            continue
+        if command == "h":
+            current_x += float(tokens[index])
+            points.append((current_x, current_y))
+            index += 1
+            continue
+        if command == "V":
+            current_y = float(tokens[index])
+            points.append((current_x, current_y))
+            index += 1
+            continue
+        if command == "v":
+            current_y += float(tokens[index])
+            points.append((current_x, current_y))
+            index += 1
+            continue
+        if command in {"C", "c"}:
+            if index + 5 >= len(tokens):
+                break
+            values = [float(tokens[index + offset]) for offset in range(6)]
+            if command == "c":
+                curve_points = [
+                    (current_x + values[0], current_y + values[1]),
+                    (current_x + values[2], current_y + values[3]),
+                    (current_x + values[4], current_y + values[5]),
+                ]
+                current_x += values[4]
+                current_y += values[5]
+            else:
+                curve_points = [
+                    (values[0], values[1]),
+                    (values[2], values[3]),
+                    (values[4], values[5]),
+                ]
+                current_x = values[4]
+                current_y = values[5]
+            points.extend(curve_points)
+            index += 6
+            continue
+        if command in {"Q", "q"}:
+            if index + 3 >= len(tokens):
+                break
+            values = [float(tokens[index + offset]) for offset in range(4)]
+            if command == "q":
+                curve_points = [
+                    (current_x + values[0], current_y + values[1]),
+                    (current_x + values[2], current_y + values[3]),
+                ]
+                current_x += values[2]
+                current_y += values[3]
+            else:
+                curve_points = [
+                    (values[0], values[1]),
+                    (values[2], values[3]),
+                ]
+                current_x = values[2]
+                current_y = values[3]
+            points.extend(curve_points)
+            index += 4
+            continue
+        return []
+
+    return points
+
+
+def _identity_matrix() -> list[list[float]]:
+    return [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+
+
+def _parse_transform(value: Optional[str]) -> list[list[float]]:
+    matrix = _identity_matrix()
+    if not value:
+        return matrix
+    for name, args in re.findall(r"([A-Za-z]+)\s*\(([^)]*)\)", value):
+        numbers = [float(number) for number in re.findall(r"[+-]?(?:\d*\.\d+|\d+)", args)]
+        if name == "translate":
+            tx = numbers[0] if numbers else 0.0
+            ty = numbers[1] if len(numbers) > 1 else 0.0
+            transform = [
+                [1.0, 0.0, tx],
+                [0.0, 1.0, ty],
+                [0.0, 0.0, 1.0],
+            ]
+        elif name == "scale":
+            sx = numbers[0] if numbers else 1.0
+            sy = numbers[1] if len(numbers) > 1 else sx
+            transform = [
+                [sx, 0.0, 0.0],
+                [0.0, sy, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        else:
+            return matrix
+        matrix = _compose_matrices(matrix, transform)
+    return matrix
+
+
+def _compose_matrices(left: list[list[float]], right: list[list[float]]) -> list[list[float]]:
+    return [
+        [
+            left[row][0] * right[0][column]
+            + left[row][1] * right[1][column]
+            + left[row][2] * right[2][column]
+            for column in range(3)
+        ]
+        for row in range(3)
+    ]
+
+
+def _apply_matrix(matrix: list[list[float]], point: tuple[float, float]) -> tuple[float, float]:
+    x, y = point
+    return (
+        matrix[0][0] * x + matrix[0][1] * y + matrix[0][2],
+        matrix[1][0] * x + matrix[1][1] * y + matrix[1][2],
+    )
+
+
+def _bounds_from_points(points: list[tuple[float, float]]) -> Optional[Bounds]:
+    if not points:
+        return None
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    return Bounds(min(xs), min(ys), max(xs), max(ys))
+
+
+def _union_bounds(bounds: list[Bounds]) -> Optional[Bounds]:
+    if not bounds:
+        return None
+    return Bounds(
+        min(bound.min_x for bound in bounds),
+        min(bound.min_y for bound in bounds),
+        max(bound.max_x for bound in bounds),
+        max(bound.max_y for bound in bounds),
+    )
+
+
 def build_workspace_audit(
     *,
     plot_area: PlotArea,
@@ -361,6 +711,7 @@ def build_preparation_audit(
     placement_origin_x_mm: Optional[float],
     placement_origin_y_mm: Optional[float],
     prepared_view_box: Optional[tuple[float, float, float, float]],
+    source_content_ratios: Optional[tuple[float, float, float, float]],
 ) -> PlotPreparationMetadata.PreparationAudit:
     overflow_x = max(0.0, prepared_width_mm - plot_area.draw_width_mm)
     overflow_y = max(0.0, prepared_height_mm - plot_area.draw_height_mm)
@@ -378,6 +729,7 @@ def build_preparation_audit(
     )
     return PlotPreparationMetadata.PreparationAudit(
         strategy=strategy,
+        comparison_frame_version=1,
         fit_scale=round(scale, 6) if scale is not None else None,
         prepared_within_drawable_area=(
             overflow_x <= PREPARATION_EPSILON_MM and overflow_y <= PREPARATION_EPSILON_MM
@@ -411,6 +763,18 @@ def build_preparation_audit(
         ),
         prepared_viewbox_height=(
             round(prepared_view_box[3], 3) if prepared_view_box is not None else None
+        ),
+        source_content_left_ratio=(
+            round(source_content_ratios[0], 6) if source_content_ratios is not None else None
+        ),
+        source_content_top_ratio=(
+            round(source_content_ratios[1], 6) if source_content_ratios is not None else None
+        ),
+        source_content_width_ratio=(
+            round(source_content_ratios[2], 6) if source_content_ratios is not None else None
+        ),
+        source_content_height_ratio=(
+            round(source_content_ratios[3], 6) if source_content_ratios is not None else None
         ),
     )
 
@@ -537,6 +901,16 @@ def build_prepared_svg(
     root_copy.attrib["viewBox"] = (
         f"0 0 {format_numeric(plot_area.page_width_mm)} {format_numeric(plot_area.page_height_mm)}"
     )
+    prepared_background = ET.Element(
+        qualify_svg_tag(root_copy.tag, "rect"),
+        {
+            "x": "0",
+            "y": "0",
+            "width": "100%",
+            "height": "100%",
+            "fill": PREPARED_PAGE_BACKGROUND_FILL,
+        },
+    )
     wrapper = ET.Element(
         qualify_svg_tag(root_copy.tag, "g"),
         {
@@ -552,7 +926,9 @@ def build_prepared_svg(
     existing_children = list(root_copy)
     for child in existing_children:
         root_copy.remove(child)
-        wrapper.append(child)
+        if not is_full_page_background_rect(child, source_box=source_box):
+            wrapper.append(child)
+    root_copy.append(prepared_background)
     root_copy.append(wrapper)
     return ET.tostring(root_copy, encoding="unicode")
 
@@ -579,6 +955,46 @@ def classify_source_units(root: ET.Element) -> str:
     if len(units) > 1:
         return "mixed"
     return next(iter(units))
+
+
+def is_full_page_background_rect(child: ET.Element, *, source_box: SourceBox) -> bool:
+    if child.tag.rsplit("}", 1)[-1] != "rect":
+        return False
+
+    width = child.attrib.get("width", "").strip()
+    height = child.attrib.get("height", "").strip()
+    if width == "100%" and height == "100%":
+        return True
+
+    x = child.attrib.get("x", "0").strip() or "0"
+    y = child.attrib.get("y", "0").strip() or "0"
+    if not is_zero_length(x) or not is_zero_length(y):
+        return False
+
+    width_length = parse_svg_length(width)
+    height_length = parse_svg_length(height)
+    if width_length is None or height_length is None:
+        return False
+
+    return lengths_match_source_bounds(
+        width_length,
+        source_box.view_box_width,
+    ) and lengths_match_source_bounds(
+        height_length,
+        source_box.view_box_height,
+    )
+
+
+def is_zero_length(value: str) -> bool:
+    if value in {"", "0", "0.0", "0%"}:
+        return True
+    parsed = parse_svg_length(value)
+    return parsed is not None and parsed[0] == 0.0
+
+
+def lengths_match_source_bounds(length: tuple[float, Optional[str]], expected: float) -> bool:
+    value, unit = length
+    return unit in {None, "px"} and abs(value - expected) <= 1e-6
 
 
 def parse_svg_length(value: Optional[str]) -> Optional[tuple[float, Optional[str]]]:

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
@@ -14,7 +14,7 @@ from learn_to_draw_api.models import (
 )
 
 
-ACTIVE_RUN_STATUSES = {"pending", "plotting", "capturing"}
+ACTIVE_RUN_STATUSES = {"pending", "plotting", "capturing", "awaiting_capture_review"}
 
 
 class PlotRunStore:

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import time
 from datetime import datetime, timezone
 
+import cv2
 from fastapi.testclient import TestClient
+import numpy as np
 
 from learn_to_draw_api.adapters.axidraw_models import resolve_axidraw_model_info
 from learn_to_draw_api.adapters.mock_camera import MockCamera
@@ -44,6 +46,43 @@ def wait_for_run_completion(client: TestClient, run_id: str):
             return payload
         time.sleep(0.01)
     raise AssertionError("Plot run did not finish in time.")
+
+
+def wait_for_run_status(client: TestClient, run_id: str, statuses: set[str]):
+    for _ in range(200):
+        response = client.get(f"/api/plot-runs/{run_id}")
+        assert response.status_code == 200
+        payload = response.json()
+        if payload["status"] in statuses:
+            return payload
+        time.sleep(0.01)
+    raise AssertionError(f"Plot run did not reach expected state: {statuses}")
+
+
+def wait_for_latest_capture_normalization(client: TestClient, capture_id: str):
+    for _ in range(200):
+        response = client.get("/api/captures/latest")
+        assert response.status_code == 200
+        capture = response.json()["capture"]
+        if capture and capture["id"] == capture_id and capture.get("normalized") is not None:
+            return capture
+        time.sleep(0.01)
+    raise AssertionError("Latest capture normalization did not finish in time.")
+
+
+def _jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    image = np.full((height, width, 3), 245, dtype=np.uint8)
+    cv2.rectangle(image, (80, 60), (width - 80, height - 60), (32, 32, 32), 6)
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
+def _blank_jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    image = np.full((height, width, 3), 250, dtype=np.uint8)
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
 
 
 def test_health_and_status_endpoints(tmp_path):
@@ -120,12 +159,18 @@ def test_status_reports_plot_capability_flags(tmp_path):
 def test_capture_and_latest_capture_endpoints(tmp_path):
     with create_test_client(tmp_path, camera=MockCamera(capture_delay_s=0)) as client:
         capture_response = client.post("/api/camera/capture")
-        latest_response = client.get("/api/captures/latest")
+        latest_capture = wait_for_latest_capture_normalization(
+            client,
+            capture_response.json()["capture"]["id"],
+        )
 
     assert capture_response.status_code == 200
     capture_payload = capture_response.json()
     assert capture_payload["capture"]["public_url"].startswith("/captures/")
-    assert latest_response.json()["capture"]["id"] == capture_payload["capture"]["id"]
+    assert capture_payload["capture"]["normalized"] is None
+    assert latest_capture["id"] == capture_payload["capture"]["id"]
+    assert latest_capture["normalized"]["metadata"]["target_frame_source"] == "workspace_drawable_area"
+    assert latest_capture["normalized"]["metadata"]["frame"]["kind"] == "page_aligned"
 
 
 class StubRealCamera:
@@ -209,7 +254,41 @@ class StubRealCamera:
             capture_id="capture-real-001",
             timestamp=datetime.now(timezone.utc),
             filename="capture-real-001.jpg",
-            content=b"jpeg-bytes",
+            content=_jpeg_bytes(),
+            media_type="image/jpeg",
+            width=640,
+            height=480,
+        )
+
+
+class LowConfidenceCamera:
+    driver = "mock-camera"
+
+    def __init__(self) -> None:
+        self._connected = False
+        self._capture_count = 0
+
+    def connect(self) -> None:
+        self._connected = True
+
+    def disconnect(self) -> None:
+        self._connected = False
+
+    def get_status(self) -> DeviceStatus:
+        return MockCamera(driver=self.driver).get_status().model_copy(
+            update={"connected": self._connected}
+        )
+
+    def set_selected_device(self, device_id: str | None):
+        return self.get_status()
+
+    def capture(self) -> CaptureArtifact:
+        self._capture_count += 1
+        return CaptureArtifact(
+            capture_id=f"capture-review-{self._capture_count}",
+            timestamp=datetime.now(timezone.utc),
+            filename=f"capture-review-{self._capture_count}.jpg",
+            content=_blank_jpeg_bytes(),
             media_type="image/jpeg",
             width=640,
             height=480,
@@ -220,7 +299,10 @@ def test_capture_endpoint_persists_real_camera_artifact(tmp_path):
     with create_test_client(tmp_path, camera=StubRealCamera()) as client:
         status_before = client.get("/api/hardware/status")
         capture_response = client.post("/api/camera/capture")
-        latest_response = client.get("/api/captures/latest")
+        latest_capture = wait_for_latest_capture_normalization(
+            client,
+            capture_response.json()["capture"]["id"],
+        )
 
     assert status_before.status_code == 200
     assert status_before.json()["camera"]["details"]["readiness_state"] == "ready"
@@ -231,7 +313,9 @@ def test_capture_endpoint_persists_real_camera_artifact(tmp_path):
     assert payload["capture"]["public_url"].endswith(".jpg")
     assert payload["capture"]["width"] == 640
     assert payload["capture"]["height"] == 480
-    assert latest_response.json()["capture"]["id"] == payload["capture"]["id"]
+    assert latest_capture["id"] == payload["capture"]["id"]
+    assert latest_capture["normalized"]["rectified_grayscale_url"].endswith(".png")
+    assert latest_capture["normalized"]["metadata"]["frame"]["kind"] == "page_aligned"
 
 
 def test_camera_device_endpoint_updates_selected_device(tmp_path):
@@ -612,6 +696,12 @@ def test_pattern_asset_and_plot_run_endpoints(tmp_path):
 
     assert completed["status"] == "completed"
     assert completed["capture"]["public_url"].startswith("/captures/")
+    assert completed["capture"]["normalized"] is not None
+    assert completed["capture"]["normalized"]["metadata"]["target_frame_source"] == "prepared_svg"
+    assert completed["capture"]["normalized"]["metadata"]["frame"]["kind"] == "page_aligned"
+    assert completed["capture"]["normalized"]["metadata"]["frame"]["version"] == 1
+    assert completed["capture"]["normalized"]["metadata"]["frame"]["page_width_mm"] == 210.0
+    assert completed["capture"]["normalized"]["metadata"]["frame"]["page_height_mm"] == 297.0
     assert completed["observed_result"]["capture"]["id"] == completed["capture"]["id"]
     assert completed["observed_result"]["camera_driver"] == "mock-camera"
     assert completed["prepared_artifact"]["public_url"].startswith("/plot-run-artifacts/")
@@ -627,9 +717,73 @@ def test_pattern_asset_and_plot_run_endpoints(tmp_path):
     assert completed["plotter_run_details"]["preparation"]["drawable_width_mm"] == 170.0
     assert completed["plotter_run_details"]["preparation"]["workspace_audit"]["page_within_plotter_bounds"] is True
     assert completed["plotter_run_details"]["preparation"]["preparation_audit"]["strategy"] == "fit_top_left"
+    assert completed["plotter_run_details"]["preparation"]["preparation_audit"]["comparison_frame_version"] == 1
     assert completed["plotter_run_details"]["preparation"]["preparation_audit"]["placement_origin_x_mm"] == 20.0
+    assert completed["plotter_run_details"]["preparation"]["preparation_audit"]["source_content_left_ratio"] == 0.083333
     assert latest.json()["run"]["id"] == run["id"]
     assert recent.json()["runs"][0]["id"] == run["id"]
+
+
+def test_plot_run_capture_review_accept_endpoint(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=MockPlotter(plot_delay_s=0),
+        camera=LowConfidenceCamera(),
+    ) as client:
+        asset_response = client.post(
+            "/api/plot-assets/patterns",
+            json={"pattern_id": "test-grid"},
+        )
+        run_response = client.post("/api/plot-runs", json={"asset_id": asset_response.json()["id"]})
+        pending = wait_for_run_status(client, run_response.json()["id"], {"awaiting_capture_review"})
+        review_response = client.get(f"/api/plot-runs/{pending['id']}/capture-review")
+        accept_response = client.post(f"/api/plot-runs/{pending['id']}/capture-review/accept")
+        completed = wait_for_run_completion(client, pending["id"])
+
+    assert review_response.status_code == 200
+    review_payload = review_response.json()
+    assert review_payload["review"]["review_status"] == "pending"
+    assert review_payload["capture"]["normalized"] is None
+    assert accept_response.status_code == 200
+    assert accept_response.json()["run"]["status"] == "capturing"
+    assert completed["status"] == "completed"
+    assert completed["capture"]["normalized"] is not None
+    assert completed["capture"]["review"]["confirmation_source"] == "auto"
+
+
+def test_plot_run_capture_review_reuse_last_endpoint(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=MockPlotter(plot_delay_s=0),
+        camera=LowConfidenceCamera(),
+    ) as client:
+        asset_response = client.post(
+            "/api/plot-assets/patterns",
+            json={"pattern_id": "test-grid"},
+        )
+        asset_id = asset_response.json()["id"]
+
+        first_run = client.post("/api/plot-runs", json={"asset_id": asset_id}).json()
+        first_pending = wait_for_run_status(client, first_run["id"], {"awaiting_capture_review"})
+        first_corners = first_pending["capture"]["review"]["proposed_corners"]
+        adjust_response = client.post(
+            f"/api/plot-runs/{first_pending['id']}/capture-review/adjust",
+            json={"corners": first_corners},
+        )
+        first_completed = wait_for_run_completion(client, first_pending["id"])
+
+        second_run = client.post("/api/plot-runs", json={"asset_id": asset_id}).json()
+        second_pending = wait_for_run_status(client, second_run["id"], {"awaiting_capture_review"})
+        reuse_response = client.post(
+            f"/api/plot-runs/{second_pending['id']}/capture-review/reuse-last"
+        )
+        second_completed = wait_for_run_completion(client, second_pending["id"])
+
+    assert adjust_response.status_code == 200
+    assert first_completed["capture"]["review"]["confirmation_source"] == "adjusted"
+    assert second_pending["capture"]["review"]["reuse_last_available"] is True
+    assert reuse_response.status_code == 200
+    assert second_completed["capture"]["review"]["confirmation_source"] == "reused_last"
 
 
 def test_diagnostic_plot_run_skips_capture(tmp_path):
@@ -685,6 +839,8 @@ def test_normal_preparation_accepts_unitless_upload(tmp_path):
     assert completed["status"] == "completed"
     assert completed["plotter_run_details"]["preparation"]["units_inferred"] is True
     assert completed["observed_result"]["capture"]["id"] == completed["capture"]["id"]
+    assert completed["capture"]["normalized"]["metadata"]["output"]["width"] == 1448
+    assert completed["capture"]["normalized"]["metadata"]["output"]["height"] == 2048
     assert completed["plotter_run_details"]["preparation"]["prepared_width_mm"] == 170.0
     assert completed["plotter_run_details"]["preparation"]["workspace_audit"]["drawable_origin_x_mm"] == 20.0
     assert completed["plotter_run_details"]["preparation"]["preparation_audit"]["strategy"] == "fit_top_left"

--- a/apps/api/tests/test_capture_normalization.py
+++ b/apps/api/tests/test_capture_normalization.py
@@ -1,0 +1,637 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from learn_to_draw_api.services.capture_normalization import (
+    CaptureNormalizationService,
+    LOW_CONFIDENCE_THRESHOLD,
+    target_from_page_size,
+)
+
+
+def _encode_png(image: np.ndarray) -> bytes:
+    ok, encoded = cv2.imencode(".png", image)
+    assert ok
+    return encoded.tobytes()
+
+
+def _decode_png(content: bytes) -> np.ndarray:
+    image = cv2.imdecode(np.frombuffer(content, dtype=np.uint8), cv2.IMREAD_UNCHANGED)
+    assert image is not None
+    return image
+
+
+def _build_perspective_paper_image(
+    *,
+    width: int = 1400,
+    height: int = 1000,
+    destination: np.ndarray | None = None,
+) -> bytes:
+    frame = np.full((height, width, 3), (26, 30, 28), dtype=np.uint8)
+    paper_width = 760
+    paper_height = 980
+    paper = np.full((paper_height, paper_width, 3), 244, dtype=np.uint8)
+    cv2.rectangle(paper, (0, 0), (paper_width - 1, paper_height - 1), (222, 217, 208), 6)
+    cv2.line(paper, (90, 180), (paper_width - 90, 180), (34, 40, 48), 8)
+    cv2.rectangle(paper, (110, 250), (paper_width - 110, paper_height - 160), (26, 32, 40), 6)
+    cv2.polylines(
+        paper,
+        [
+            np.array(
+                [
+                    (120, 760),
+                    (220, 460),
+                    (360, 620),
+                    (500, 400),
+                    (640, 730),
+                ],
+                dtype=np.int32,
+            )
+        ],
+        isClosed=False,
+        color=(38, 44, 52),
+        thickness=8,
+    )
+    source = np.array(
+        [
+            [0.0, 0.0],
+            [float(paper_width - 1), 0.0],
+            [float(paper_width - 1), float(paper_height - 1)],
+            [0.0, float(paper_height - 1)],
+        ],
+        dtype=np.float32,
+    )
+    if destination is None:
+        destination = np.array(
+            [
+                [260.0, 90.0],
+                [1060.0, 110.0],
+                [1120.0, 910.0],
+                [220.0, 940.0],
+            ],
+            dtype=np.float32,
+        )
+    matrix = cv2.getPerspectiveTransform(source, destination)
+    warped_paper = cv2.warpPerspective(paper, matrix, (width, height))
+    warped_mask = cv2.warpPerspective(
+        np.full((paper_height, paper_width), 255, dtype=np.uint8),
+        matrix,
+        (width, height),
+    )
+    mask = warped_mask > 0
+    frame[mask] = warped_paper[mask]
+    return _encode_png(frame)
+
+
+def _build_connected_bright_rail_image() -> bytes:
+    width = 1600
+    height = 1100
+    frame = np.full((height, width, 3), (28, 31, 30), dtype=np.uint8)
+
+    for x in range(0, width, 70):
+        cv2.line(frame, (x, 0), (x, height - 1), (56, 60, 58), 1)
+    for y in range(0, height, 70):
+        cv2.line(frame, (0, y), (width - 1, y), (56, 60, 58), 1)
+
+    paper_quad = np.array(
+        [
+            [300, 250],
+            [1210, 230],
+            [1450, 1010],
+            [120, 1020],
+        ],
+        dtype=np.int32,
+    )
+    cv2.fillConvexPoly(frame, paper_quad, (245, 243, 239))
+    cv2.polylines(frame, [paper_quad], isClosed=True, color=(228, 223, 214), thickness=6)
+    cv2.rectangle(frame, (460, 310), (920, 660), (76, 92, 182), 5)
+    cv2.line(frame, (470, 620), (900, 360), (76, 92, 182), 5)
+    cv2.circle(frame, (580, 430), 48, (76, 92, 182), 4)
+
+    cv2.rectangle(frame, (170, 55), (1515, 180), (242, 241, 238), thickness=-1)
+    cv2.rectangle(frame, (860, 180), (955, 305), (242, 241, 238), thickness=-1)
+    cv2.rectangle(frame, (1325, 250), (1505, 980), (235, 235, 232), thickness=-1)
+    return _encode_png(frame)
+
+
+def _build_perspective_paper_with_glare() -> bytes:
+    content = _build_perspective_paper_image()
+    image = cv2.imdecode(np.frombuffer(content, dtype=np.uint8), cv2.IMREAD_COLOR)
+    assert image is not None
+    cv2.ellipse(image, (980, 360), (210, 130), -18, 0, 360, (255, 255, 255), thickness=-1)
+    return _encode_png(image)
+
+
+def _build_perspective_paper_with_partial_edge_loss() -> bytes:
+    content = _build_perspective_paper_image()
+    image = cv2.imdecode(np.frombuffer(content, dtype=np.uint8), cv2.IMREAD_COLOR)
+    assert image is not None
+    cv2.rectangle(image, (220, 180), (310, 930), (242, 242, 242), thickness=-1)
+    return _encode_png(image)
+
+
+def _build_dense_plotted_paper_image() -> bytes:
+    width = 1700
+    height = 1200
+    frame = np.full((height, width, 3), (24, 28, 27), dtype=np.uint8)
+    paper = np.full((900, 1220, 3), 244, dtype=np.uint8)
+    cv2.rectangle(paper, (0, 0), (1219, 899), (224, 220, 214), 6)
+    cv2.rectangle(paper, (110, 120), (930, 660), (38, 46, 58), 6)
+    for x in range(170, 931, 100):
+        cv2.line(paper, (x, 120), (x, 660), (86, 92, 102), 4)
+    for y in range(190, 661, 70):
+        cv2.line(paper, (110, y), (930, y), (86, 92, 102), 3)
+    cv2.circle(paper, (220, 230), 72, (56, 64, 78), 5)
+    cv2.circle(paper, (760, 250), 64, (56, 64, 78), 5)
+    cv2.line(paper, (170, 640), (840, 150), (56, 64, 78), 5)
+    cv2.ellipse(paper, (500, 570), (260, 110), 0, 190, 350, (56, 64, 78), 5)
+    cv2.putText(
+        paper,
+        "Dense Pattern Check",
+        (120, 82),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        1.2,
+        (120, 88, 52),
+        3,
+        cv2.LINE_AA,
+    )
+    source = np.array(
+        [
+            [0.0, 0.0],
+            [1219.0, 0.0],
+            [1219.0, 899.0],
+            [0.0, 899.0],
+        ],
+        dtype=np.float32,
+    )
+    destination = np.array(
+        [
+            [270.0, 220.0],
+            [1430.0, 170.0],
+            [1510.0, 1010.0],
+            [180.0, 1110.0],
+        ],
+        dtype=np.float32,
+    )
+    matrix = cv2.getPerspectiveTransform(source, destination)
+    warped_paper = cv2.warpPerspective(paper, matrix, (width, height))
+    warped_mask = cv2.warpPerspective(
+        np.full((900, 1220), 255, dtype=np.uint8),
+        matrix,
+        (width, height),
+    )
+    mask = warped_mask > 0
+    frame[mask] = warped_paper[mask]
+    cv2.rectangle(frame, (0, 250), (95, 980), (226, 226, 223), thickness=-1)
+    cv2.rectangle(frame, (780, 0), (1310, 140), (232, 232, 229), thickness=-1)
+    return _encode_png(frame)
+
+
+def _build_off_axis_dense_paper_image() -> bytes:
+    width = 1920
+    height = 1080
+    frame = np.full((height, width, 3), (28, 31, 30), dtype=np.uint8)
+    for x in range(0, width, 68):
+        cv2.line(frame, (x, 0), (x, height - 1), (54, 58, 56), 1)
+    for y in range(0, height, 68):
+        cv2.line(frame, (0, y), (width - 1, y), (54, 58, 56), 1)
+    cv2.rectangle(frame, (0, 0), (width - 1, 180), (36, 38, 40), thickness=-1)
+
+    paper = np.full((820, 1220, 3), 244, dtype=np.uint8)
+    cv2.rectangle(paper, (0, 0), (1219, 819), (225, 222, 215), 6)
+    cv2.rectangle(paper, (130, 110), (760, 520), (70, 88, 170), 4)
+    for x in range(180, 761, 90):
+        cv2.line(paper, (x, 110), (x, 520), (88, 96, 108), 3)
+    for y in range(170, 521, 55):
+        cv2.line(paper, (130, y), (760, y), (88, 96, 108), 2)
+    cv2.circle(paper, (240, 220), 52, (88, 96, 108), 4)
+    cv2.circle(paper, (650, 230), 52, (88, 96, 108), 4)
+    cv2.line(paper, (160, 480), (770, 150), (88, 96, 108), 4)
+    cv2.ellipse(paper, (460, 450), (210, 90), 0, 190, 350, (88, 96, 108), 4)
+
+    source = np.array(
+        [
+            [0.0, 0.0],
+            [1219.0, 0.0],
+            [1219.0, 819.0],
+            [0.0, 819.0],
+        ],
+        dtype=np.float32,
+    )
+    destination = np.array(
+        [
+            [520.0, 330.0],
+            [1760.0, 270.0],
+            [1830.0, 995.0],
+            [600.0, 1060.0],
+        ],
+        dtype=np.float32,
+    )
+    matrix = cv2.getPerspectiveTransform(source, destination)
+    warped_paper = cv2.warpPerspective(paper, matrix, (width, height))
+    warped_mask = cv2.warpPerspective(
+        np.full((820, 1220), 255, dtype=np.uint8),
+        matrix,
+        (width, height),
+    )
+    mask = warped_mask > 0
+    frame[mask] = warped_paper[mask]
+    return _encode_png(frame)
+
+
+def _build_off_axis_paper_with_left_extension() -> bytes:
+    image = cv2.imdecode(
+        np.frombuffer(_build_off_axis_dense_paper_image(), dtype=np.uint8),
+        cv2.IMREAD_COLOR,
+    )
+    assert image is not None
+    cv2.rectangle(image, (220, 300), (600, 1060), (243, 243, 240), thickness=-1)
+    return _encode_png(image)
+
+
+def _build_off_axis_paper_with_bottom_extension() -> bytes:
+    image = cv2.imdecode(
+        np.frombuffer(_build_off_axis_dense_paper_image(), dtype=np.uint8),
+        cv2.IMREAD_COLOR,
+    )
+    assert image is not None
+    cv2.rectangle(image, (560, 900), (1830, 1060), (243, 243, 240), thickness=-1)
+    return _encode_png(image)
+
+
+def _build_outline_only_rectangle_image() -> bytes:
+    width = 1500
+    height = 1100
+    frame = np.full((height, width, 3), (24, 28, 26), dtype=np.uint8)
+    corners = np.array(
+        [
+            [250, 160],
+            [1180, 180],
+            [1290, 980],
+            [180, 1010],
+        ],
+        dtype=np.int32,
+    )
+    cv2.polylines(frame, [corners], isClosed=True, color=(236, 236, 236), thickness=10)
+    cv2.line(frame, tuple(corners[0]), tuple(corners[2]), (245, 245, 245), thickness=4)
+    return _encode_png(frame)
+
+
+def _assert_corners_within_margin(
+    result,
+    *,
+    width: int,
+    height: int,
+    margin: float,
+) -> None:
+    corners = result.metadata.corners
+    xs = [
+        corners.top_left[0],
+        corners.top_right[0],
+        corners.bottom_right[0],
+        corners.bottom_left[0],
+    ]
+    ys = [
+        corners.top_left[1],
+        corners.top_right[1],
+        corners.bottom_right[1],
+        corners.bottom_left[1],
+    ]
+    assert min(xs) >= -margin
+    assert min(ys) >= -margin
+    assert max(xs) <= width - 1 + margin
+    assert max(ys) <= height - 1 + margin
+
+
+def test_capture_normalization_detects_confident_paper_region():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_perspective_paper_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+    grayscale = _decode_png(result.rectified_grayscale)
+
+    assert result.metadata.method == "paper_region_v2"
+    assert result.metadata.confidence >= LOW_CONFIDENCE_THRESHOLD
+    assert result.metadata.output.width == 2048
+    assert result.metadata.output.height == 1950
+    assert result.metadata.target_frame_source == "prepared_svg"
+    assert result.metadata.frame is not None
+    assert result.metadata.frame.kind == "page_aligned"
+    assert result.metadata.frame.page_width_mm == 210.0
+    assert result.metadata.frame.page_height_mm == 200.0
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.mode == "default"
+    assert result.metadata.diagnostics.region_v2.status == "used"
+    assert result.metadata.diagnostics.line_v1.status == "not_run"
+    assert result.metadata.transform.matrix[0][0] != 0
+    assert len(result.rectified_grayscale) > 0
+    assert len(result.debug_overlay) > 0
+    assert int(grayscale[grayscale.shape[0] // 2, grayscale.shape[1] // 2]) > 120
+    _assert_corners_within_margin(result, width=1400, height=1000, margin=40.0)
+
+
+def test_capture_normalization_contour_experiment_detects_perspective_page():
+    service = CaptureNormalizationService(experiment="contour_v3")
+
+    result = service.normalize(
+        content=_build_perspective_paper_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_contour_v3"
+    assert result.metadata.confidence > 0.0
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.mode == "default"
+    assert result.metadata.diagnostics.contour_v3.status == "used"
+    assert result.metadata.diagnostics.region_v2.status == "not_run"
+    assert result.metadata.diagnostics.line_v1.status == "not_run"
+    _assert_corners_within_margin(result, width=1400, height=1000, margin=45.0)
+
+
+def test_capture_normalization_contour_experiment_detects_off_axis_page():
+    service = CaptureNormalizationService(experiment="contour_v3")
+
+    result = service.normalize(
+        content=_build_off_axis_dense_paper_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_contour_v3"
+    assert result.metadata.confidence > 0.0
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.contour_v3.status == "used"
+    candidate = result.metadata.diagnostics.contour_v3.best_candidate
+    assert candidate is not None
+    assert candidate.mean_border_support is not None and candidate.mean_border_support >= 0.5
+    _assert_corners_within_margin(result, width=1920, height=1080, margin=85.0)
+
+
+def test_capture_normalization_keeps_best_region_candidate_for_strong_skew():
+    service = CaptureNormalizationService()
+    result = service.normalize(
+        content=_build_perspective_paper_image(
+            destination=np.array(
+                [
+                    [430.0, 120.0],
+                    [840.0, 260.0],
+                    [780.0, 860.0],
+                    [360.0, 800.0],
+                ],
+                dtype=np.float32,
+            )
+        ),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="workspace_drawable_area",
+        ),
+    )
+
+    assert result.metadata.method == "paper_region_v2"
+    assert result.metadata.confidence > 0.0
+    assert result.metadata.output.width == 2048
+    assert result.metadata.output.height == 1950
+    assert result.metadata.target_frame_source == "workspace_drawable_area"
+    assert result.metadata.frame is not None
+    assert result.metadata.frame.kind == "page_aligned"
+    _assert_corners_within_margin(result, width=1400, height=1000, margin=40.0)
+
+
+def test_capture_normalization_uses_line_fallback_when_bright_rail_region_is_not_credible():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_connected_bright_rail_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_edges_v1"
+    assert result.metadata.confidence > 0.0
+    assert result.metadata.output.width == 2048
+    assert result.metadata.output.height == 1950
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.region_v2.status == "rejected"
+    assert result.metadata.diagnostics.region_v2.best_candidate is not None
+    assert result.metadata.diagnostics.region_v2.best_candidate.rejection_reason is not None
+    assert result.metadata.diagnostics.line_v1.status == "used"
+    _assert_corners_within_margin(result, width=1600, height=1100, margin=120.0)
+    assert result.metadata.corners.top_left[0] > 180.0
+    assert result.metadata.corners.top_left[1] > 180.0
+    assert result.metadata.corners.bottom_left[0] > 120.0
+
+
+def test_capture_normalization_keeps_region_fit_under_glare():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_perspective_paper_with_glare(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_region_v2"
+    assert result.metadata.confidence > 0.0
+    _assert_corners_within_margin(result, width=1400, height=1000, margin=50.0)
+
+
+def test_capture_normalization_keeps_region_fit_with_partial_edge_loss():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_perspective_paper_with_partial_edge_loss(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_region_v2"
+    assert result.metadata.confidence > 0.0
+    _assert_corners_within_margin(result, width=1400, height=1000, margin=55.0)
+
+
+def test_capture_normalization_keeps_region_fit_with_dense_internal_strokes():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_dense_plotted_paper_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_region_v2"
+    assert result.metadata.confidence > 0.0
+    _assert_corners_within_margin(result, width=1700, height=1200, margin=75.0)
+
+
+def test_capture_normalization_keeps_region_fit_tight_on_off_axis_page():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_off_axis_dense_paper_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_region_v2"
+    assert result.metadata.confidence > 0.0
+    _assert_corners_within_margin(result, width=1920, height=1080, margin=80.0)
+    assert result.metadata.corners.top_left[0] > 500.0
+    assert result.metadata.corners.bottom_left[0] > 540.0
+    assert result.metadata.diagnostics is not None
+    candidate = result.metadata.diagnostics.region_v2.best_candidate
+    assert candidate is not None
+    assert candidate.top_score is not None and candidate.top_score >= 0.95
+    assert candidate.right_score is not None and candidate.right_score >= 0.95
+    assert candidate.bottom_score is not None and candidate.bottom_score >= 0.95
+    assert candidate.left_score is not None and candidate.left_score >= 0.95
+    assert candidate.mean_border_support is not None and candidate.mean_border_support >= 0.95
+    assert candidate.refined_area_ratio is not None and candidate.refined_area_ratio < 1.05
+    assert candidate.max_outward_expansion_px is not None and candidate.max_outward_expansion_px <= 2.1
+
+
+def test_capture_normalization_region_only_rejects_weak_left_border_candidate():
+    service = CaptureNormalizationService(mode="region_only")
+
+    result = service.normalize(
+        content=_build_off_axis_paper_with_left_extension(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "fallback_full_frame"
+    assert result.metadata.confidence == 0.0
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.mode == "region_only"
+    assert result.metadata.diagnostics.region_v2.status == "rejected"
+    assert result.metadata.diagnostics.region_v2.rejection_reason == "weak_left_border"
+    candidate = result.metadata.diagnostics.region_v2.best_candidate
+    assert candidate is not None
+    assert candidate.rejection_reason == "weak_left_border"
+    assert candidate.left_score is not None and candidate.left_score < 0.28
+    assert candidate.top_score is not None and candidate.top_score >= 0.95
+    assert candidate.right_score is not None and candidate.right_score >= 0.95
+    assert candidate.bottom_score is not None and candidate.bottom_score >= 0.95
+    assert result.metadata.diagnostics.line_v1.status == "not_run"
+
+
+def test_capture_normalization_region_only_rejects_weak_bottom_border_candidate():
+    service = CaptureNormalizationService(mode="region_only")
+
+    result = service.normalize(
+        content=_build_off_axis_paper_with_bottom_extension(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "fallback_full_frame"
+    assert result.metadata.confidence == 0.0
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.mode == "region_only"
+    assert result.metadata.diagnostics.region_v2.status == "rejected"
+    assert result.metadata.diagnostics.region_v2.rejection_reason == "weak_bottom_border"
+    candidate = result.metadata.diagnostics.region_v2.best_candidate
+    assert candidate is not None
+    assert candidate.rejection_reason == "weak_bottom_border"
+    assert candidate.bottom_score is not None and candidate.bottom_score < 0.28
+    assert candidate.top_score is not None and candidate.top_score >= 0.95
+    assert candidate.right_score is not None and candidate.right_score >= 0.95
+    assert candidate.left_score is not None and candidate.left_score >= 0.95
+    assert result.metadata.diagnostics.line_v1.status == "not_run"
+
+
+def test_capture_normalization_uses_line_fallback_when_no_bright_region_exists():
+    service = CaptureNormalizationService()
+
+    result = service.normalize(
+        content=_build_outline_only_rectangle_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "paper_edges_v1"
+    assert result.metadata.confidence > 0.0
+    _assert_corners_within_margin(result, width=1500, height=1100, margin=120.0)
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.region_v2.status in {"rejected", "unavailable"}
+    assert result.metadata.diagnostics.line_v1.status == "used"
+
+
+def test_capture_normalization_region_only_mode_skips_line_fallback():
+    service = CaptureNormalizationService(mode="region_only")
+
+    result = service.normalize(
+        content=_build_outline_only_rectangle_image(),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "fallback_full_frame"
+    assert result.metadata.confidence == 0.0
+    assert result.metadata.diagnostics is not None
+    assert result.metadata.diagnostics.mode == "region_only"
+    assert result.metadata.diagnostics.line_v1.status == "not_run"
+    assert result.metadata.diagnostics.line_v1.rejection_reason == "disabled_in_region_only_mode"
+
+
+def test_capture_normalization_falls_back_to_full_frame_when_no_rectangle_found():
+    service = CaptureNormalizationService()
+    image = np.full((900, 1200, 3), (25, 28, 26), dtype=np.uint8)
+    cv2.circle(image, (400, 420), 120, (70, 90, 110), thickness=-1)
+    cv2.line(image, (100, 120), (1040, 780), (110, 120, 130), 18)
+
+    result = service.normalize(
+        content=_encode_png(image),
+        target=target_from_page_size(
+            page_width_mm=210.0,
+            page_height_mm=200.0,
+            source="prepared_svg",
+        ),
+    )
+
+    assert result.metadata.method == "fallback_full_frame"
+    assert result.metadata.confidence == 0.0
+    assert result.metadata.output.width == 2048
+    assert result.metadata.output.height == 1950
+    assert result.metadata.corners.top_left == (0.0, 0.0)

--- a/apps/api/tests/test_plot_workflow_preparation.py
+++ b/apps/api/tests/test_plot_workflow_preparation.py
@@ -11,6 +11,7 @@ from learn_to_draw_api.services.plot_workflow_preparation import (
     pattern_definition,
     prepare_svg_for_plotting,
 )
+from xml.etree import ElementTree as ET
 
 
 def build_device_settings() -> PlotterDeviceSettings:
@@ -127,3 +128,58 @@ def test_prepare_svg_for_plotting_rejects_non_finite_viewbox_math() -> None:
         )
 
     assert str(exc_info.value) == "Prepared SVG math produced non-finite bounds or scale."
+
+
+def test_prepare_svg_for_plotting_hoists_full_page_background_rect() -> None:
+    svg_text = (
+        "<svg xmlns='http://www.w3.org/2000/svg' width='200' height='100' "
+        "viewBox='0 0 200 100'>"
+        "<rect width='100%' height='100%' fill='#f8f3ea' />"
+        "<path d='M 0 0 H 200' stroke='black' />"
+        "</svg>"
+    )
+    root = parse_svg_root(svg_text)
+
+    prepared_svg_text, _ = prepare_svg_for_plotting(
+        svg_text,
+        root,
+        purpose="normal",
+        plot_area=build_plot_area(),
+        device_settings=build_device_settings(),
+    )
+
+    prepared_root = ET.fromstring(prepared_svg_text)
+    children = list(prepared_root)
+
+    assert len(children) == 2
+    assert children[0].tag.endswith("rect")
+    assert children[0].attrib["x"] == "0"
+    assert children[0].attrib["y"] == "0"
+    assert children[0].attrib["width"] == "100%"
+    assert children[0].attrib["height"] == "100%"
+    assert children[0].attrib["fill"] == "#ffffff"
+    assert children[1].tag.endswith("g")
+    assert children[1].attrib["transform"].startswith("translate(")
+    assert len(list(children[1])) == 1
+    assert list(children[1])[0].tag.endswith("path")
+
+
+def test_prepare_svg_for_plotting_records_tight_content_ratios_for_test_grid() -> None:
+    pattern = pattern_definition("test-grid")
+    assert pattern is not None
+    root = parse_svg_root(pattern["svg_text"])
+
+    _, preparation = prepare_svg_for_plotting(
+        pattern["svg_text"],
+        root,
+        purpose="normal",
+        plot_area=build_plot_area(),
+        device_settings=build_device_settings(),
+    )
+
+    audit = preparation.preparation_audit
+    assert audit.comparison_frame_version == 1
+    assert audit.source_content_left_ratio == pytest.approx(80 / 960, abs=1e-6)
+    assert audit.source_content_top_ratio == pytest.approx(80 / 720, abs=1e-6)
+    assert audit.source_content_width_ratio == pytest.approx(800 / 960, abs=1e-6)
+    assert audit.source_content_height_ratio == pytest.approx(560 / 720, abs=1e-6)

--- a/apps/api/tests/test_plot_workflow_service.py
+++ b/apps/api/tests/test_plot_workflow_service.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+import cv2
+import numpy as np
+
 from learn_to_draw_api.adapters.camera import CaptureArtifact
 from learn_to_draw_api.adapters.mock_camera import MockCamera
 from learn_to_draw_api.adapters.mock_plotter import MockPlotter
 from learn_to_draw_api.models import (
     PatternAssetCreateRequest,
+    PlotRunCaptureReviewAdjustRequest,
     PlotterCalibrationRequest,
     PlotterWorkspaceRequest,
 )
+from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
+from learn_to_draw_api.services.capture_review_memory import CaptureReviewMemoryStore
+from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.plot_workflow import (
     PlotAssetStore,
@@ -59,7 +66,53 @@ class StubRealCamera:
             capture_id=f"real-capture-{self._capture_count}",
             timestamp=MockCamera(capture_delay_s=0).capture().timestamp,
             filename=f"real-capture-{self._capture_count}.jpg",
-            content=b"jpeg-bytes",
+            content=_jpeg_bytes(),
+            media_type="image/jpeg",
+            width=640,
+            height=480,
+        )
+
+
+def _jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    image = np.full((height, width, 3), 245, dtype=np.uint8)
+    cv2.rectangle(image, (60, 40), (width - 60, height - 40), (30, 30, 30), 6)
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
+def _blank_jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    image = np.full((height, width, 3), 250, dtype=np.uint8)
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
+class LowConfidenceCamera:
+    driver = "mock-camera"
+
+    def __init__(self) -> None:
+        self._capture_count = 0
+
+    def connect(self) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        return None
+
+    def get_status(self):
+        return MockCamera(driver=self.driver).get_status()
+
+    def set_selected_device(self, device_id: str | None):
+        return self.get_status()
+
+    def capture(self) -> CaptureArtifact:
+        self._capture_count += 1
+        return CaptureArtifact(
+            capture_id=f"review-capture-{self._capture_count}",
+            timestamp=MockCamera(capture_delay_s=0).capture().timestamp,
+            filename=f"review-capture-{self._capture_count}.jpg",
+            content=_blank_jpeg_bytes(),
             media_type="image/jpeg",
             width=640,
             height=480,
@@ -90,10 +143,16 @@ def _build_service(tmp_path, *, plotter=None, camera=None, config_overrides=None
         config=config,
         device_settings_service=device_settings_service,
     )
+    capture_store = CaptureStore(tmp_path / "captures", "/captures")
     return PlotWorkflowService(
         plotter=plotter or MockPlotter(plot_delay_s=0),
         camera=camera or MockCamera(capture_delay_s=0),
-        capture_store=CaptureStore(tmp_path / "captures", "/captures"),
+        capture_store=capture_store,
+        capture_service=CaptureService(
+            store=capture_store,
+            normalization_service=CaptureNormalizationService(),
+        ),
+        review_memory_store=CaptureReviewMemoryStore(tmp_path / "workspace"),
         asset_store=PlotAssetStore(tmp_path / "plot_assets", "/plot-assets"),
         run_store=PlotRunStore(tmp_path / "plot_runs"),
         calibration_service=calibration_service,
@@ -109,6 +168,15 @@ def _wait_for_terminal_run(service: PlotWorkflowService, run_id: str):
             return run
         time.sleep(0.01)
     raise AssertionError("Run did not reach a terminal state in time.")
+
+
+def _wait_for_run_status(service: PlotWorkflowService, run_id: str, statuses: set[str]):
+    for _ in range(200):
+        run = service.get_run(run_id)
+        if run.status in statuses:
+            return run
+        time.sleep(0.01)
+    raise AssertionError(f"Run did not reach expected status in time: {statuses}")
 
 
 def test_plot_asset_store_separates_public_url_from_disk_path(tmp_path):
@@ -140,11 +208,20 @@ def test_plot_workflow_service_completes_pattern_run(tmp_path):
     assert completed.observed_result.capture.id == completed.capture.id
     assert completed.observed_result.camera_driver == "mock-camera"
     assert completed.observed_result.duration_ms >= 0
+    assert completed.capture.normalized is not None
+    assert completed.capture.normalized.metadata.target_frame_source == "prepared_svg"
+    assert completed.capture.normalized.metadata.output.width == 1448
+    assert completed.capture.normalized.metadata.output.height == 2048
+    assert completed.capture.normalized.metadata.frame is not None
+    assert completed.capture.normalized.metadata.frame.kind == "page_aligned"
+    assert completed.capture.normalized.metadata.frame.page_width_mm == 210.0
+    assert completed.capture.normalized.metadata.frame.page_height_mm == 297.0
     assert completed.prepared_artifact is not None
     assert completed.prepared_artifact.public_url.endswith(f"/{completed.id}-prepared.svg")
     assert completed.prepared_artifact.mime_type == "image/svg+xml"
     assert completed.stage_states["plot"].status == "completed"
     assert completed.stage_states["capture"].status == "completed"
+    assert completed.stage_states["capture_review"].status == "completed"
     assert completed.plotter_run_details["document_id"] == asset.id
     assert completed.plotter_run_details["calibration"]["driver_calibration"]["native_res_factor"] == 1016.0
     assert completed.plotter_run_details["device"]["plotter_bounds_source"] == "config_default"
@@ -164,10 +241,13 @@ def test_plot_workflow_service_completes_pattern_run(tmp_path):
     assert completed.plotter_run_details["preparation"]["prepared_width_mm"] == 160.0
     assert completed.plotter_run_details["preparation"]["prepared_height_mm"] == 120.0
     assert completed.plotter_run_details["preparation"]["preparation_audit"]["strategy"] == "fit_top_left"
+    assert completed.plotter_run_details["preparation"]["preparation_audit"]["comparison_frame_version"] == 1
     assert completed.plotter_run_details["preparation"]["preparation_audit"]["fit_scale"] == 0.166667
     assert completed.plotter_run_details["preparation"]["preparation_audit"]["placement_origin_x_mm"] == 20.0
     assert completed.plotter_run_details["preparation"]["preparation_audit"]["content_max_x_mm"] == 180.0
     assert completed.plotter_run_details["preparation"]["preparation_audit"]["prepared_within_drawable_area"] is True
+    assert completed.plotter_run_details["preparation"]["preparation_audit"]["source_content_left_ratio"] == 0.083333
+    assert completed.plotter_run_details["preparation"]["preparation_audit"]["source_content_top_ratio"] == 0.111111
 
 
 def test_plot_workflow_service_fails_before_capture_on_plot_error(tmp_path):
@@ -187,6 +267,7 @@ def test_plot_workflow_service_fails_before_capture_on_plot_error(tmp_path):
     assert failed.observed_result is None
     assert failed.stage_states["plot"].status == "failed"
     assert failed.stage_states["capture"].status == "pending"
+    assert failed.stage_states["capture_review"].status == "pending"
 
 
 def test_plot_workflow_service_fails_after_plot_on_camera_error(tmp_path):
@@ -205,6 +286,7 @@ def test_plot_workflow_service_fails_after_plot_on_camera_error(tmp_path):
     assert failed.observed_result is None
     assert failed.stage_states["plot"].status == "completed"
     assert failed.stage_states["capture"].status == "failed"
+    assert failed.stage_states["capture_review"].status == "pending"
     assert failed.error == "Mock camera failed to capture."
 
 
@@ -222,6 +304,7 @@ def test_plot_workflow_service_skips_capture_for_diagnostic_run(tmp_path):
     assert completed.capture is None
     assert completed.observed_result is None
     assert completed.stage_states["capture"].status == "completed"
+    assert completed.stage_states["capture_review"].status == "pending"
     assert completed.camera_run_details["capture_mode"] == "skip"
 
 
@@ -232,7 +315,12 @@ def test_plot_workflow_service_persists_real_camera_capture(tmp_path):
     )
 
     run = service.create_run(asset.id)
-    completed = _wait_for_terminal_run(service, run.id)
+    current = _wait_for_run_status(service, run.id, {"completed", "awaiting_capture_review"})
+    if current.status == "awaiting_capture_review":
+        service.accept_capture_review(run.id)
+        completed = _wait_for_terminal_run(service, run.id)
+    else:
+        completed = current
 
     assert completed.status == "completed"
     assert completed.capture is not None
@@ -241,8 +329,141 @@ def test_plot_workflow_service_persists_real_camera_capture(tmp_path):
     assert completed.capture.public_url.endswith(".jpg")
     assert completed.observed_result.capture.mime_type == "image/jpeg"
     assert completed.observed_result.camera_driver == "camerabridge"
+    assert completed.capture.normalized is not None
+    assert completed.capture.normalized.rectified_grayscale_url.endswith(".png")
     assert completed.camera_run_details["driver"] == "camerabridge"
     assert completed.camera_run_details["resolution"] == "640x480"
+
+
+def test_plot_workflow_service_pauses_for_capture_review_on_low_confidence(tmp_path):
+    service = _build_service(tmp_path, camera=LowConfidenceCamera())
+    asset = service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+
+    run = service.create_run(asset.id)
+    pending = _wait_for_run_status(service, run.id, {"awaiting_capture_review"})
+
+    assert pending.capture is not None
+    assert pending.capture.normalized is None
+    assert pending.capture.review is not None
+    assert pending.capture.review.review_required is True
+    assert pending.capture.review.review_status == "pending"
+    assert pending.capture.review.confirmed_corners is None
+    assert pending.stage_states["capture"].status == "completed"
+    assert pending.stage_states["capture_review"].status == "in_progress"
+
+
+def test_plot_workflow_service_accepts_proposed_capture_review_and_completes(tmp_path):
+    service = _build_service(tmp_path, camera=LowConfidenceCamera())
+    asset = service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+
+    run = service.create_run(asset.id)
+    pending = _wait_for_run_status(service, run.id, {"awaiting_capture_review"})
+    response = service.accept_capture_review(pending.id)
+    completed = _wait_for_terminal_run(service, run.id)
+
+    assert response.run.status in {"capturing", "completed"}
+    assert completed.status == "completed"
+    assert completed.capture is not None
+    assert completed.capture.normalized is not None
+    assert completed.capture.review is not None
+    assert completed.capture.review.review_status == "confirmed"
+    assert completed.capture.review.confirmation_source == "auto"
+    assert completed.capture.review.confirmed_corners == completed.capture.review.proposed_corners
+
+
+def test_plot_workflow_service_uses_adjusted_capture_review_corners(tmp_path):
+    service = _build_service(tmp_path, camera=LowConfidenceCamera())
+    asset = service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+
+    run = service.create_run(asset.id)
+    pending = _wait_for_run_status(service, run.id, {"awaiting_capture_review"})
+    assert pending.capture is not None
+    assert pending.capture.review is not None
+    proposed = pending.capture.review.proposed_corners
+    adjusted = proposed.model_copy(
+        update={
+            "top_left": (proposed.top_left[0] + 12.0, proposed.top_left[1] + 8.0),
+            "bottom_left": (proposed.bottom_left[0] + 12.0, proposed.bottom_left[1] - 10.0),
+        }
+    )
+
+    service.adjust_capture_review(
+        pending.id,
+        PlotRunCaptureReviewAdjustRequest(corners=adjusted),
+    )
+    completed = _wait_for_terminal_run(service, run.id)
+
+    assert completed.capture is not None
+    assert completed.capture.review is not None
+    assert completed.capture.review.confirmation_source == "adjusted"
+    assert completed.capture.review.confirmed_corners == adjusted
+    assert completed.capture.normalized is not None
+    assert completed.capture.normalized.metadata.corners.top_left == adjusted.top_left
+
+
+def test_plot_workflow_service_reuses_last_confirmed_capture_quad_for_matching_scope(tmp_path):
+    service = _build_service(tmp_path, camera=LowConfidenceCamera())
+    asset = service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+
+    first_run = service.create_run(asset.id)
+    first_pending = _wait_for_run_status(service, first_run.id, {"awaiting_capture_review"})
+    assert first_pending.capture is not None
+    assert first_pending.capture.review is not None
+    first_adjusted = first_pending.capture.review.proposed_corners.model_copy(
+        update={
+            "top_left": (40.0, 30.0),
+            "top_right": (590.0, 32.0),
+            "bottom_right": (590.0, 445.0),
+            "bottom_left": (42.0, 448.0),
+        }
+    )
+    service.adjust_capture_review(
+        first_pending.id,
+        PlotRunCaptureReviewAdjustRequest(corners=first_adjusted),
+    )
+    _wait_for_terminal_run(service, first_run.id)
+
+    second_run = service.create_run(asset.id)
+    second_pending = _wait_for_run_status(service, second_run.id, {"awaiting_capture_review"})
+    assert second_pending.capture is not None
+    assert second_pending.capture.review is not None
+    assert second_pending.capture.review.reuse_last_available is True
+
+    service.reuse_last_capture_review(second_pending.id)
+    second_completed = _wait_for_terminal_run(service, second_run.id)
+
+    assert second_completed.capture is not None
+    assert second_completed.capture.review is not None
+    assert second_completed.capture.review.confirmation_source == "reused_last"
+    assert second_completed.capture.review.confirmed_corners == first_adjusted
+
+
+def test_plot_workflow_service_hides_reuse_last_for_workspace_mismatch(tmp_path):
+    first_service = _build_service(tmp_path, camera=LowConfidenceCamera())
+    asset = first_service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+
+    first_run = first_service.create_run(asset.id)
+    first_pending = _wait_for_run_status(first_service, first_run.id, {"awaiting_capture_review"})
+    assert first_pending.capture is not None
+    assert first_pending.capture.review is not None
+    first_service.adjust_capture_review(
+        first_pending.id,
+        PlotRunCaptureReviewAdjustRequest(corners=first_pending.capture.review.proposed_corners),
+    )
+    _wait_for_terminal_run(first_service, first_run.id)
+
+    second_service = _build_service(
+        tmp_path,
+        camera=LowConfidenceCamera(),
+        config_overrides={"plot_margin_left_mm": 24.0},
+    )
+    second_asset = second_service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+    second_run = second_service.create_run(second_asset.id)
+    second_pending = _wait_for_run_status(second_service, second_run.id, {"awaiting_capture_review"})
+
+    assert second_pending.capture is not None
+    assert second_pending.capture.review is not None
+    assert second_pending.capture.review.reuse_last_available is False
 
 
 def test_builtin_patterns_use_explicit_physical_units(tmp_path):

--- a/apps/api/tests/test_services.py
+++ b/apps/api/tests/test_services.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import threading
 import time
 
+import cv2
+import numpy as np
 import pytest
 
 from learn_to_draw_api.adapters.axidraw_models import resolve_axidraw_model_info
@@ -15,6 +17,8 @@ from learn_to_draw_api.models import (
     HardwareUnavailableError,
     InvalidArtifactError,
 )
+from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
+from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.hardware import HardwareService
 from learn_to_draw_api.services.plotter_calibration import (
@@ -56,11 +60,35 @@ class StubRealCamera:
             capture_id="real-capture",
             timestamp=MockCamera(capture_delay_s=0).capture().timestamp,
             filename="real-capture.jpg",
-            content=b"jpeg-bytes",
+            content=_jpeg_bytes(),
             media_type="image/jpeg",
             width=640,
             height=480,
         )
+
+
+def _jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    image = np.full((height, width, 3), 245, dtype=np.uint8)
+    cv2.rectangle(image, (80, 60), (width - 80, height - 60), (30, 30, 30), 6)
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
+def _capture_service(store: CaptureStore) -> CaptureService:
+    return CaptureService(
+        store=store,
+        normalization_service=CaptureNormalizationService(),
+    )
+
+
+def _wait_for_latest_normalized(store: CaptureStore, capture_id: str):
+    for _ in range(200):
+        latest = store.latest()
+        if latest is not None and latest.id == capture_id and latest.normalized is not None:
+            return latest
+        time.sleep(0.01)
+    raise AssertionError("Capture normalization did not finish in time.")
 
 
 def build_calibration_service(tmp_path):
@@ -115,9 +143,9 @@ def test_capture_store_persists_latest_capture(tmp_path):
     artifact = camera.capture()
     saved = store.save(artifact)
 
-    assert (tmp_path / f"{saved.id}.svg").exists()
+    assert (tmp_path / f"{saved.id}.png").exists()
     assert store.latest() is not None
-    assert store.latest().public_url == f"/captures/{saved.id}.svg"
+    assert store.latest().public_url == f"/captures/{saved.id}.png"
 
     reloaded_store = CaptureStore(tmp_path, "/captures")
     assert reloaded_store.latest() is not None
@@ -146,10 +174,12 @@ def test_capture_store_normalizes_public_url_independently_of_disk_path(tmp_path
 
 
 def test_hardware_service_runs_walk_home_and_capture(tmp_path):
+    capture_store = CaptureStore(tmp_path, "/captures")
     service = HardwareService(
         plotter=MockPlotter(origin_delay_s=0),
         camera=MockCamera(capture_delay_s=0),
-        capture_store=CaptureStore(tmp_path, "/captures"),
+        capture_store=capture_store,
+        capture_service=_capture_service(capture_store),
         calibration_service=build_calibration_service(tmp_path),
         device_settings_service=build_device_settings_service(tmp_path),
         workspace_service=build_workspace_service(tmp_path),
@@ -160,15 +190,25 @@ def test_hardware_service_runs_walk_home_and_capture(tmp_path):
     capture_response = service.capture_image()
 
     assert origin_response.status.details["position"] == "walk_home"
-    assert capture_response.capture.public_url.endswith(".svg")
+    assert capture_response.capture.public_url.endswith(".png")
+    assert capture_response.capture.normalized is None
     assert service.latest_capture().capture.id == capture_response.capture.id
+    normalized = _wait_for_latest_normalized(capture_store, capture_response.capture.id)
+    assert normalized.normalized is not None
+    assert normalized.normalized.metadata.target_frame_source == "workspace_drawable_area"
+    assert normalized.normalized.metadata.frame is not None
+    assert normalized.normalized.metadata.frame.kind == "page_aligned"
+    assert normalized.normalized.metadata.frame.page_width_mm == 210.0
+    assert normalized.normalized.metadata.frame.page_height_mm == 297.0
 
 
 def test_hardware_service_persists_real_camera_capture_metadata(tmp_path):
+    capture_store = CaptureStore(tmp_path, "/captures")
     service = HardwareService(
         plotter=MockPlotter(origin_delay_s=0),
         camera=StubRealCamera(),
-        capture_store=CaptureStore(tmp_path, "/captures"),
+        capture_store=capture_store,
+        capture_service=_capture_service(capture_store),
         calibration_service=build_calibration_service(tmp_path),
         device_settings_service=build_device_settings_service(tmp_path),
         workspace_service=build_workspace_service(tmp_path),
@@ -181,13 +221,19 @@ def test_hardware_service_persists_real_camera_capture_metadata(tmp_path):
     assert capture_response.capture.mime_type == "image/jpeg"
     assert capture_response.capture.width == 640
     assert capture_response.capture.height == 480
+    normalized = _wait_for_latest_normalized(capture_store, capture_response.capture.id)
+    assert normalized.normalized is not None
+    assert normalized.normalized.metadata.frame is not None
+    assert normalized.normalized.metadata.frame.kind == "page_aligned"
 
 
 def test_hardware_service_rejects_concurrent_plotter_actions(tmp_path):
+    capture_store = CaptureStore(tmp_path, "/captures")
     service = HardwareService(
         plotter=MockPlotter(origin_delay_s=0.2),
         camera=MockCamera(capture_delay_s=0),
-        capture_store=CaptureStore(tmp_path, "/captures"),
+        capture_store=capture_store,
+        capture_service=_capture_service(capture_store),
         calibration_service=build_calibration_service(tmp_path),
         device_settings_service=build_device_settings_service(tmp_path),
         workspace_service=build_workspace_service(tmp_path),

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -789,6 +789,50 @@ button {
   word-break: break-all;
 }
 
+.latest-capture-panel header {
+  align-items: flex-start;
+}
+
+.latest-capture-panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.latest-capture-frame {
+  padding: 18px;
+  background:
+    radial-gradient(circle at top, rgba(127, 111, 74, 0.1), transparent 42%),
+    rgba(255, 248, 238, 0.03);
+}
+
+.latest-capture-frame img {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: min(72vh, 820px);
+  object-fit: contain;
+}
+
+.latest-capture-meta-item {
+  background: rgba(255, 248, 238, 0.07);
+  border-color: rgba(214, 199, 175, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 248, 238, 0.04);
+}
+
+.latest-capture-meta-item span {
+  color: #b6ab99;
+}
+
+.latest-capture-meta-item strong {
+  color: #f4efe7;
+}
+
+.latest-capture-meta-path {
+  color: #a79c8d;
+}
+
 .workflow-grid {
   display: grid;
   grid-template-columns: 1.05fr 1fr;
@@ -1033,6 +1077,23 @@ button {
 
   .run-list-meta {
     justify-content: start;
+  }
+
+  .capture-review-modal {
+    padding: 12px;
+  }
+
+  .capture-review-modal-panel {
+    width: 100%;
+    height: min(100vh - 24px, 1000px);
+    max-height: calc(100vh - 24px);
+    box-sizing: border-box;
+    padding: 14px;
+  }
+
+  .capture-review-modal-header,
+  .capture-review-modal-footer {
+    display: grid;
   }
 
   .compact-details strong {
@@ -1791,9 +1852,47 @@ button {
   height: 100%;
 }
 
+.artifact-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
 .artifact-card h3 {
   margin: 0;
   font-size: 1.12rem;
+}
+
+.artifact-card-actions {
+  display: flex;
+  justify-content: end;
+}
+
+.artifact-variant-selector {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 248, 238, 0.04);
+}
+
+.artifact-variant-button {
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.artifact-variant-button-active {
+  background: rgba(208, 161, 95, 0.18);
+  color: #f4efe7;
 }
 
 .artifact-footer {
@@ -1957,6 +2056,159 @@ button {
   width: 100%;
   height: 100%;
   object-fit: contain;
+}
+
+.artifact-frame-review {
+  display: block;
+}
+
+.capture-review-shell {
+  display: grid;
+  gap: 12px;
+  height: 100%;
+}
+
+.capture-review-frame {
+  min-height: 0;
+  height: 100%;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(208, 161, 95, 0.18);
+  background: rgba(14, 14, 13, 0.9);
+}
+
+.capture-review-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+}
+
+.capture-review-polygon {
+  fill: rgba(255, 211, 138, 0.08);
+  stroke: #ffc55f;
+  stroke-width: 3;
+}
+
+.capture-review-handle {
+  fill: #ffc55f;
+  stroke: rgba(25, 22, 18, 0.95);
+  stroke-width: 2;
+}
+
+.capture-review-handle-interactive {
+  cursor: grab;
+}
+
+.capture-review-label {
+  fill: #fff6ec;
+  font-size: 22px;
+  font-weight: 700;
+  paint-order: stroke;
+  stroke: rgba(16, 14, 12, 0.85);
+  stroke-width: 3px;
+}
+
+.capture-review-meta {
+  display: grid;
+  gap: 4px;
+}
+
+.capture-review-caption {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+
+.capture-review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.capture-review-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+
+.capture-review-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 8, 10, 0.82);
+  backdrop-filter: blur(8px);
+}
+
+.capture-review-modal-panel {
+  position: relative;
+  z-index: 1;
+  width: min(96vw, 1720px);
+  height: min(94vh, 1180px);
+  max-height: calc(100vh - 40px);
+  box-sizing: border-box;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(208, 161, 95, 0.24);
+  background:
+    linear-gradient(180deg, rgba(29, 26, 22, 0.98), rgba(17, 16, 14, 0.98)),
+    rgba(16, 14, 12, 0.96);
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(255, 232, 201, 0.03);
+}
+
+.capture-review-modal-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.capture-review-modal-header h3 {
+  margin: 0 0 6px;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+}
+
+.capture-review-modal-header p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.capture-review-modal-stage {
+  display: grid;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.capture-review-frame-modal {
+  height: 100%;
+  min-height: 0;
+  border-radius: 20px;
+}
+
+.capture-review-modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  position: sticky;
+  bottom: 0;
+  padding-top: 12px;
+  border-top: 1px solid rgba(208, 161, 95, 0.14);
+  background:
+    linear-gradient(180deg, rgba(17, 16, 14, 0), rgba(17, 16, 14, 0.96) 22%),
+    rgba(17, 16, 14, 0.96);
+}
+
+.capture-review-modal-footer .capture-review-caption {
+  max-width: 40ch;
 }
 
 .source-inspect-toggle {

--- a/apps/web/src/components/LatestCapturePanel.tsx
+++ b/apps/web/src/components/LatestCapturePanel.tsx
@@ -1,4 +1,14 @@
+import { useEffect, useMemo, useState } from "react";
+
 import type { CaptureMetadata } from "../types/hardware";
+
+type CaptureVariantKey = "raw" | "normalized" | "debug";
+
+interface CaptureVariantOption {
+  key: CaptureVariantKey;
+  label: string;
+  url: string;
+}
 
 interface LatestCapturePanelProps {
   capture: CaptureMetadata | null;
@@ -9,8 +19,46 @@ export function LatestCapturePanel({
   capture,
   refreshing,
 }: LatestCapturePanelProps) {
+  const variantOptions = useMemo(() => {
+    if (!capture) {
+      return [] as CaptureVariantOption[];
+    }
+    const options: CaptureVariantOption[] = [
+      {
+        key: "raw",
+        label: "Raw",
+        url: capture.public_url,
+      },
+    ];
+    if (capture.normalized) {
+      options.push(
+        {
+          key: "normalized",
+          label: "Normalized",
+          url: capture.normalized.rectified_grayscale_url,
+        },
+        {
+          key: "debug",
+          label: "Debug",
+          url: capture.normalized.debug_overlay_url,
+        },
+      );
+    }
+    return options;
+  }, [capture]);
+  const defaultVariant: CaptureVariantKey = capture?.normalized ? "normalized" : "raw";
+  const [variant, setVariant] = useState<CaptureVariantKey>(defaultVariant);
+
+  useEffect(() => {
+    setVariant(defaultVariant);
+  }, [defaultVariant, capture?.id]);
+
+  const selectedVariant =
+    variantOptions.find((option) => option.key === variant) ?? variantOptions[0] ?? null;
+  const footerLabel = selectedVariant ? `${selectedVariant.label} variant` : null;
+
   return (
-    <section className="capture-panel">
+    <section className="capture-panel latest-capture-panel">
       <header>
         <div>
           <h2>Latest Capture</h2>
@@ -20,16 +68,41 @@ export function LatestCapturePanel({
               : "No captures saved yet"}
           </div>
         </div>
-        <button type="button" className="button-secondary" disabled>
-          {refreshing ? "Refreshing..." : "Disk-backed"}
-        </button>
+        <div className="capture-panel-actions latest-capture-panel-actions">
+          {variantOptions.length > 1 ? (
+            <div className="artifact-variant-selector" role="group" aria-label="Latest capture variant">
+              {variantOptions.map((option) => (
+                <button
+                  key={option.key}
+                  type="button"
+                  className={
+                    option.key === variant
+                      ? "artifact-variant-button artifact-variant-button-active"
+                      : "artifact-variant-button"
+                  }
+                  aria-pressed={option.key === variant}
+                  onClick={() => setVariant(option.key)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <button type="button" className="button-secondary" disabled>
+            {refreshing ? "Refreshing..." : "Disk-backed"}
+          </button>
+        </div>
       </header>
 
-      <div className="capture-frame">
+      <div className="capture-frame latest-capture-frame">
         {capture ? (
           <img
-            src={capture.public_url}
-            alt={`Latest camera capture ${capture.id}`}
+            src={selectedVariant?.url ?? capture.public_url}
+            alt={
+              selectedVariant
+                ? `${selectedVariant.label.toLowerCase()} latest camera capture ${capture.id}`
+                : `Latest camera capture ${capture.id}`
+            }
           />
         ) : (
           <div className="empty-state">
@@ -39,24 +112,30 @@ export function LatestCapturePanel({
       </div>
 
       {capture ? (
-        <div className="capture-meta">
-          <div className="capture-meta-grid">
-            <div className="capture-meta-item">
+        <div className="capture-meta latest-capture-meta">
+          <div className="capture-meta-grid latest-capture-meta-grid">
+            <div className="capture-meta-item latest-capture-meta-item">
               <span>Saved at</span>
               <strong>{new Date(capture.timestamp).toLocaleString()}</strong>
             </div>
-            <div className="capture-meta-item">
+            <div className="capture-meta-item latest-capture-meta-item">
               <span>Dimensions</span>
               <strong>
                 {capture.width} x {capture.height}
               </strong>
             </div>
-            <div className="capture-meta-item">
+            <div className="capture-meta-item latest-capture-meta-item">
               <span>Format</span>
               <strong>{capture.mime_type}</strong>
             </div>
+            {footerLabel ? (
+              <div className="capture-meta-item latest-capture-meta-item">
+                <span>Viewing</span>
+                <strong>{footerLabel}</strong>
+              </div>
+            ) : null}
           </div>
-          <p className="footer-note capture-meta-path">{capture.file_path}</p>
+          <p className="footer-note capture-meta-path latest-capture-meta-path">{capture.file_path}</p>
         </div>
       ) : null}
     </section>

--- a/apps/web/src/features/hardware/HardwareDashboard.tsx
+++ b/apps/web/src/features/hardware/HardwareDashboard.tsx
@@ -165,6 +165,8 @@ export function HardwareDashboard() {
           plotterCalibration={plotterCalibration}
           plotterDevice={plotterDevice}
           plotterWorkspace={plotterWorkspace}
+          latestCapture={latestCapture}
+          refreshing={refreshing}
           actionName={actionName}
           actionFeedback={actionFeedback}
           walkHome={walkHome}

--- a/apps/web/src/features/hardware/MachineSetupPanel.tsx
+++ b/apps/web/src/features/hardware/MachineSetupPanel.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
 
+import { LatestCapturePanel } from "../../components/LatestCapturePanel";
 import { StatusPill } from "../../components/StatusPill";
 import type {
+  CaptureMetadata,
   HardwareStatus,
   PlotterCalibration,
   PlotterDeviceSettings,
@@ -33,6 +35,8 @@ interface MachineSetupPanelProps {
   plotterCalibration: PlotterCalibration | null;
   plotterDevice: PlotterDeviceSettings | null;
   plotterWorkspace: PlotterWorkspace | null;
+  latestCapture: CaptureMetadata | null;
+  refreshing: boolean;
   actionName: ActionName;
   actionFeedback: ActionFeedback | null;
   walkHome: () => Promise<void>;
@@ -117,6 +121,8 @@ export function MachineSetupPanel({
   plotterCalibration,
   plotterDevice,
   plotterWorkspace,
+  latestCapture,
+  refreshing,
   actionName,
   actionFeedback,
   walkHome,
@@ -428,6 +434,8 @@ export function MachineSetupPanel({
           capture={capture}
           setCameraDevice={setCameraDevice}
         />
+
+        <LatestCapturePanel capture={latestCapture} refreshing={refreshing} />
 
         <details className="panel machine-disclosure">
           <summary>Diagnostics</summary>

--- a/apps/web/src/features/plot-workflow/PlotWorkflowPanel.tsx
+++ b/apps/web/src/features/plot-workflow/PlotWorkflowPanel.tsx
@@ -1,7 +1,13 @@
-import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ChangeEvent, type ReactNode } from "react";
 
 import { fetchPlotRun } from "../../lib/api";
-import type { CaptureMetadata, HardwareStatus, PlotterWorkspace } from "../../types/hardware";
+import type {
+  CaptureMetadata,
+  CaptureReview,
+  HardwareStatus,
+  NormalizationCorners,
+  PlotterWorkspace,
+} from "../../types/hardware";
 import type { PlotAsset, PlotRun, PlotRunSummary } from "../../types/plotting";
 import {
   formatPhysicalSize,
@@ -17,6 +23,8 @@ import {
 import type { PlotWorkflowController } from "./usePlotWorkflow";
 
 type PlotWorkflowMode = "workflow" | "history";
+type CaptureVariantKey = "raw" | "normalized" | "debug";
+type CornerKey = keyof NormalizationCorners;
 
 interface PlotWorkflowPanelProps {
   controller: PlotWorkflowController;
@@ -29,6 +37,12 @@ interface PlotWorkflowPanelProps {
 interface RunDetailRow {
   label: string;
   value: string;
+}
+
+interface CaptureVariantOption {
+  key: CaptureVariantKey;
+  label: string;
+  url: string;
 }
 
 function resolvePreparedArtifactUrl(publicUrl: string) {
@@ -154,6 +168,86 @@ function getPreparationDetails(run: PlotRun | null) {
   ].filter((detail): detail is RunDetailRow => detail !== null);
 }
 
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function getPreparedPageAspectRatio(run: PlotRun | null): number | null {
+  if (!run || !isRecord(run.plotter_run_details)) {
+    return null;
+  }
+  const preparation = isRecord(run.plotter_run_details.preparation)
+    ? run.plotter_run_details.preparation
+    : null;
+  if (!preparation) {
+    return null;
+  }
+
+  const pageWidthMm = asFiniteNumber(preparation.page_width_mm);
+  const pageHeightMm = asFiniteNumber(preparation.page_height_mm);
+  if (
+    pageWidthMm === null ||
+    pageHeightMm === null ||
+    pageWidthMm <= 0 ||
+    pageHeightMm <= 0
+  ) {
+    return null;
+  }
+  return pageWidthMm / pageHeightMm;
+}
+
+function getSelectedVariantFooter({
+  capture,
+  selectedVariant,
+  resultFooter,
+}: {
+  capture: CaptureMetadata | null;
+  selectedVariant: CaptureVariantOption | null;
+  resultFooter: string | null;
+}) {
+  if (
+    selectedVariant?.key === "normalized" &&
+    capture?.normalized?.metadata.frame?.kind !== "page_aligned"
+  ) {
+    return resultFooter ? `${selectedVariant.label} · Legacy frame · ${resultFooter}` : "Normalized · Legacy frame";
+  }
+  if (selectedVariant && resultFooter) {
+    return `${selectedVariant.label} · ${resultFooter}`;
+  }
+  if (selectedVariant) {
+    return selectedVariant.label;
+  }
+  return resultFooter;
+}
+
+function getNormalizedPageAspectRatio(capture: CaptureMetadata | null): number | null {
+  const frame = capture?.normalized?.metadata.frame;
+  if (!frame || frame.kind !== "page_aligned" || frame.page_width_mm <= 0 || frame.page_height_mm <= 0) {
+    return null;
+  }
+  return frame.page_width_mm / frame.page_height_mm;
+}
+
+function getSelectedVariantFrameStyle({
+  capture,
+  selectedVariant,
+}: {
+  capture: CaptureMetadata | null;
+  selectedVariant: CaptureVariantOption | null;
+}): CSSProperties | undefined {
+  if (selectedVariant?.key === "normalized") {
+    const normalizedAspectRatio = getNormalizedPageAspectRatio(capture);
+    if (normalizedAspectRatio !== null) {
+      return { aspectRatio: `${normalizedAspectRatio}` };
+    }
+    const legacyAspectRatio = capture?.normalized?.metadata.output.aspect_ratio;
+    if (legacyAspectRatio) {
+      return { aspectRatio: `${legacyAspectRatio}` };
+    }
+  }
+  return undefined;
+}
+
 function getCollapsedRowMeta(summary: PlotRunSummary, includeTimestamp: boolean) {
   const tokens = [formatRunKindLabel(summary.asset_kind)];
   if (summary.purpose !== "normal") {
@@ -191,6 +285,39 @@ function getResultFooter({
   return null;
 }
 
+function getCaptureVariantOptions(capture: CaptureMetadata | null): CaptureVariantOption[] {
+  if (!capture) {
+    return [];
+  }
+
+  const options: CaptureVariantOption[] = [
+    {
+      key: "raw",
+      label: "Raw",
+      url: capture.public_url,
+    },
+  ];
+  if (capture.normalized) {
+    options.push(
+      {
+        key: "normalized",
+        label: "Normalized",
+        url: capture.normalized.rectified_grayscale_url,
+      },
+      {
+        key: "debug",
+        label: "Debug",
+        url: capture.normalized.debug_overlay_url,
+      },
+    );
+  }
+  return options;
+}
+
+function getDefaultCaptureVariant(capture: CaptureMetadata | null): CaptureVariantKey {
+  return capture?.normalized ? "normalized" : "raw";
+}
+
 function ArtifactCard({
   className,
   title,
@@ -198,6 +325,9 @@ function ArtifactCard({
   alt,
   emptyMessage,
   footer,
+  headerActions,
+  frameStyle,
+  frameContent,
 }: {
   className?: string;
   title: string;
@@ -205,14 +335,20 @@ function ArtifactCard({
   alt?: string;
   emptyMessage: string;
   footer?: string | null;
+  headerActions?: ReactNode;
+  frameStyle?: CSSProperties;
+  frameContent?: ReactNode;
 }) {
   return (
     <article className={className ? `artifact-card ${className}` : "artifact-card"}>
       <header className="artifact-card-header">
         <h3>{title}</h3>
+        {headerActions ? <div className="artifact-card-actions">{headerActions}</div> : null}
       </header>
-      <div className="artifact-frame">
-        {imageUrl ? (
+      <div className="artifact-frame" style={frameStyle}>
+        {frameContent ? (
+          frameContent
+        ) : imageUrl ? (
           <img src={imageUrl} alt={alt ?? title} />
         ) : (
           <div className="empty-state">{emptyMessage}</div>
@@ -220,6 +356,347 @@ function ArtifactCard({
       </div>
       {footer ? <p className="artifact-footer">{footer}</p> : null}
     </article>
+  );
+}
+
+function cornersEqual(left: NormalizationCorners, right: NormalizationCorners) {
+  return (
+    left.top_left[0] === right.top_left[0] &&
+    left.top_left[1] === right.top_left[1] &&
+    left.top_right[0] === right.top_right[0] &&
+    left.top_right[1] === right.top_right[1] &&
+    left.bottom_right[0] === right.bottom_right[0] &&
+    left.bottom_right[1] === right.bottom_right[1] &&
+    left.bottom_left[0] === right.bottom_left[0] &&
+    left.bottom_left[1] === right.bottom_left[1]
+  );
+}
+
+function cloneCorners(corners: NormalizationCorners): NormalizationCorners {
+  return {
+    top_left: [...corners.top_left] as [number, number],
+    top_right: [...corners.top_right] as [number, number],
+    bottom_right: [...corners.bottom_right] as [number, number],
+    bottom_left: [...corners.bottom_left] as [number, number],
+  };
+}
+
+function CaptureReviewEditor({
+  capture,
+  review,
+  busy,
+  onAccept,
+  onAdjust,
+  onReuseLast,
+}: {
+  capture: CaptureMetadata;
+  review: CaptureReview;
+  busy: boolean;
+  onAccept: () => Promise<void>;
+  onAdjust: (corners: NormalizationCorners) => Promise<void>;
+  onReuseLast: () => Promise<void>;
+}) {
+  const [draftCorners, setDraftCorners] = useState<NormalizationCorners>(() =>
+    cloneCorners(review.proposed_corners),
+  );
+  const [activeCorner, setActiveCorner] = useState<CornerKey | null>(null);
+  const [isAdjusting, setIsAdjusting] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const previousCaptureIdRef = useRef(capture.id);
+  const previousProposalSignatureRef = useRef(JSON.stringify(review.proposed_corners));
+  const proposalSignature = JSON.stringify(review.proposed_corners);
+
+  useEffect(() => {
+    const captureChanged = previousCaptureIdRef.current !== capture.id;
+    const proposalChanged = previousProposalSignatureRef.current !== proposalSignature;
+    if (captureChanged || (proposalChanged && !isAdjusting && !isDirty && activeCorner === null)) {
+      setDraftCorners(cloneCorners(review.proposed_corners));
+      setActiveCorner(null);
+      setIsDirty(false);
+    }
+    if (captureChanged) {
+      setIsAdjusting(false);
+    }
+    previousCaptureIdRef.current = capture.id;
+    previousProposalSignatureRef.current = proposalSignature;
+  }, [activeCorner, capture.id, isAdjusting, isDirty, proposalSignature, review.proposed_corners]);
+
+  useEffect(() => {
+    if (!isAdjusting || typeof document === "undefined") {
+      return undefined;
+    }
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isAdjusting]);
+
+  const hasAdjustment = !cornersEqual(draftCorners, review.proposed_corners);
+
+  function updateCorner(clientX: number, clientY: number, key: CornerKey) {
+    const svg = svgRef.current;
+    if (!svg) {
+      return;
+    }
+    const rect = svg.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      return;
+    }
+    const x = Math.max(0, Math.min(capture.width, ((clientX - rect.left) / rect.width) * capture.width));
+    const y = Math.max(0, Math.min(capture.height, ((clientY - rect.top) / rect.height) * capture.height));
+    setDraftCorners((current) => ({
+      ...current,
+      [key]: [Number(x.toFixed(1)), Number(y.toFixed(1))],
+    }));
+    setIsDirty(true);
+  }
+
+  function resetDraftCorners() {
+    setDraftCorners(cloneCorners(review.proposed_corners));
+    setActiveCorner(null);
+    setIsDirty(false);
+  }
+
+  function openAdjustMode() {
+    resetDraftCorners();
+    setIsAdjusting(true);
+  }
+
+  function closeAdjustMode() {
+    resetDraftCorners();
+    setIsAdjusting(false);
+  }
+
+  function renderCaptureCanvas(interactive: boolean) {
+    return (
+      <div
+        className={interactive ? "capture-review-frame capture-review-frame-modal" : "capture-review-frame"}
+      >
+        <svg
+          ref={interactive ? svgRef : null}
+          viewBox={`0 0 ${capture.width} ${capture.height}`}
+          className="capture-review-svg"
+          onPointerMove={(event) => {
+            if (interactive && activeCorner) {
+              updateCorner(event.clientX, event.clientY, activeCorner);
+            }
+          }}
+          onPointerUp={() => {
+            if (interactive) {
+              setActiveCorner(null);
+            }
+          }}
+          onPointerCancel={() => {
+            if (interactive) {
+              setActiveCorner(null);
+            }
+          }}
+          onPointerLeave={() => {
+            if (interactive) {
+              setActiveCorner(null);
+            }
+          }}
+        >
+          <image href={capture.public_url} x="0" y="0" width={capture.width} height={capture.height} />
+          <polygon
+            className="capture-review-polygon"
+            points={[
+              draftCorners.top_left.join(","),
+              draftCorners.top_right.join(","),
+              draftCorners.bottom_right.join(","),
+              draftCorners.bottom_left.join(","),
+            ].join(" ")}
+          />
+          {(
+            [
+              ["top_left", draftCorners.top_left, "TL"],
+              ["top_right", draftCorners.top_right, "TR"],
+              ["bottom_right", draftCorners.bottom_right, "BR"],
+              ["bottom_left", draftCorners.bottom_left, "BL"],
+            ] as const
+          ).map(([key, point, label]) => (
+            <g key={key}>
+              <circle
+                className={
+                  interactive
+                    ? "capture-review-handle capture-review-handle-interactive"
+                    : "capture-review-handle"
+                }
+                cx={point[0]}
+                cy={point[1]}
+                r={interactive ? 18 : 12}
+                onPointerDown={
+                  interactive
+                    ? (event) => {
+                        event.preventDefault();
+                        event.currentTarget.setPointerCapture(event.pointerId);
+                        setActiveCorner(key);
+                        updateCorner(event.clientX, event.clientY, key);
+                      }
+                    : undefined
+                }
+              />
+              <text
+                x={point[0] + (interactive ? 22 : 14)}
+                y={point[1] - (interactive ? 22 : 14)}
+                className="capture-review-label"
+              >
+                {label}
+              </text>
+            </g>
+          ))}
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="capture-review-shell">
+        {renderCaptureCanvas(false)}
+        <div className="capture-review-meta">
+          <p className="capture-review-caption">
+            {`Detection: ${review.detector_method} · confidence ${review.detector_confidence.toFixed(2)}`}
+          </p>
+          <p className="capture-review-caption">
+            Accept when the suggested quad is already usable, or open adjust mode to fine-tune the page corners.
+          </p>
+        </div>
+        <div className="capture-review-actions">
+          <button
+            type="button"
+            className="artifact-variant-button artifact-variant-button-active"
+            disabled={busy}
+            onClick={() => void onAccept()}
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            className="artifact-variant-button"
+            disabled={busy}
+            onClick={openAdjustMode}
+          >
+            Adjust
+          </button>
+          <button
+            type="button"
+            className="artifact-variant-button"
+            disabled={busy || !review.reuse_last_available}
+            onClick={() => void onReuseLast()}
+          >
+            Reuse last
+          </button>
+        </div>
+      </div>
+      {isAdjusting ? (
+        <div className="capture-review-modal" role="dialog" aria-modal="true" aria-label="Adjust capture corners">
+          <div
+            className="capture-review-modal-backdrop"
+            onClick={() => {
+              if (!busy) {
+                closeAdjustMode();
+              }
+            }}
+          />
+          <div className="capture-review-modal-panel">
+            <header className="capture-review-modal-header">
+              <div>
+                <h3>Adjust capture corners</h3>
+                <p>{`Drag each corner onto the paper edge, then apply the adjusted quad.`}</p>
+              </div>
+              <button type="button" className="button-ghost" onClick={closeAdjustMode} disabled={busy}>
+                Close
+              </button>
+            </header>
+            <div className="capture-review-modal-stage">{renderCaptureCanvas(true)}</div>
+            <div className="capture-review-modal-footer">
+              <p className="capture-review-caption">
+                {`Detection: ${review.detector_method} · confidence ${review.detector_confidence.toFixed(2)}`}
+              </p>
+              <div className="capture-review-actions">
+                <button type="button" className="artifact-variant-button" disabled={busy || !isDirty} onClick={resetDraftCorners}>
+                  Reset
+                </button>
+                <button
+                  type="button"
+                  className="artifact-variant-button"
+                  disabled={busy || !review.reuse_last_available}
+                  onClick={() => void onReuseLast()}
+                >
+                  Reuse last
+                </button>
+                <button
+                  type="button"
+                  className="artifact-variant-button artifact-variant-button-active"
+                  disabled={busy || !hasAdjustment}
+                  onClick={() => void onAdjust(draftCorners)}
+                >
+                  Apply adjusted quad
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function RunCaptureReview({
+  run,
+  preparedImageUrl,
+  preparedPageAspectRatio,
+  reviewCapture,
+  review,
+  reviewBusy,
+  onAccept,
+  onAdjust,
+  onReuseLast,
+}: {
+  run: PlotRun;
+  preparedImageUrl: string | null;
+  preparedPageAspectRatio: number | null;
+  reviewCapture: CaptureMetadata;
+  review: CaptureReview;
+  reviewBusy: boolean;
+  onAccept: () => Promise<void>;
+  onAdjust: (corners: NormalizationCorners) => Promise<void>;
+  onReuseLast: () => Promise<void>;
+}) {
+  const preparedFrameStyle =
+    preparedPageAspectRatio !== null ? { aspectRatio: `${preparedPageAspectRatio}` } : undefined;
+
+  return (
+    <div className="run-artifact-compare">
+      <ArtifactCard
+        className="artifact-card-prepared"
+        title="Prepared"
+        imageUrl={preparedImageUrl}
+        alt={`Prepared output for run ${run.id}`}
+        emptyMessage="Prepared output unavailable."
+        footer={run.asset.name}
+        frameStyle={preparedFrameStyle}
+      />
+      <article className="artifact-card artifact-card-result">
+        <header className="artifact-card-header">
+          <h3>Review capture</h3>
+        </header>
+        <div className="artifact-frame artifact-frame-review">
+          <CaptureReviewEditor
+            capture={reviewCapture}
+            review={review}
+            busy={reviewBusy}
+            onAccept={onAccept}
+            onAdjust={onAdjust}
+            onReuseLast={onReuseLast}
+          />
+        </div>
+        <p className="artifact-footer">Normalization will continue after you confirm the page corners.</p>
+      </article>
+    </div>
   );
 }
 
@@ -328,21 +805,48 @@ function RunArtifactCompare({
   preparedImageUrl,
   preparedAlt,
   preparedFooter,
-  resultImageUrl,
+  resultCapture,
   resultAlt,
   resultFooter,
   preparedEmptyMessage,
   resultEmptyMessage,
+  preparedPageAspectRatio,
 }: {
   preparedImageUrl: string | null;
   preparedAlt: string;
   preparedFooter: string | null;
-  resultImageUrl: string | null;
+  resultCapture: CaptureMetadata | null;
   resultAlt: string;
   resultFooter: string | null;
   preparedEmptyMessage: string;
   resultEmptyMessage: string;
+  preparedPageAspectRatio: number | null;
 }) {
+  const variantOptions = useMemo(
+    () => getCaptureVariantOptions(resultCapture),
+    [resultCapture],
+  );
+  const defaultVariant = getDefaultCaptureVariant(resultCapture);
+  const [resultVariant, setResultVariant] = useState<CaptureVariantKey>(defaultVariant);
+
+  useEffect(() => {
+    setResultVariant(defaultVariant);
+  }, [defaultVariant, resultCapture?.id]);
+
+  const selectedVariant =
+    variantOptions.find((option) => option.key === resultVariant) ?? variantOptions[0] ?? null;
+  const variantFooter = getSelectedVariantFooter({
+    capture: resultCapture,
+    selectedVariant,
+    resultFooter,
+  });
+  const preparedFrameStyle =
+    preparedPageAspectRatio !== null ? { aspectRatio: `${preparedPageAspectRatio}` } : undefined;
+  const resultFrameStyle = getSelectedVariantFrameStyle({
+    capture: resultCapture,
+    selectedVariant,
+  });
+
   return (
     <div className="run-artifact-compare">
       <ArtifactCard
@@ -352,14 +856,41 @@ function RunArtifactCompare({
         alt={preparedAlt}
         emptyMessage={preparedEmptyMessage}
         footer={preparedFooter}
+        frameStyle={preparedFrameStyle}
       />
       <ArtifactCard
         className="artifact-card-result"
         title="Result"
-        imageUrl={resultImageUrl}
-        alt={resultAlt}
+        imageUrl={selectedVariant?.url ?? null}
+        alt={
+          selectedVariant
+            ? `${selectedVariant.label.toLowerCase()} ${resultAlt}`
+            : resultAlt
+        }
         emptyMessage={resultEmptyMessage}
-        footer={resultFooter}
+        footer={variantFooter}
+        frameStyle={resultFrameStyle}
+        headerActions={
+          variantOptions.length > 1 ? (
+            <div className="artifact-variant-selector" role="group" aria-label="Result variant">
+              {variantOptions.map((option) => (
+                <button
+                  key={option.key}
+                  type="button"
+                  className={
+                    option.key === resultVariant
+                      ? "artifact-variant-button artifact-variant-button-active"
+                      : "artifact-variant-button"
+                  }
+                  aria-pressed={option.key === resultVariant}
+                  onClick={() => setResultVariant(option.key)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          ) : null
+        }
       />
     </div>
   );
@@ -389,6 +920,7 @@ function ExpandedRunSummary({
   onToggleSource: () => void;
 }) {
   const detailRows = getPreparationDetails(run);
+  const preparedPageAspectRatio = getPreparedPageAspectRatio(run);
 
   return (
     <section className="run-summary-card">
@@ -398,7 +930,7 @@ function ExpandedRunSummary({
         preparedImageUrl={preparedImageUrl}
         preparedAlt={run ? `Prepared output for run ${run.id}` : "Prepared output"}
         preparedFooter={sourceAsset?.name ?? null}
-        resultImageUrl={resultCapture?.public_url ?? null}
+        resultCapture={resultCapture}
         resultAlt={run ? `Result image for run ${run.id}` : "Result image"}
         resultFooter={getResultFooter({ capture: resultCapture, run })}
         preparedEmptyMessage={
@@ -413,6 +945,7 @@ function ExpandedRunSummary({
                 : "Result appears once the run reaches capture."
             : "No saved result yet."
         }
+        preparedPageAspectRatio={preparedPageAspectRatio}
       />
 
       <RunStepSummary run={run} />
@@ -424,14 +957,24 @@ function ExpandedRunSummary({
 
 function WorkflowRunSummary({
   displayRun,
+  pendingCaptureReview,
   selectedAsset,
   latestCapture,
+  reviewBusy,
+  onAcceptCaptureReview,
+  onAdjustCaptureReview,
+  onReuseLastCaptureReview,
   sourceOpen,
   onToggleSource,
 }: {
   displayRun: PlotRun | null;
+  pendingCaptureReview: PlotWorkflowController["pendingCaptureReview"];
   selectedAsset: PlotAsset | null;
   latestCapture: CaptureMetadata | null;
+  reviewBusy: boolean;
+  onAcceptCaptureReview: (runId: string) => Promise<void>;
+  onAdjustCaptureReview: (runId: string, corners: NormalizationCorners) => Promise<void>;
+  onReuseLastCaptureReview: (runId: string) => Promise<void>;
   sourceOpen: boolean;
   onToggleSource: () => void;
 }) {
@@ -440,6 +983,13 @@ function WorkflowRunSummary({
   const preparedImageUrl = displayRun?.prepared_artifact
     ? resolvePreparedArtifactUrl(displayRun.prepared_artifact.public_url)
     : null;
+  const preparedPageAspectRatio = getPreparedPageAspectRatio(displayRun);
+  const review =
+    displayRun?.status === "awaiting_capture_review" &&
+    pendingCaptureReview?.run_id === displayRun.id &&
+    pendingCaptureReview.capture.review
+      ? pendingCaptureReview.capture.review
+      : null;
 
   return (
     <section className="panel comparison-panel">
@@ -462,43 +1012,58 @@ function WorkflowRunSummary({
         </div>
       </header>
 
-      <RunArtifactCompare
-        preparedImageUrl={preparedImageUrl}
-        preparedAlt={displayRun ? `Prepared output for run ${displayRun.id}` : "Prepared output"}
-        preparedFooter={sourceAsset?.name ?? null}
-        resultImageUrl={resultCapture?.public_url ?? null}
-        resultAlt={
-          displayRun && resultCapture
-            ? `Result image for run ${displayRun.id}`
-            : latestCapture
-              ? `Latest result capture ${latestCapture.id}`
-              : "Result image"
-        }
-        resultFooter={
-          displayRun
-            ? getResultFooter({
-                capture: displayRun.observed_result?.capture ?? displayRun.capture ?? null,
-                run: displayRun,
-              })
-            : latestCapture
-              ? formatResultMeta({ capture: latestCapture, includeTimestamp: false })
-              : null
-        }
-        preparedEmptyMessage={
-          displayRun
-            ? "Prepared output unavailable."
-            : "Prepared output appears after a run is prepared."
-        }
-        resultEmptyMessage={
-          displayRun
-            ? displayRun.capture_mode === "skip"
-              ? "Capture skipped for this run."
-              : displayRun.status === "failed"
-                ? displayRun.error ?? "No result saved."
-                : "Result appears once the run reaches capture."
-            : "No saved result yet."
-        }
-      />
+      {displayRun?.status === "awaiting_capture_review" && displayRun.capture && review ? (
+        <RunCaptureReview
+          run={displayRun}
+          preparedImageUrl={preparedImageUrl}
+          preparedPageAspectRatio={preparedPageAspectRatio}
+          reviewCapture={displayRun.capture}
+          review={review}
+          reviewBusy={reviewBusy}
+          onAccept={() => onAcceptCaptureReview(displayRun.id)}
+          onAdjust={(corners) => onAdjustCaptureReview(displayRun.id, corners)}
+          onReuseLast={() => onReuseLastCaptureReview(displayRun.id)}
+        />
+      ) : (
+        <RunArtifactCompare
+          preparedImageUrl={preparedImageUrl}
+          preparedAlt={displayRun ? `Prepared output for run ${displayRun.id}` : "Prepared output"}
+          preparedFooter={sourceAsset?.name ?? null}
+          resultCapture={resultCapture}
+          resultAlt={
+            displayRun && resultCapture
+              ? `Result image for run ${displayRun.id}`
+              : latestCapture
+                ? `Latest result capture ${latestCapture.id}`
+                : "Result image"
+          }
+          resultFooter={
+            displayRun
+              ? getResultFooter({
+                  capture: displayRun.observed_result?.capture ?? displayRun.capture ?? null,
+                  run: displayRun,
+                })
+              : latestCapture
+                ? formatResultMeta({ capture: latestCapture, includeTimestamp: false })
+                : null
+          }
+          preparedEmptyMessage={
+            displayRun
+              ? "Prepared output unavailable."
+              : "Prepared output appears after a run is prepared."
+          }
+          resultEmptyMessage={
+            displayRun
+              ? displayRun.capture_mode === "skip"
+                ? "Capture skipped for this run."
+                : displayRun.status === "failed"
+                  ? displayRun.error ?? "No result saved."
+                  : "Result appears once the run reaches capture."
+              : "No saved result yet."
+          }
+          preparedPageAspectRatio={preparedPageAspectRatio}
+        />
+      )}
 
       <RunStepSummary run={displayRun} />
       <RunDetailsBlock rows={getPreparationDetails(displayRun)} />
@@ -521,6 +1086,7 @@ export function PlotWorkflowPanel({
     inspectedRun,
     inspectedRunId,
     recentRuns,
+    pendingCaptureReview,
     busyAction,
     activeRun,
     error,
@@ -529,6 +1095,9 @@ export function PlotWorkflowPanel({
     uploadSvg,
     startRun,
     inspectRun,
+    acceptCaptureReview,
+    adjustCaptureReview,
+    reuseLastCaptureReview,
   } = controller;
   const [historyRunDetails, setHistoryRunDetails] = useState<Record<string, PlotRun>>({});
   const [workflowSourceOpen, setWorkflowSourceOpen] = useState(false);
@@ -817,13 +1386,18 @@ export function PlotWorkflowPanel({
           ) : null}
         </section>
 
-        <WorkflowRunSummary
-          displayRun={displayRun}
-          selectedAsset={selectedAsset}
-          latestCapture={latestCapture}
-          sourceOpen={workflowSourceOpen}
-          onToggleSource={() => setWorkflowSourceOpen((current) => !current)}
-        />
+      <WorkflowRunSummary
+        displayRun={displayRun}
+        pendingCaptureReview={pendingCaptureReview}
+        selectedAsset={selectedAsset}
+        latestCapture={latestCapture}
+        reviewBusy={busyAction === "review"}
+        onAcceptCaptureReview={acceptCaptureReview}
+        onAdjustCaptureReview={adjustCaptureReview}
+        onReuseLastCaptureReview={reuseLastCaptureReview}
+        sourceOpen={workflowSourceOpen}
+        onToggleSource={() => setWorkflowSourceOpen((current) => !current)}
+      />
       </div>
     </section>
   );

--- a/apps/web/src/features/plot-workflow/plotWorkflowFormatters.ts
+++ b/apps/web/src/features/plot-workflow/plotWorkflowFormatters.ts
@@ -13,10 +13,24 @@ interface ResultCaptureLike {
 }
 
 export interface RunStepSummaryItem {
-  key: "prepare" | "plot" | "capture";
+  key: "prepare" | "plot" | "capture" | "capture_review";
   label: string;
   tone: "ok" | "warn" | "error" | "neutral";
   note?: string | null;
+}
+
+function getStageStateOrDefault(
+  stageState: PlotStageState | undefined,
+  fallbackMessage: string | null = null,
+): PlotStageState {
+  return (
+    stageState ?? {
+      status: "pending",
+      started_at: null,
+      completed_at: null,
+      message: fallbackMessage,
+    }
+  );
 }
 
 export function getStageLabel(run: PlotRun | null) {
@@ -28,6 +42,9 @@ export function getStageLabel(run: PlotRun | null) {
   }
   if (run.status === "capturing") {
     return "Capturing";
+  }
+  if (run.status === "awaiting_capture_review") {
+    return "Needs review";
   }
   if (run.status === "completed") {
     return "Completed";
@@ -43,7 +60,12 @@ export function getRunStatusTone(status: PlotRun["status"] | "idle") {
   if (status === "completed") {
     return "ok";
   }
-  if (status === "pending" || status === "plotting" || status === "capturing") {
+  if (
+    status === "pending" ||
+    status === "plotting" ||
+    status === "capturing" ||
+    status === "awaiting_capture_review"
+  ) {
     return "warn";
   }
   if (status === "failed") {
@@ -92,9 +114,13 @@ export function getStepSummaryItems(run: PlotRun | null): RunStepSummaryItem[] {
   }
 
   const items: RunStepSummaryItem[] = [];
-  const prepareState = run.stage_states.prepare;
-  const plotState = run.stage_states.plot;
-  const captureState = run.stage_states.capture;
+  const prepareState = getStageStateOrDefault(run.stage_states.prepare);
+  const plotState = getStageStateOrDefault(run.stage_states.plot);
+  const captureState = getStageStateOrDefault(run.stage_states.capture);
+  const captureReviewState = getStageStateOrDefault(
+    run.stage_states.capture_review,
+    "Capture review not required for this run.",
+  );
 
   items.push({
     key: "prepare",
@@ -174,6 +200,32 @@ export function getStepSummaryItems(run: PlotRun | null): RunStepSummaryItem[] {
         : captureState.message,
   });
 
+  items.push({
+    key: "capture_review",
+    label:
+      captureReviewState.status === "completed"
+        ? "Reviewed ✓"
+        : captureReviewState.status === "failed"
+          ? "Review !"
+          : captureReviewState.status === "in_progress"
+            ? run.status === "awaiting_capture_review"
+              ? "Review needed"
+              : "Reviewing…"
+            : "Review",
+    tone:
+      captureReviewState.status === "completed"
+        ? "ok"
+        : captureReviewState.status === "failed"
+          ? "error"
+          : captureReviewState.status === "in_progress"
+            ? "warn"
+            : "neutral",
+    note:
+      captureReviewState.status === "completed"
+        ? null
+        : captureReviewState.message,
+  });
+
   return items;
 }
 
@@ -183,6 +235,9 @@ export function getStepSummaryNote(run: PlotRun | null) {
   }
   if (run.status === "completed" && run.capture_mode !== "skip") {
     return null;
+  }
+  if (run.status === "awaiting_capture_review") {
+    return run.stage_states.capture_review.message ?? "Review the detected page corners.";
   }
   if (run.status === "completed" && run.capture_mode === "skip") {
     return "Capture skipped for this run.";

--- a/apps/web/src/features/plot-workflow/usePlotWorkflow.ts
+++ b/apps/web/src/features/plot-workflow/usePlotWorkflow.ts
@@ -1,24 +1,29 @@
 import { useEffect, useRef, useState } from "react";
 
 import {
+  acceptPlotRunCaptureReview,
+  adjustPlotRunCaptureReview,
   createPatternAsset,
   createPlotRun,
   fetchPlotRun,
+  fetchPlotRunCaptureReview,
   fetchLatestPlotRun,
   fetchPlotRuns,
+  reuseLastPlotRunCaptureReview,
   uploadPlotAsset,
 } from "../../lib/api";
 import type {
   PlotAsset,
   PlotRun,
+  PlotRunCaptureReviewPayload,
   PlotRunSummary,
 } from "../../types/plotting";
 
-type PlotAction = "upload" | "pattern" | "start" | null;
+type PlotAction = "upload" | "pattern" | "start" | "review" | null;
 type NoticeTone = "info" | "success" | "error";
 type SelectionSource = "manual" | "run-derived" | null;
 
-const ACTIVE_RUN_STATUSES = new Set(["pending", "plotting", "capturing"]);
+const ACTIVE_RUN_STATUSES = new Set(["pending", "plotting", "capturing", "awaiting_capture_review"]);
 export const PLOT_WORKFLOW_ACTIVE_POLL_INTERVAL_MS = 1200;
 export const PLOT_WORKFLOW_IDLE_POLL_INTERVAL_MS = 3500;
 
@@ -29,6 +34,7 @@ export interface PlotWorkflowController {
   inspectedRun: PlotRun | null;
   inspectedRunId: string | null;
   recentRuns: PlotRunSummary[];
+  pendingCaptureReview: PlotRunCaptureReviewPayload | null;
   loading: boolean;
   refreshing: boolean;
   busyAction: PlotAction;
@@ -43,6 +49,12 @@ export interface PlotWorkflowController {
   uploadSvg: (file: File) => Promise<void>;
   startRun: () => Promise<void>;
   inspectRun: (runId: string) => Promise<void>;
+  acceptCaptureReview: (runId: string) => Promise<void>;
+  adjustCaptureReview: (
+    runId: string,
+    corners: NonNullable<PlotRunCaptureReviewPayload["review"]>["proposed_corners"],
+  ) => Promise<void>;
+  reuseLastCaptureReview: (runId: string) => Promise<void>;
 }
 
 export function usePlotWorkflow(): PlotWorkflowController {
@@ -52,6 +64,7 @@ export function usePlotWorkflow(): PlotWorkflowController {
   const [inspectedRun, setInspectedRun] = useState<PlotRun | null>(null);
   const [inspectedRunId, setInspectedRunId] = useState<string | null>(null);
   const [recentRuns, setRecentRuns] = useState<PlotRunSummary[]>([]);
+  const [pendingCaptureReview, setPendingCaptureReview] = useState<PlotRunCaptureReviewPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [busyAction, setBusyAction] = useState<PlotAction>(null);
@@ -82,14 +95,30 @@ export function usePlotWorkflow(): PlotWorkflowController {
         return;
       }
       setLatestRun(latest.run);
-      if (inspectedRunId !== null && latest.run?.id !== inspectedRunId) {
-        const selectedRun = await fetchPlotRun(inspectedRunId);
+      const effectiveInspectedRunId = inspectedRunId ?? latest.run?.id ?? null;
+      if (effectiveInspectedRunId !== null && latest.run?.id !== effectiveInspectedRunId) {
+        const selectedRun = await fetchPlotRun(effectiveInspectedRunId);
         if (!mountedRef.current) {
           return;
         }
         setInspectedRun(selectedRun);
       } else {
         setInspectedRun(latest.run);
+      }
+      const reviewTargetId = effectiveInspectedRunId;
+      if (
+        reviewTargetId !== null &&
+        ((reviewTargetId === latest.run?.id && latest.run?.status === "awaiting_capture_review") ||
+          (reviewTargetId !== latest.run?.id &&
+            (await fetchPlotRun(reviewTargetId)).status === "awaiting_capture_review"))
+      ) {
+        const reviewPayload = await fetchPlotRunCaptureReview(reviewTargetId);
+        if (!mountedRef.current) {
+          return;
+        }
+        setPendingCaptureReview(reviewPayload);
+      } else {
+        setPendingCaptureReview(null);
       }
       setRecentRuns(runs.runs);
       if (selectionSourceRef.current !== "manual") {
@@ -185,6 +214,7 @@ export function usePlotWorkflow(): PlotWorkflowController {
       setLatestRun(run);
       setInspectedRun(run);
       setInspectedRunId(run.id);
+      setPendingCaptureReview(null);
       updateSelection(run.asset, "run-derived");
       await refresh({ silent: true });
       setNotice({ tone: "success", message: "Plot run started." });
@@ -234,6 +264,7 @@ export function usePlotWorkflow(): PlotWorkflowController {
     inspectedRun,
     inspectedRunId,
     recentRuns,
+    pendingCaptureReview,
     loading,
     refreshing,
     busyAction,
@@ -253,6 +284,11 @@ export function usePlotWorkflow(): PlotWorkflowController {
         }
         setInspectedRun(run);
         setInspectedRunId(runId);
+        setPendingCaptureReview(
+          run.status === "awaiting_capture_review"
+            ? await fetchPlotRunCaptureReview(runId)
+            : null,
+        );
         setError(null);
       } catch (refreshError) {
         if (!mountedRef.current) {
@@ -266,6 +302,90 @@ export function usePlotWorkflow(): PlotWorkflowController {
       } finally {
         if (mountedRef.current) {
           setRefreshing(false);
+        }
+      }
+    },
+    acceptCaptureReview: async (runId: string) => {
+      try {
+        setBusyAction("review");
+        setError(null);
+        const response = await acceptPlotRunCaptureReview(runId);
+        if (!mountedRef.current) {
+          return;
+        }
+        setLatestRun(response.run);
+        setInspectedRun(response.run);
+        setInspectedRunId(response.run.id);
+        setPendingCaptureReview(null);
+        setNotice({ tone: "info", message: response.message });
+        await refresh({ silent: true });
+      } catch (actionError) {
+        if (!mountedRef.current) {
+          return;
+        }
+        const message =
+          actionError instanceof Error ? actionError.message : "Failed to accept capture review.";
+        setError(message);
+        setNotice({ tone: "error", message });
+      } finally {
+        if (mountedRef.current) {
+          setBusyAction(null);
+        }
+      }
+    },
+    adjustCaptureReview: async (runId, corners) => {
+      try {
+        setBusyAction("review");
+        setError(null);
+        const response = await adjustPlotRunCaptureReview(runId, corners);
+        if (!mountedRef.current) {
+          return;
+        }
+        setLatestRun(response.run);
+        setInspectedRun(response.run);
+        setInspectedRunId(response.run.id);
+        setPendingCaptureReview(null);
+        setNotice({ tone: "info", message: response.message });
+        await refresh({ silent: true });
+      } catch (actionError) {
+        if (!mountedRef.current) {
+          return;
+        }
+        const message =
+          actionError instanceof Error ? actionError.message : "Failed to save adjusted corners.";
+        setError(message);
+        setNotice({ tone: "error", message });
+      } finally {
+        if (mountedRef.current) {
+          setBusyAction(null);
+        }
+      }
+    },
+    reuseLastCaptureReview: async (runId: string) => {
+      try {
+        setBusyAction("review");
+        setError(null);
+        const response = await reuseLastPlotRunCaptureReview(runId);
+        if (!mountedRef.current) {
+          return;
+        }
+        setLatestRun(response.run);
+        setInspectedRun(response.run);
+        setInspectedRunId(response.run.id);
+        setPendingCaptureReview(null);
+        setNotice({ tone: "info", message: response.message });
+        await refresh({ silent: true });
+      } catch (actionError) {
+        if (!mountedRef.current) {
+          return;
+        }
+        const message =
+          actionError instanceof Error ? actionError.message : "Failed to reuse the last confirmed quad.";
+        setError(message);
+        setNotice({ tone: "error", message });
+      } finally {
+        if (mountedRef.current) {
+          setBusyAction(null);
         }
       }
     },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   LatestPlotRunResponse,
   PlotAsset,
   PlotRun,
+  PlotRunCaptureReviewPayload,
   PlotRunListResponse,
 } from "../types/plotting";
 import type { HelperStatus } from "../types/helper";
@@ -286,6 +287,49 @@ export function fetchPlotRuns() {
 
 export function fetchPlotRun(runId: string) {
   return requestJson<PlotRun>(`/api/plot-runs/${runId}`);
+}
+
+export function fetchPlotRunCaptureReview(runId: string) {
+  return requestJson<PlotRunCaptureReviewPayload>(`/api/plot-runs/${runId}/capture-review`);
+}
+
+export function acceptPlotRunCaptureReview(runId: string) {
+  return requestJson<{ ok: boolean; message: string; run: PlotRun }>(
+    `/api/plot-runs/${runId}/capture-review/accept`,
+    {
+      method: "POST",
+    },
+  );
+}
+
+export function adjustPlotRunCaptureReview(
+  runId: string,
+  corners: {
+    top_left: [number, number];
+    top_right: [number, number];
+    bottom_right: [number, number];
+    bottom_left: [number, number];
+  },
+) {
+  return requestJson<{ ok: boolean; message: string; run: PlotRun }>(
+    `/api/plot-runs/${runId}/capture-review/adjust`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ corners }),
+    },
+  );
+}
+
+export function reuseLastPlotRunCaptureReview(runId: string) {
+  return requestJson<{ ok: boolean; message: string; run: PlotRun }>(
+    `/api/plot-runs/${runId}/capture-review/reuse-last`,
+    {
+      method: "POST",
+    },
+  );
 }
 
 export function fetchHelperStatus() {

--- a/apps/web/src/types/hardware.ts
+++ b/apps/web/src/types/hardware.ts
@@ -65,6 +65,96 @@ export interface CaptureMetadata {
   width: number;
   height: number;
   mime_type: string;
+  review: CaptureReview | null;
+  normalized: NormalizedCaptureArtifacts | null;
+}
+
+export interface CaptureReview {
+  review_required: boolean;
+  review_status: "pending" | "confirmed";
+  proposed_corners: NormalizationCorners;
+  confirmed_corners: NormalizationCorners | null;
+  confirmation_source: "auto" | "adjusted" | "reused_last" | null;
+  detector_method: "paper_contour_v3" | "paper_region_v2" | "paper_edges_v1" | "fallback_full_frame";
+  detector_confidence: number;
+  reuse_last_available: boolean;
+}
+
+export interface NormalizationCorners {
+  top_left: [number, number];
+  top_right: [number, number];
+  bottom_right: [number, number];
+  bottom_left: [number, number];
+}
+
+export interface NormalizationTransform {
+  matrix: number[][];
+}
+
+export interface NormalizationOutput {
+  width: number;
+  height: number;
+  aspect_ratio: number;
+}
+
+export interface NormalizationFrame {
+  kind: "page_aligned";
+  version: number;
+  page_width_mm: number;
+  page_height_mm: number;
+}
+
+export interface NormalizationDiagnosticCandidate {
+  corners?: NormalizationCorners | null;
+  bounds?: [number, number, number, number] | null;
+  component_area?: number | null;
+  rect_area?: number | null;
+  fill_ratio?: number | null;
+  occupancy_score?: number | null;
+  edge_support_score?: number | null;
+  top_score?: number | null;
+  right_score?: number | null;
+  bottom_score?: number | null;
+  left_score?: number | null;
+  mean_border_support?: number | null;
+  max_outward_expansion_px?: number | null;
+  refined_area_ratio?: number | null;
+  aspect_log_error?: number | null;
+  score?: number | null;
+  confidence?: number | null;
+  rejection_reason?: string | null;
+}
+
+export interface NormalizationMethodDiagnostics {
+  status: "used" | "rejected" | "not_run" | "unavailable";
+  rejection_reason?: string | null;
+  candidate_count: number;
+  best_candidate?: NormalizationDiagnosticCandidate | null;
+}
+
+export interface NormalizationDiagnostics {
+  mode: "default" | "region_only";
+  contour_v3?: NormalizationMethodDiagnostics | null;
+  region_v2: NormalizationMethodDiagnostics;
+  line_v1: NormalizationMethodDiagnostics;
+}
+
+export interface NormalizationMetadata {
+  method: "paper_contour_v3" | "paper_region_v2" | "paper_edges_v1" | "fallback_full_frame";
+  confidence: number;
+  corners: NormalizationCorners;
+  transform: NormalizationTransform;
+  output: NormalizationOutput;
+  target_frame_source: "prepared_svg" | "workspace_drawable_area";
+  frame?: NormalizationFrame | null;
+  diagnostics?: NormalizationDiagnostics | null;
+}
+
+export interface NormalizedCaptureArtifacts {
+  rectified_color_url: string;
+  rectified_grayscale_url: string;
+  debug_overlay_url: string;
+  metadata: NormalizationMetadata;
 }
 
 export interface LatestCaptureResponse {

--- a/apps/web/src/types/plotting.ts
+++ b/apps/web/src/types/plotting.ts
@@ -1,3 +1,5 @@
+import type { CaptureMetadata } from "./hardware";
+
 export interface PlotAsset {
   id: string;
   kind: "uploaded_svg" | "built_in_pattern";
@@ -18,7 +20,13 @@ export interface PlotStageState {
 
 export interface PlotRun {
   id: string;
-  status: "pending" | "plotting" | "capturing" | "completed" | "failed";
+  status:
+    | "pending"
+    | "plotting"
+    | "capturing"
+    | "awaiting_capture_review"
+    | "completed"
+    | "failed";
   purpose: "normal" | "diagnostic";
   capture_mode: "auto" | "skip";
   created_at: string;
@@ -29,31 +37,15 @@ export interface PlotRun {
     public_url: string;
     mime_type: string;
   } | null;
-  capture: {
-    id: string;
-    timestamp: string;
-    file_path: string;
-    public_url: string;
-    width: number;
-    height: number;
-    mime_type: string;
-  } | null;
+  capture: CaptureMetadata | null;
   observed_result?: {
-    capture: {
-      id: string;
-      timestamp: string;
-      file_path: string;
-      public_url: string;
-      width: number;
-      height: number;
-      mime_type: string;
-    };
+    capture: CaptureMetadata;
     camera_driver: string;
     captured_at: string;
     duration_ms: number;
   } | null;
   error: string | null;
-  stage_states: Record<"prepare" | "plot" | "capture", PlotStageState>;
+  stage_states: Record<"prepare" | "plot" | "capture" | "capture_review", PlotStageState>;
   plotter_run_details: Record<string, unknown>;
   camera_run_details: Record<string, unknown>;
 }
@@ -76,4 +68,10 @@ export interface LatestPlotRunResponse {
 
 export interface PlotRunListResponse {
   runs: PlotRunSummary[];
+}
+
+export interface PlotRunCaptureReviewPayload {
+  run_id: string;
+  capture: CaptureMetadata;
+  review: CaptureMetadata["review"];
 }

--- a/apps/web/tests/dashboard.test.tsx
+++ b/apps/web/tests/dashboard.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import { App } from "../src/app/App";
+import type { CaptureReview } from "../src/types/hardware";
+import type { PlotRun } from "../src/types/plotting";
 import {
   createHardwareDashboardHarness,
   defaultAxiDrawHardwareStatus,
@@ -12,15 +14,53 @@ function buildRun({
   name,
   createdAt,
   observedCaptureId,
+  includeNormalized = false,
+  status,
+  review = null,
 }: {
   id: string;
   name: string;
   createdAt: string;
   observedCaptureId?: string;
-}) {
+  includeNormalized?: boolean;
+  status?: "completed" | "plotting" | "awaiting_capture_review";
+  review?: CaptureReview | null;
+}): PlotRun {
+  const normalized = observedCaptureId && includeNormalized
+    ? {
+        rectified_color_url: `/captures/${observedCaptureId}-rectified-color.png`,
+        rectified_grayscale_url: `/captures/${observedCaptureId}-rectified-grayscale.png`,
+        debug_overlay_url: `/captures/${observedCaptureId}-debug-overlay.png`,
+        metadata: {
+          method: "paper_edges_v1" as const,
+          confidence: 0.91,
+          corners: {
+            top_left: [10, 10] as [number, number],
+            top_right: [100, 10] as [number, number],
+            bottom_right: [100, 100] as [number, number],
+            bottom_left: [10, 100] as [number, number],
+          },
+          transform: {
+            matrix: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+          },
+          output: {
+            width: 2048,
+            height: 1950,
+            aspect_ratio: 1.05,
+          },
+          target_frame_source: "prepared_svg" as const,
+          frame: {
+            kind: "page_aligned" as const,
+            version: 1,
+            page_width_mm: 210,
+            page_height_mm: 200,
+          },
+        },
+      }
+    : null;
   return {
     id,
-    status: observedCaptureId ? ("completed" as const) : ("plotting" as const),
+    status: status ?? (observedCaptureId ? ("completed" as const) : ("plotting" as const)),
     purpose: "normal" as const,
     capture_mode: "auto" as const,
     created_at: createdAt,
@@ -49,6 +89,8 @@ function buildRun({
           width: 1600,
           height: 1200,
           mime_type: "image/jpeg",
+          review,
+          normalized,
         }
       : null,
     observed_result: observedCaptureId
@@ -61,6 +103,8 @@ function buildRun({
             width: 1600,
             height: 1200,
             mime_type: "image/jpeg",
+            review,
+            normalized,
           },
           camera_driver: "mock-camera",
           captured_at: createdAt,
@@ -87,15 +131,39 @@ function buildRun({
         completed_at: observedCaptureId ? createdAt : null,
         message: observedCaptureId ? "Captured." : "Waiting.",
       },
+      capture_review: {
+        status:
+          status === "awaiting_capture_review"
+            ? ("in_progress" as const)
+            : observedCaptureId
+              ? ("completed" as const)
+              : ("pending" as const),
+        started_at: status === "awaiting_capture_review" || observedCaptureId ? createdAt : null,
+        completed_at: observedCaptureId ? createdAt : null,
+        message:
+          status === "awaiting_capture_review"
+            ? "Review the detected page corners before normalization."
+            : observedCaptureId
+              ? "Capture review confirmed."
+              : "Waiting.",
+      },
     },
     plotter_run_details: {
       preparation: {
         source_width: 120,
         source_height: 90,
+        page_width_mm: 210,
+        page_height_mm: 200,
         prepared_width_mm: 110,
         prepared_height_mm: 82,
         preparation_audit: {
           prepared_within_drawable_area: true,
+          placement_origin_x_mm: 5,
+          placement_origin_y_mm: 5,
+          source_content_left_ratio: 0.1,
+          source_content_top_ratio: 0.1,
+          source_content_width_ratio: 0.8,
+          source_content_height_ratio: 0.6,
         },
       },
     },
@@ -168,6 +236,8 @@ describe("workflow-first dashboard", () => {
         width: 1920,
         height: 1080,
         mime_type: "image/jpeg",
+        review: null,
+        normalized: null,
       },
     });
     installHardwareDashboardFetchMock(harness);
@@ -200,6 +270,8 @@ describe("workflow-first dashboard", () => {
         width: 1920,
         height: 1080,
         mime_type: "image/jpeg",
+        review: null,
+        normalized: null,
       },
       recentRuns: [
         {
@@ -227,6 +299,126 @@ describe("workflow-first dashboard", () => {
     expect(
       screen.queryByRole("img", { name: /latest result capture capture-global-002/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("defaults to the normalized result and allows switching to raw and debug variants", async () => {
+    const latestRun = buildRun({
+      id: "run-020",
+      name: "Variant Study",
+      createdAt: "2026-03-15T20:14:00Z",
+      observedCaptureId: "capture-run-020",
+      includeNormalized: true,
+    });
+    const harness = createHardwareDashboardHarness({
+      latestRun,
+      recentRuns: [
+        {
+          id: latestRun.id,
+          status: latestRun.status,
+          purpose: latestRun.purpose,
+          created_at: latestRun.created_at,
+          updated_at: latestRun.updated_at,
+          asset_id: latestRun.asset.id,
+          asset_name: latestRun.asset.name,
+          asset_kind: latestRun.asset.kind,
+          error: null,
+        },
+      ],
+    });
+    installHardwareDashboardFetchMock(harness);
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("img", {
+        name: /normalized result image for run run-020/i,
+      }),
+    ).toBeInTheDocument();
+    const preparedFrame = screen
+      .getByRole("img", { name: /prepared output for run run-020/i })
+      .closest(".artifact-frame");
+    expect(preparedFrame?.getAttribute("style")).toContain("aspect-ratio");
+    const resultFrame = screen
+      .getByRole("img", { name: /normalized result image for run run-020/i })
+      .closest(".artifact-frame");
+    expect(resultFrame?.getAttribute("style")).toContain("aspect-ratio");
+    expect(screen.getByRole("button", { name: /^normalized$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^debug$/i }));
+    expect(
+      await screen.findByRole("img", {
+        name: /debug result image for run run-020/i,
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^raw$/i }));
+    expect(
+      await screen.findByRole("img", {
+        name: /raw result image for run run-020/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the capture review UI for a run awaiting corner confirmation", async () => {
+    const pendingRun = buildRun({
+      id: "run-review-001",
+      name: "Needs review",
+      createdAt: "2026-03-15T20:18:00Z",
+      observedCaptureId: "capture-review-001",
+      status: "awaiting_capture_review",
+      review: {
+        review_required: true,
+        review_status: "pending",
+        proposed_corners: {
+          top_left: [100, 120],
+          top_right: [1400, 110],
+          bottom_right: [1450, 1080],
+          bottom_left: [80, 1090],
+        },
+        confirmed_corners: null,
+        confirmation_source: null,
+        detector_method: "paper_region_v2",
+        detector_confidence: 0.32,
+        reuse_last_available: true,
+      },
+    });
+    const harness = createHardwareDashboardHarness({
+      latestRun: pendingRun,
+      plotRunsById: {
+        [pendingRun.id]: pendingRun,
+      },
+      recentRuns: [
+        {
+          id: pendingRun.id,
+          status: pendingRun.status,
+          purpose: pendingRun.purpose,
+          created_at: pendingRun.created_at,
+          updated_at: pendingRun.updated_at,
+          asset_id: pendingRun.asset.id,
+          asset_name: pendingRun.asset.name,
+          asset_kind: pendingRun.asset.kind,
+          error: null,
+        },
+      ],
+    });
+    installHardwareDashboardFetchMock(harness);
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: /review capture/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^accept$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^adjust$/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /^reuse last$/i })).toBeEnabled();
+    expect(screen.getByText(/paper_region_v2/i)).toBeInTheDocument();
+    expect(screen.getByText(/confidence 0.32/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^adjust$/i }));
+
+    expect(await screen.findByRole("dialog", { name: /adjust capture corners/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /apply adjusted quad/i })).toBeDisabled();
   });
 
   it("keeps the source hidden by default and reveals it on demand in the Workflow view", async () => {
@@ -288,7 +480,7 @@ describe("workflow-first dashboard", () => {
 
     expect(await screen.findByRole("heading", { name: /paper setup/i })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /current setup/i })).not.toBeInTheDocument();
-    expect(screen.queryByText(/latest capture/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /latest capture/i })).toBeInTheDocument();
     expect(screen.getAllByLabelText(/paper setup preview/i)).toHaveLength(1);
     expect(screen.getByRole("heading", { name: /^plotter$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /capture test image/i })).toBeInTheDocument();

--- a/apps/web/tests/hardwareDashboardFocused.test.tsx
+++ b/apps/web/tests/hardwareDashboardFocused.test.tsx
@@ -167,7 +167,77 @@ describe("machine and camera focused behaviors", () => {
     fireEvent.click(await screen.findByRole("button", { name: /capture test image/i }));
 
     expect(await screen.findByText(/image captured\./i)).toBeInTheDocument();
-    expect(screen.queryByText(/latest capture/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /latest capture/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /latest camera capture capture-real-001/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows latest-capture raw, normalized, and debug variants on the Machine tab", async () => {
+    const harness = createHardwareDashboardHarness({
+      latestCapture: {
+        id: "capture-machine-001",
+        timestamp: "2026-03-15T20:05:00Z",
+        file_path: "/tmp/capture-machine-001.jpg",
+        public_url: "/captures/capture-machine-001.jpg",
+        width: 1920,
+        height: 1080,
+        mime_type: "image/jpeg",
+        review: null,
+        normalized: {
+          rectified_color_url: "/captures/capture-machine-001-rectified-color.png",
+          rectified_grayscale_url: "/captures/capture-machine-001-rectified-grayscale.png",
+          debug_overlay_url: "/captures/capture-machine-001-debug-overlay.png",
+          metadata: {
+            method: "paper_edges_v1",
+            confidence: 0.92,
+            corners: {
+              top_left: [12, 12],
+              top_right: [100, 12],
+              bottom_right: [100, 120],
+              bottom_left: [12, 120],
+            },
+            transform: {
+              matrix: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+            },
+            output: {
+              width: 1448,
+              height: 2048,
+              aspect_ratio: 0.707031,
+            },
+            target_frame_source: "workspace_drawable_area",
+            frame: {
+              kind: "page_aligned",
+              version: 1,
+              page_width_mm: 210,
+              page_height_mm: 297,
+            },
+          },
+        },
+      },
+    });
+    installHardwareDashboardFetchMock(harness);
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /^machine$/i }));
+
+    expect(
+      await screen.findByRole("img", {
+        name: /normalized latest camera capture capture-machine-001/i,
+      }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^debug$/i }));
+    expect(
+      await screen.findByRole("img", {
+        name: /debug latest camera capture capture-machine-001/i,
+      }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^raw$/i }));
+    expect(
+      await screen.findByRole("img", {
+        name: /raw latest camera capture capture-machine-001/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it("keeps invalid paper setup drafts local and blocks save until they fit", async () => {

--- a/apps/web/tests/hardwareDashboardTestUtils.ts
+++ b/apps/web/tests/hardwareDashboardTestUtils.ts
@@ -8,11 +8,13 @@ import {
 import type {
   CaptureMetadata,
   HardwareStatus,
+  NormalizationCorners,
   PlotterCalibration,
   PlotterDeviceSettings,
   PlotterWorkspace,
 } from "../src/types/hardware";
 import type { HelperStatus } from "../src/types/helper";
+import type { PlotRun, PlotRunSummary } from "../src/types/plotting";
 
 export const defaultHardwareStatus: HardwareStatus = {
   plotter: {
@@ -182,9 +184,9 @@ export interface HardwareDashboardHarness {
   currentDevice: PlotterDeviceSettings;
   currentWorkspace: PlotterWorkspace;
   latestCapture: CaptureMetadata | null;
-  latestRun: Record<string, unknown> | null;
-  recentRuns: Record<string, unknown>[];
-  plotRunsById: Record<string, Record<string, unknown>>;
+  latestRun: PlotRun | null;
+  recentRuns: PlotRunSummary[];
+  plotRunsById: Record<string, PlotRun>;
   backendReachable: boolean;
   helperReachable: boolean;
   helperStatus: HelperStatus;
@@ -210,6 +212,11 @@ export interface HardwareDashboardHarness {
     margin_top_mm: number;
     margin_right_mm: number;
     margin_bottom_mm: number;
+  }>;
+  captureReviewActions: Array<{
+    runId: string;
+    action: "accept" | "adjust" | "reuse-last";
+    corners?: NormalizationCorners;
   }>;
 }
 
@@ -272,6 +279,7 @@ export function createHardwareDashboardHarness(
     plotterTestActions: [],
     safeBoundsRequests: [],
     workspaceRequests: [],
+    captureReviewActions: [],
     ...overrides,
   };
 }
@@ -415,6 +423,8 @@ export function installHardwareDashboardFetchMock(
           width: 1920,
           height: 1080,
           mime_type: "image/jpeg",
+          review: null,
+          normalized: null,
         };
         harness.currentHardwareStatus = {
           ...harness.currentHardwareStatus,
@@ -514,6 +524,93 @@ export function installHardwareDashboardFetchMock(
 
       if (url === "/api/plot-runs" && method === "GET") {
         return jsonResponse({ runs: harness.recentRuns });
+      }
+
+      if (url.match(/^\/api\/plot-runs\/[^/]+\/capture-review$/) && method === "GET") {
+        const runId = url.split("/")[3] ?? "";
+        const run =
+          (harness.latestRun && harness.latestRun.id === runId ? harness.latestRun : null) ??
+          harness.plotRunsById[runId];
+        if (!run || !run.capture || !run.capture.review) {
+          return new Response("Not found", { status: 404 });
+        }
+        return jsonResponse({
+          run_id: runId,
+          capture: run.capture,
+          review: run.capture.review,
+        });
+      }
+
+      if (url.match(/^\/api\/plot-runs\/[^/]+\/capture-review\/accept$/) && method === "POST") {
+        const runId = url.split("/")[3] ?? "";
+        harness.captureReviewActions.push({ runId, action: "accept" });
+        const run =
+          (harness.latestRun && harness.latestRun.id === runId ? harness.latestRun : null) ??
+          harness.plotRunsById[runId];
+        if (!run || !run.capture?.review) {
+          return new Response("Not found", { status: 404 });
+        }
+        run.capture.review = {
+          ...run.capture.review,
+          review_status: "confirmed",
+          confirmation_source: "auto",
+          confirmed_corners: run.capture.review.proposed_corners,
+        };
+        run.status = "capturing";
+        return jsonResponse({
+          ok: true,
+          message: "Capture review accepted. Finalizing normalization.",
+          run,
+        });
+      }
+
+      if (url.match(/^\/api\/plot-runs\/[^/]+\/capture-review\/adjust$/) && method === "POST") {
+        const runId = url.split("/")[3] ?? "";
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          corners: NormalizationCorners;
+        };
+        harness.captureReviewActions.push({ runId, action: "adjust", corners: body.corners });
+        const run =
+          (harness.latestRun && harness.latestRun.id === runId ? harness.latestRun : null) ??
+          harness.plotRunsById[runId];
+        if (!run || !run.capture?.review) {
+          return new Response("Not found", { status: 404 });
+        }
+        run.capture.review = {
+          ...run.capture.review,
+          review_status: "confirmed",
+          confirmation_source: "adjusted",
+          confirmed_corners: body.corners,
+        };
+        run.status = "capturing";
+        return jsonResponse({
+          ok: true,
+          message: "Adjusted capture corners saved. Finalizing normalization.",
+          run,
+        });
+      }
+
+      if (url.match(/^\/api\/plot-runs\/[^/]+\/capture-review\/reuse-last$/) && method === "POST") {
+        const runId = url.split("/")[3] ?? "";
+        harness.captureReviewActions.push({ runId, action: "reuse-last" });
+        const run =
+          (harness.latestRun && harness.latestRun.id === runId ? harness.latestRun : null) ??
+          harness.plotRunsById[runId];
+        if (!run || !run.capture?.review) {
+          return new Response("Not found", { status: 404 });
+        }
+        run.capture.review = {
+          ...run.capture.review,
+          review_status: "confirmed",
+          confirmation_source: "reused_last",
+          confirmed_corners: run.capture.review.proposed_corners,
+        };
+        run.status = "capturing";
+        return jsonResponse({
+          ok: true,
+          message: "Reused the last confirmed quad for this setup.",
+          run,
+        });
       }
 
       if (url.startsWith("/api/plot-runs/") && method === "GET") {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,8 @@ The current backend structure centers on:
 
 - `routes.py` and `api.py` for the thin FastAPI surface
 - `services/hardware.py` for hardware status and control orchestration
-- `services/captures.py` for persisted capture storage and latest-capture lookup
+- `services/captures.py` for persisted raw capture storage, normalized-derivative metadata, and latest-capture lookup
+- `services/capture_service.py` and `services/capture_normalization.py` for backend-owned post-capture normalization
 - `services/plot_workflow.py` for asset storage, run creation, preparation, plotting, and capture flow
 - `services/plotter_calibration.py`, `services/plotter_device_settings.py`, and `services/plotter_workspace.py` for persisted plotter state
 
@@ -60,7 +61,7 @@ Hardware integration stays behind backend interfaces.
 
 Local persisted state is organized by purpose:
 
-- `artifacts/captures`: saved capture metadata and SVG output
+- `artifacts/captures`: saved raw capture metadata plus normalized derivative artifacts such as rectified grayscale and debug overlays
 - `artifacts/plot_assets`: uploaded or built-in plot sources
 - `artifacts/plot_runs`: run records and prepared output where applicable
 - `artifacts/calibration`: persisted plotter calibration values
@@ -74,12 +75,22 @@ Filesystem paths and public URLs are kept separate in the backend so local stora
 The app currently supports a single backend-owned plotting workflow with a few narrow supporting flows.
 
 - `status`: the frontend polls backend hardware status and availability
-- `captures`: the backend can trigger and persist camera captures, then serve the latest result
-- `plot runs`: uploaded SVGs and built-in patterns become stored assets, then tracked runs with explicit preparation, plotting, and optional capture stages; normal runs can persist a run-scoped observed result after capture
+- `captures`: the backend can trigger and persist camera captures, then enrich them with backend-owned normalized derivatives without mutating the raw source artifact
+  Manual captures normalize into a canonical page-sized workspace frame, while normal plot runs normalize inline into the prepared page frame so prepared and observed artifacts share the same backend-owned comparison coordinates. Paper detection is backend-owned and deterministic, with a region-first bright-paper detector on dark-mat captures plus explicit edge/full-frame fallbacks.
+- `plot runs`: uploaded SVGs and built-in patterns become stored assets, then tracked runs with explicit preparation, plotting, and optional capture stages; normal runs persist a run-scoped observed result whose embedded capture record can include normalized comparison-ready artifacts
 - `diagnostics`: fixed built-in pen and pattern tests stay separate from normal plotting semantics
 - `workspace`: page size and margins are persisted and validated against the current drawable area
 - `device settings`: stable machine information and operational safe bounds are backend-owned and surfaced read-only except for narrow safe overrides
 - `calibration`: persisted plotter calibration remains backend-owned and separate from transient runtime overrides
+
+## Experimental Capture Normalization Diagnostics
+
+Capture normalization exposes backend-only diagnostic switches for saved-capture replay and detector comparison:
+
+- `LEARN_TO_DRAW_NORMALIZATION_MODE`: `default` or `region_only`
+- `LEARN_TO_DRAW_NORMALIZATION_EXPERIMENT`: `region_v2` or `contour_v3`
+
+These switches are session/runtime configuration only. They are not persisted as operator settings and should not be surfaced as broad browser controls. Use them to compare detector behavior or inspect rejected candidates while keeping the backend as the sole owner of capture analysis.
 
 ## Extension Points
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -98,4 +98,20 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Made camera selection the primary camera action, demoted capture to a test action, and removed the Machine-tab latest-capture surface
 - Collapsed machine details and diagnostics so advanced hardware data no longer competes with setup tasks in the default view
 
+## Post-Capture Normalization Slice
+
+- Added a backend-owned normalization pipeline that turns raw raster captures into rectified, framed, and comparison-ready derivatives without mutating the raw artifact
+- Extended capture records so both standalone captures and plot-run observed results can expose normalized grayscale, debug overlay, and normalization metadata through the existing API responses
+- Kept manual capture requests fast by saving the raw artifact first and running workspace page-frame normalization in the background, while normal plot runs normalize inline before completion into the prepared page frame
+- Adjusted the line-based fallback to stabilize top-edge selection against bright plotter-rail captures and changed the canonical normalized artifact to a white-backed page-aligned frame instead of a drawing-frame artifact with UI crop compensation
+- Replaced the primary edge-led paper detector with a region-first `paper_region_v2` detector that segments the bright sheet from the dark mat, refines the fitted rectangle with local edge evidence, and falls back to the older line detector only when the region candidate is not credible
+- Relaxed region occupancy scoring so dense plotted strokes and titles inside the paper no longer cause otherwise-valid paper regions to be rejected back into the weaker line fallback
+- Tightened the region-first fit by replacing the loose `minAreaRect` candidate with a contour-clipped rotated box, which keeps left and bottom edges closer to the visible paper border on off-axis real captures
+- Added structured normalization diagnostics plus a temporary `region_only` backend mode so rejected `paper_region_v2` candidates can be inspected directly without the noisy line-based fallback masking the failure reason
+- Replaced the loose region-box refinement with contour-anchored border snapping, added per-side border-support diagnostics, and started explicitly rejecting region candidates whose left/right/top/bottom borders do not align with the visible paper edge
+- Added an experimental contour-first `paper_contour_v3` detector plus a backend experiment switch and replay helper so saved real captures can be compared against `paper_region_v2` without relying on live-camera trial and error
+- Increased the canonical normalization long side to `2048px` so downstream comparison artifacts preserve more stroke detail
+- Added tight source-content bounds plus a comparison-frame version to preparation metadata and simplified the Workflow comparison view so Prepared and Normalized Result render directly from matching backend-owned page-frame artifacts
+- Added deterministic OpenCV regression coverage for confident paper detection, low-confidence best-effort output, and full-frame fallback plus a small result-variant selector in the workflow UI
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Add backend-owned post-capture normalization artifacts for raw captures and plot-run observed results.
- Add capture-review state for plot runs so detected page corners can be accepted, adjusted, or reused before final normalization.
- Add deterministic normalization tests, replay tooling, docs, and workflow UI support for raw/normalized/debug result variants.

## Why

The project had planned and observed artifacts, but captured camera output was not normalized into the same backend-owned page frame as prepared plot output. This made comparison fragile and pushed too much interpretation into the UI. This slice keeps capture analysis in the backend and gives the operator a narrow review step when detection confidence needs confirmation.

## Notes

- `LEARN_TO_DRAW_NORMALIZATION_MODE` and `LEARN_TO_DRAW_NORMALIZATION_EXPERIMENT` are backend-only diagnostic/runtime switches for detector comparison and saved-capture replay.
- These switches are not persisted operator settings and are not exposed as broad browser controls.
- `.playwright-mcp/` is ignored as local browser automation state.

## Verification

- `make check`
