### PR TITLE
[codex] Decouple capture review scope keys

### DIFF
--- a/apps/api/src/learn_to_draw_api/services/capture_review_memory.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_review_memory.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from learn_to_draw_api.models import NormalizationCorners
+from learn_to_draw_api.models import NormalizationCorners, PlotRun, PlotterWorkspace
 
 
 class CaptureReviewMemoryRecord(BaseModel):
@@ -73,6 +73,53 @@ class CaptureReviewMemoryStore:
             ]
         )
 
+    def build_scope_key_for_workspace(
+        self,
+        *,
+        workspace: PlotterWorkspace,
+        camera_driver: str,
+        camera_device_id: Optional[str],
+    ) -> Optional[str]:
+        if camera_device_id is None:
+            return None
+        return self.build_scope_key(
+            camera_driver=camera_driver,
+            camera_device_id=camera_device_id,
+            page_width_mm=workspace.page_size_mm.width_mm,
+            page_height_mm=workspace.page_size_mm.height_mm,
+            margin_left_mm=workspace.margins_mm.left_mm,
+            margin_top_mm=workspace.margins_mm.top_mm,
+            margin_right_mm=workspace.margins_mm.right_mm,
+            margin_bottom_mm=workspace.margins_mm.bottom_mm,
+        )
+
+    def build_scope_key_for_run(
+        self,
+        *,
+        run: PlotRun,
+        camera_driver: str,
+        camera_device_id: Optional[str],
+    ) -> Optional[str]:
+        if camera_device_id is None:
+            return None
+        workspace = run.plotter_run_details.get("workspace")
+        if not isinstance(workspace, dict):
+            return None
+        page_size = workspace.get("page_size_mm")
+        margins = workspace.get("margins_mm")
+        if not isinstance(page_size, dict) or not isinstance(margins, dict):
+            return None
+        return self.build_scope_key(
+            camera_driver=camera_driver,
+            camera_device_id=camera_device_id,
+            page_width_mm=float(page_size["width_mm"]),
+            page_height_mm=float(page_size["height_mm"]),
+            margin_left_mm=float(margins["left_mm"]),
+            margin_top_mm=float(margins["top_mm"]),
+            margin_right_mm=float(margins["right_mm"]),
+            margin_bottom_mm=float(margins["bottom_mm"]),
+        )
+
     def create_record(
         self,
         *,
@@ -113,4 +160,3 @@ class CaptureReviewMemoryStore:
 
 class CaptureReviewMemoryPayload(BaseModel):
     records: dict[str, dict] = Field(default_factory=dict)
-

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow.py
@@ -194,7 +194,11 @@ class PlotWorkflowService:
 
     def reuse_last_capture_review(self, run_id: str) -> PlotRunCaptureReviewResponse:
         run = self._run_store.get(run_id)
-        scope_key = self._executor._build_review_scope_key_from_run(run)
+        scope_key = self._review_memory_store.build_scope_key_for_run(
+            run=run,
+            camera_driver=self._camera.driver,
+            camera_device_id=self._camera_device_id(),
+        )
         record = self._review_memory_store.get(scope_key) if scope_key is not None else None
         if record is None:
             raise AppConflictError("No previously confirmed quad is available for this setup.")
@@ -295,6 +299,20 @@ class PlotWorkflowService:
                 message=str(exc),
             )
             self._run_store.save(run)
+
+    def _camera_device_id(self) -> Optional[str]:
+        details = self._camera.get_status().details
+        if not isinstance(details, dict):
+            return None
+        for key in (
+            "effective_selected_device_id",
+            "active_device_id",
+            "persisted_selected_device_id",
+        ):
+            value = details.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return self._camera.driver
 
 
 __all__ = ["PlotAssetStore", "PlotRunStore", "PlotWorkflowService"]

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
@@ -145,9 +145,10 @@ class PlotRunExecutor:
                     content=capture_artifact.content,
                     normalization_target=normalization_target,
                 )
-                scope_key = self._build_review_scope_key(
+                scope_key = self._review_memory_store.build_scope_key_for_workspace(
                     workspace=workspace,
                     camera_driver=self._camera.driver,
+                    camera_device_id=self._camera_device_id(),
                 )
                 reuse_last_available = (
                     self._review_memory_store.get(scope_key) is not None
@@ -301,7 +302,11 @@ class PlotRunExecutor:
                 update={"capture": updated_capture}
             )
         if persist_review_memory and review.confirmation_source in {"adjusted", "reused_last"}:
-            scope_key = self._build_review_scope_key_from_run(run)
+            scope_key = self._review_memory_store.build_scope_key_for_run(
+                run=run,
+                camera_driver=self._camera.driver,
+                camera_device_id=self._camera_device_id(),
+            )
             if scope_key is not None:
                 workspace = run.plotter_run_details["workspace"]
                 self._review_memory_store.save(
@@ -330,48 +335,6 @@ class PlotRunExecutor:
         run.updated_at = datetime.now(timezone.utc)
         self._run_store.save(run)
         return run
-
-    def _build_review_scope_key(
-        self,
-        *,
-        workspace: PlotterWorkspace,
-        camera_driver: str,
-    ) -> Optional[str]:
-        camera_device_id = self._camera_device_id()
-        if camera_device_id is None:
-            return None
-        return self._review_memory_store.build_scope_key(
-            camera_driver=camera_driver,
-            camera_device_id=camera_device_id,
-            page_width_mm=workspace.page_size_mm.width_mm,
-            page_height_mm=workspace.page_size_mm.height_mm,
-            margin_left_mm=workspace.margins_mm.left_mm,
-            margin_top_mm=workspace.margins_mm.top_mm,
-            margin_right_mm=workspace.margins_mm.right_mm,
-            margin_bottom_mm=workspace.margins_mm.bottom_mm,
-        )
-
-    def _build_review_scope_key_from_run(self, run: PlotRun) -> Optional[str]:
-        workspace = run.plotter_run_details.get("workspace")
-        if not isinstance(workspace, dict):
-            return None
-        page_size = workspace.get("page_size_mm")
-        margins = workspace.get("margins_mm")
-        if not isinstance(page_size, dict) or not isinstance(margins, dict):
-            return None
-        camera_device_id = self._camera_device_id()
-        if camera_device_id is None:
-            return None
-        return self._review_memory_store.build_scope_key(
-            camera_driver=self._camera.driver,
-            camera_device_id=camera_device_id,
-            page_width_mm=float(page_size["width_mm"]),
-            page_height_mm=float(page_size["height_mm"]),
-            margin_left_mm=float(margins["left_mm"]),
-            margin_top_mm=float(margins["top_mm"]),
-            margin_right_mm=float(margins["right_mm"]),
-            margin_bottom_mm=float(margins["bottom_mm"]),
-        )
 
     def _camera_device_id(self) -> Optional[str]:
         details = self._camera.get_status().details

--- a/apps/api/tests/test_services.py
+++ b/apps/api/tests/test_services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import threading
 import time
 
@@ -16,7 +17,13 @@ from learn_to_draw_api.models import (
     HardwareBusyError,
     HardwareUnavailableError,
     InvalidArtifactError,
+    MarginsMm,
+    PlotAsset,
+    PlotRun,
+    PlotterWorkspace,
+    SizeMm,
 )
+from learn_to_draw_api.services.capture_review_memory import CaptureReviewMemoryStore
 from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
 from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
@@ -132,6 +139,74 @@ def build_workspace_service(tmp_path):
             workspace_dir=tmp_path / "workspace",
         ),
         device_settings_service=build_device_settings_service(tmp_path),
+    )
+
+
+def _workspace() -> PlotterWorkspace:
+    return PlotterWorkspace(
+        plotter_bounds_mm=SizeMm(width_mm=300.0, height_mm=218.0),
+        page_size_mm=SizeMm(width_mm=210.0, height_mm=297.0),
+        margins_mm=MarginsMm(left_mm=20.0, top_mm=21.0, right_mm=22.0, bottom_mm=23.0),
+        drawable_area_mm=SizeMm(width_mm=168.0, height_mm=253.0),
+        updated_at=datetime.now(timezone.utc),
+        source="config_default",
+    )
+
+
+def _plot_run_with_workspace(workspace: PlotterWorkspace) -> PlotRun:
+    now = datetime.now(timezone.utc)
+    return PlotRun(
+        id="run-1",
+        status="completed",
+        created_at=now,
+        updated_at=now,
+        asset=PlotAsset(
+            id="asset-1",
+            kind="built_in_pattern",
+            pattern_id="test-grid",
+            name="Test Grid",
+            timestamp=now,
+            file_path="/tmp/test-grid.svg",
+            public_url="/plot-assets/test-grid.svg",
+            mime_type="image/svg+xml",
+        ),
+        plotter_run_details={"workspace": workspace.model_dump(mode="json")},
+    )
+
+
+def test_capture_review_memory_builds_compatible_scope_keys_from_workspace_and_run(tmp_path):
+    store = CaptureReviewMemoryStore(tmp_path / "workspace")
+    workspace = _workspace()
+    expected = "camerabridge|camera-1|210.000|297.000|20.000|21.000|22.000|23.000"
+
+    from_workspace = store.build_scope_key_for_workspace(
+        workspace=workspace,
+        camera_driver="camerabridge",
+        camera_device_id="camera-1",
+    )
+    from_run = store.build_scope_key_for_run(
+        run=_plot_run_with_workspace(workspace),
+        camera_driver="camerabridge",
+        camera_device_id="camera-1",
+    )
+
+    assert from_workspace == expected
+    assert from_run == expected
+
+
+def test_capture_review_memory_returns_no_scope_key_without_run_workspace(tmp_path):
+    store = CaptureReviewMemoryStore(tmp_path / "workspace")
+    run = _plot_run_with_workspace(_workspace()).model_copy(
+        update={"plotter_run_details": {}}
+    )
+
+    assert (
+        store.build_scope_key_for_run(
+            run=run,
+            camera_driver="camerabridge",
+            camera_device_id="camera-1",
+        )
+        is None
     )
 
 


### PR DESCRIPTION
## Summary

- Move capture-review scope-key construction behind public `CaptureReviewMemoryStore` helpers.
- Update `PlotWorkflowService` and `PlotRunExecutor` to call that seam instead of sharing executor private methods.
- Add focused tests that lock the existing scope-key format for workspace-derived and persisted-run-derived keys.

## Notes

- No route, response model, frontend, or artifact-model changes.
- The persisted scope-key format is unchanged for compatibility with existing `capture_review_memory.json` records.

Closes #27

## Verification

- `cd apps/api && PYTHONPATH=src python3 -m pytest tests/test_services.py tests/test_plot_workflow_service.py tests/test_api.py -q`
- `make api-test`
- `make api-lint`
