### PR TITLE
Add versioned manual capture registration

### DIFF
--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -58,6 +58,11 @@ class NormalizationCorners(BaseModel):
 
 class NormalizationTransform(BaseModel):
     matrix: list[list[float]]
+    inverse_matrix: Optional[list[list[float]]] = None
+    source_space: Optional[Literal["raw_capture_px"]] = None
+    destination_space: Optional[Literal["page_px"]] = None
+    pixels_per_mm_x: Optional[float] = Field(default=None, gt=0)
+    pixels_per_mm_y: Optional[float] = Field(default=None, gt=0)
 
 
 class NormalizationOutput(BaseModel):
@@ -66,7 +71,13 @@ class NormalizationOutput(BaseModel):
     aspect_ratio: float = Field(gt=0)
 
 
-NormalizationMethod = Literal["paper_contour_v3", "paper_region_v2", "paper_edges_v1", "fallback_full_frame"]
+NormalizationMethod = Literal[
+    "paper_contour_v3",
+    "paper_region_v2",
+    "paper_edges_v1",
+    "fallback_full_frame",
+    "manual_corners_v2",
+]
 NormalizationTargetFrameSource = Literal["prepared_svg", "workspace_drawable_area"]
 NormalizationFrameKind = Literal["page_aligned"]
 
@@ -76,6 +87,7 @@ class NormalizationFrame(BaseModel):
     version: int = Field(ge=1)
     page_width_mm: float = Field(gt=0)
     page_height_mm: float = Field(gt=0)
+    origin: Optional[Literal["top-left"]] = None
 
 
 class NormalizationDiagnosticCandidate(BaseModel):
@@ -115,7 +127,7 @@ class NormalizationDiagnostics(BaseModel):
 
 class NormalizationMetadata(BaseModel):
     method: NormalizationMethod
-    confidence: float = Field(ge=0, le=1)
+    confidence: Optional[float] = Field(default=None, ge=0, le=1)
     corners: NormalizationCorners
     transform: NormalizationTransform
     output: NormalizationOutput
@@ -132,17 +144,19 @@ class NormalizedCaptureArtifacts(BaseModel):
 
 
 CaptureReviewStatus = Literal["pending", "confirmed"]
-CaptureReviewConfirmationSource = Literal["auto", "adjusted", "reused_last"]
+CaptureReviewConfirmationSource = Literal["auto", "adjusted", "reused_last", "manual"]
 
 
 class CaptureReview(BaseModel):
+    registration_version: int = Field(default=1, ge=1)
+    review_mode: Optional[Literal["manual_corners"]] = None
     review_required: bool
     review_status: CaptureReviewStatus
     proposed_corners: NormalizationCorners
     confirmed_corners: Optional[NormalizationCorners] = None
     confirmation_source: Optional[CaptureReviewConfirmationSource] = None
-    detector_method: NormalizationMethod
-    detector_confidence: float = Field(ge=0, le=1)
+    detector_method: Optional[NormalizationMethod] = None
+    detector_confidence: Optional[float] = Field(default=None, ge=0, le=1)
     reuse_last_available: bool = False
 
 
@@ -387,6 +401,10 @@ class PlotRunCaptureReviewPayload(BaseModel):
 
 
 class PlotRunCaptureReviewAdjustRequest(BaseModel):
+    corners: NormalizationCorners
+
+
+class PlotRunCaptureReviewConfirmRequest(BaseModel):
     corners: NormalizationCorners
 
 

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -21,6 +21,7 @@ from learn_to_draw_api.models import (
     PlotterSafeBoundsRequest,
     PlotRun,
     PlotRunCaptureReviewAdjustRequest,
+    PlotRunCaptureReviewConfirmRequest,
     PlotRunCaptureReviewPayload,
     PlotRunCaptureReviewResponse,
     PlotRunCreateRequest,
@@ -167,6 +168,16 @@ def build_api_router(
         request: PlotRunCaptureReviewAdjustRequest,
     ) -> PlotRunCaptureReviewResponse:
         return plot_workflow_service.adjust_capture_review(run_id, request)
+
+    @router.post(
+        "/api/plot-runs/{run_id}/capture-review/confirm",
+        response_model=PlotRunCaptureReviewResponse,
+    )
+    def post_plot_run_capture_review_confirm(
+        run_id: str,
+        request: PlotRunCaptureReviewConfirmRequest,
+    ) -> PlotRunCaptureReviewResponse:
+        return plot_workflow_service.confirm_capture_review(run_id, request)
 
     @router.post(
         "/api/plot-runs/{run_id}/capture-review/reuse-last",

--- a/apps/api/src/learn_to_draw_api/services/capture_normalization/service.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_normalization/service.py
@@ -6,6 +6,7 @@ import cv2
 import numpy as np
 
 from learn_to_draw_api.models import (
+    InvalidArtifactError,
     NormalizationCorners,
     NormalizationDiagnostics,
     NormalizationFrame,
@@ -23,6 +24,8 @@ from .region_detector import RegionDetectorMixin
 from .rendering import RenderingMixin
 from .types import (
     CaptureNormalizationProposal,
+    CANONICAL_LONG_SIDE_PX,
+    CANONICAL_PAGE_BACKGROUND_COLOR,
     DetectionCandidate,
     DetectionResult,
     DetectorRunDiagnostics,
@@ -70,6 +73,188 @@ class CaptureNormalizationService(
             detection_result=detection_result,
             target=target,
         )
+
+    def initial_registration_corners(
+        self,
+        *,
+        image_width: int,
+        image_height: int,
+    ) -> NormalizationCorners:
+        if image_width < 2 or image_height < 2:
+            raise InvalidArtifactError("Capture dimensions must be at least 2 by 2 pixels.")
+        max_x = float(image_width - 1)
+        max_y = float(image_height - 1)
+        inset_x = max_x * 0.05
+        inset_y = max_y * 0.05
+        return NormalizationCorners(
+            top_left=(round(inset_x, 3), round(inset_y, 3)),
+            top_right=(round(max_x - inset_x, 3), round(inset_y, 3)),
+            bottom_right=(round(max_x - inset_x, 3), round(max_y - inset_y, 3)),
+            bottom_left=(round(inset_x, 3), round(max_y - inset_y, 3)),
+        )
+
+    def validate_registration_corners(
+        self,
+        *,
+        corners: NormalizationCorners,
+        image_width: int,
+        image_height: int,
+    ) -> np.ndarray:
+        if image_width < 2 or image_height < 2:
+            raise InvalidArtifactError("Capture dimensions must be at least 2 by 2 pixels.")
+        points = self._corners_to_numpy(corners).astype(np.float64)
+        if not np.isfinite(points).all():
+            raise InvalidArtifactError("Registration corners must contain finite coordinates.")
+
+        max_x = float(image_width - 1)
+        max_y = float(image_height - 1)
+        if (
+            np.any(points[:, 0] < 0)
+            or np.any(points[:, 0] > max_x)
+            or np.any(points[:, 1] < 0)
+            or np.any(points[:, 1] > max_y)
+        ):
+            raise InvalidArtifactError("Registration corners must be inside the capture bounds.")
+
+        edges = np.roll(points, -1, axis=0) - points
+        edge_lengths = np.linalg.norm(edges, axis=1)
+        if np.any(edge_lengths < 8.0):
+            raise InvalidArtifactError("Every registration edge must be at least 8 pixels long.")
+
+        next_edges = np.roll(edges, -1, axis=0)
+        cross_products = (
+            edges[:, 0] * next_edges[:, 1] - edges[:, 1] * next_edges[:, 0]
+        )
+        if np.any(cross_products <= 0):
+            raise InvalidArtifactError(
+                "Registration corners must form a convex, non-crossing TL/TR/BR/BL quad."
+            )
+
+        area = 0.5 * abs(
+            float(
+                np.dot(points[:, 0], np.roll(points[:, 1], -1))
+                - np.dot(points[:, 1], np.roll(points[:, 0], -1))
+            )
+        )
+        if area < float(image_width * image_height) * 0.01:
+            raise InvalidArtifactError(
+                "Registration quad must cover at least 1% of the capture area."
+            )
+        return points.astype(np.float32)
+
+    def register_with_corners(
+        self,
+        *,
+        content: bytes,
+        target: NormalizationTarget,
+        corners: NormalizationCorners,
+    ) -> NormalizationArtifacts:
+        decoded = self._decode_image(content)
+        if decoded is None:
+            raise InvalidArtifactError("Capture content is not a supported raster image.")
+        image_height, image_width = decoded.shape[:2]
+        source = self.validate_registration_corners(
+            corners=corners,
+            image_width=image_width,
+            image_height=image_height,
+        )
+        output_width, output_height = self._canonical_output_size(target.aspect_ratio)
+        destination = np.array(
+            [
+                [0.0, 0.0],
+                [float(output_width - 1), 0.0],
+                [float(output_width - 1), float(output_height - 1)],
+                [0.0, float(output_height - 1)],
+            ],
+            dtype=np.float32,
+        )
+        matrix = cv2.getPerspectiveTransform(source, destination)
+        inverse_matrix = np.linalg.inv(matrix)
+        rectified = cv2.warpPerspective(
+            decoded,
+            matrix,
+            (output_width, output_height),
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=CANONICAL_PAGE_BACKGROUND_COLOR,
+        )
+        grayscale = cv2.cvtColor(rectified, cv2.COLOR_BGR2GRAY)
+        debug_overlay = self._build_registration_overlay(decoded, source)
+        return NormalizationArtifacts(
+            rectified_color=self._encode_png(rectified),
+            rectified_grayscale=self._encode_png(grayscale),
+            debug_overlay=self._encode_png(debug_overlay),
+            metadata=NormalizationMetadata(
+                method="manual_corners_v2",
+                confidence=None,
+                corners=corners,
+                transform=NormalizationTransform(
+                    matrix=self._rounded_matrix(matrix),
+                    inverse_matrix=self._rounded_matrix(inverse_matrix),
+                    source_space="raw_capture_px",
+                    destination_space="page_px",
+                    pixels_per_mm_x=(output_width - 1) / target.page_width_mm,
+                    pixels_per_mm_y=(output_height - 1) / target.page_height_mm,
+                ),
+                output=NormalizationOutput(
+                    width=output_width,
+                    height=output_height,
+                    aspect_ratio=target.aspect_ratio,
+                ),
+                target_frame_source=target.source,
+                diagnostics=None,
+                frame=NormalizationFrame(
+                    kind="page_aligned",
+                    version=2,
+                    page_width_mm=target.page_width_mm,
+                    page_height_mm=target.page_height_mm,
+                    origin="top-left",
+                ),
+            ),
+        )
+
+    def _canonical_output_size(self, aspect_ratio: float) -> tuple[int, int]:
+        if aspect_ratio >= 1:
+            return CANONICAL_LONG_SIDE_PX, max(
+                1, int(round(CANONICAL_LONG_SIDE_PX / aspect_ratio))
+            )
+        return (
+            max(1, int(round(CANONICAL_LONG_SIDE_PX * aspect_ratio))),
+            CANONICAL_LONG_SIDE_PX,
+        )
+
+    def _rounded_matrix(self, matrix: np.ndarray) -> list[list[float]]:
+        return [[float(round(value, 9)) for value in row] for row in matrix.tolist()]
+
+    def _build_registration_overlay(
+        self,
+        image: np.ndarray,
+        corners: np.ndarray,
+    ) -> np.ndarray:
+        overlay = image.copy()
+        polygon = np.round(corners).astype(np.int32).reshape((-1, 1, 2))
+        thickness = max(2, int(round(max(image.shape[:2]) / 600)))
+        cv2.polylines(
+            overlay,
+            [polygon],
+            isClosed=True,
+            color=(20, 210, 20),
+            thickness=thickness,
+            lineType=cv2.LINE_AA,
+        )
+        for point, label in zip(corners, ("TL", "TR", "BR", "BL")):
+            x, y = (int(round(point[0])), int(round(point[1])))
+            cv2.circle(overlay, (x, y), thickness * 3, (20, 210, 20), thickness=-1)
+            cv2.putText(
+                overlay,
+                label,
+                (x + thickness * 4, y - thickness * 4),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.65,
+                (20, 210, 20),
+                thickness,
+                cv2.LINE_AA,
+            )
+        return overlay
 
     def inspect(
         self,

--- a/apps/api/src/learn_to_draw_api/services/capture_service.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_service.py
@@ -8,6 +8,7 @@ from learn_to_draw_api.adapters.camera import CaptureArtifact
 from learn_to_draw_api.models import (
     CaptureMetadata,
     CaptureReview,
+    InvalidArtifactError,
     NormalizationCorners,
     NormalizationDiagnostics,
     NormalizationMethod,
@@ -107,6 +108,19 @@ class CaptureService:
     ) -> CaptureMetadata:
         return self._store.save_review(capture_id, review)
 
+    def validate_registration_corners(
+        self,
+        *,
+        corners: NormalizationCorners,
+        image_width: int,
+        image_height: int,
+    ) -> None:
+        self._normalization_service.validate_registration_corners(
+            corners=corners,
+            image_width=image_width,
+            image_height=image_height,
+        )
+
     def finalize_capture_with_review(
         self,
         *,
@@ -114,19 +128,30 @@ class CaptureService:
         content: bytes,
         normalization_target: NormalizationTarget,
         corners: NormalizationCorners,
-        method: NormalizationMethod,
-        confidence: float,
+        method: Optional[NormalizationMethod],
+        confidence: Optional[float],
         diagnostics: Optional[NormalizationDiagnostics],
         review: CaptureReview,
     ) -> CaptureMetadata:
-        normalized = self._normalization_service.normalize_with_corners(
-            content=content,
-            target=normalization_target,
-            corners=corners,
-            method=method,
-            confidence=confidence,
-            diagnostics=diagnostics,
-        )
+        if review.registration_version >= 2:
+            normalized = self._normalization_service.register_with_corners(
+                content=content,
+                target=normalization_target,
+                corners=corners,
+            )
+        else:
+            if method is None or confidence is None:
+                raise InvalidArtifactError(
+                    "Legacy capture review is missing detector metadata."
+                )
+            normalized = self._normalization_service.normalize_with_corners(
+                content=content,
+                target=normalization_target,
+                corners=corners,
+                method=method,
+                confidence=confidence,
+                diagnostics=diagnostics,
+            )
         return self._store_normalized_artifacts(
             capture_id,
             normalized=normalized,

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow.py
@@ -16,6 +16,7 @@ from learn_to_draw_api.models import (
     PlotAsset,
     PlotRun,
     PlotRunCaptureReviewAdjustRequest,
+    PlotRunCaptureReviewConfirmRequest,
     PlotRunCaptureReviewPayload,
     PlotRunCaptureMode,
     PlotRunCaptureReviewResponse,
@@ -192,6 +193,22 @@ class PlotWorkflowService:
             run=run,
         )
 
+    def confirm_capture_review(
+        self,
+        run_id: str,
+        request: PlotRunCaptureReviewConfirmRequest,
+    ) -> PlotRunCaptureReviewResponse:
+        run = self._confirm_capture_review(
+            run_id,
+            corners=request.corners,
+            source="manual",
+            registration_version=2,
+        )
+        return PlotRunCaptureReviewResponse(
+            message="Manual capture registration saved. Finalizing normalization.",
+            run=run,
+        )
+
     def reuse_last_capture_review(self, run_id: str) -> PlotRunCaptureReviewResponse:
         run = self._run_store.get(run_id)
         scope_key = self._review_memory_store.build_scope_key_for_run(
@@ -246,6 +263,7 @@ class PlotWorkflowService:
         *,
         corners,
         source,
+        registration_version: Optional[int] = None,
     ) -> PlotRun:
         with self._lock:
             run = self._run_store.get(run_id)
@@ -255,12 +273,26 @@ class PlotWorkflowService:
                 raise AppConflictError("This plot run does not have a capture review payload.")
             review = run.capture.review
             confirmed_corners = corners or review.proposed_corners
+            if registration_version is not None:
+                self._capture_service.validate_registration_corners(
+                    corners=confirmed_corners,
+                    image_width=run.capture.width,
+                    image_height=run.capture.height,
+                )
+            review_updates = {
+                "review_status": "confirmed",
+                "confirmed_corners": confirmed_corners,
+                "confirmation_source": source,
+            }
+            if registration_version is not None:
+                review_updates.update(
+                    {
+                        "registration_version": registration_version,
+                        "review_mode": "manual_corners",
+                    }
+                )
             updated_review = review.model_copy(
-                update={
-                    "review_status": "confirmed",
-                    "confirmed_corners": confirmed_corners,
-                    "confirmation_source": source,
-                }
+                update=review_updates
             )
             updated_capture = self._capture_service.save_capture_review(
                 run.capture.id,

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
@@ -31,7 +31,9 @@ class PlotRunStore:
     def save(self, run: PlotRun) -> PlotRun:
         with self._lock:
             metadata_path = self._runs_dir / f"{run.id}.json"
-            metadata_path.write_text(run.model_dump_json(indent=2), encoding="utf-8")
+            temp_path = metadata_path.with_suffix(".json.tmp")
+            temp_path.write_text(run.model_dump_json(indent=2), encoding="utf-8")
+            temp_path.replace(metadata_path)
             self._cache[run.id] = run
         return run
 

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -751,6 +751,77 @@ def test_plot_run_capture_review_accept_endpoint(tmp_path):
     assert completed["capture"]["review"]["confirmation_source"] == "auto"
 
 
+def test_plot_run_capture_review_confirm_endpoint_creates_v2_registration(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=MockPlotter(plot_delay_s=0),
+        camera=LowConfidenceCamera(),
+    ) as client:
+        asset_response = client.post(
+            "/api/plot-assets/patterns",
+            json={"pattern_id": "test-grid"},
+        )
+        run_response = client.post(
+            "/api/plot-runs", json={"asset_id": asset_response.json()["id"]}
+        )
+        pending = wait_for_run_status(
+            client, run_response.json()["id"], {"awaiting_capture_review"}
+        )
+        corners = pending["capture"]["review"]["proposed_corners"]
+        confirm_response = client.post(
+            f"/api/plot-runs/{pending['id']}/capture-review/confirm",
+            json={"corners": corners},
+        )
+        completed = wait_for_run_completion(client, pending["id"])
+
+    assert confirm_response.status_code == 200
+    assert confirm_response.json()["run"]["status"] == "capturing"
+    assert completed["capture"]["review"]["registration_version"] == 2
+    assert completed["capture"]["review"]["review_mode"] == "manual_corners"
+    assert completed["capture"]["review"]["confirmation_source"] == "manual"
+    metadata = completed["capture"]["normalized"]["metadata"]
+    assert metadata["method"] == "manual_corners_v2"
+    assert metadata["frame"]["version"] == 2
+    assert metadata["transform"]["source_space"] == "raw_capture_px"
+    assert metadata["transform"]["destination_space"] == "page_px"
+    assert metadata["transform"]["inverse_matrix"] is not None
+
+
+def test_plot_run_capture_review_confirm_rejects_invalid_quad_without_state_change(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=MockPlotter(plot_delay_s=0),
+        camera=LowConfidenceCamera(),
+    ) as client:
+        asset_response = client.post(
+            "/api/plot-assets/patterns",
+            json={"pattern_id": "test-grid"},
+        )
+        run_response = client.post(
+            "/api/plot-runs", json={"asset_id": asset_response.json()["id"]}
+        )
+        pending = wait_for_run_status(
+            client, run_response.json()["id"], {"awaiting_capture_review"}
+        )
+        invalid_corners = {
+            "top_left": [50.0, 50.0],
+            "top_right": [590.0, 430.0],
+            "bottom_right": [590.0, 50.0],
+            "bottom_left": [50.0, 430.0],
+        }
+        confirm_response = client.post(
+            f"/api/plot-runs/{pending['id']}/capture-review/confirm",
+            json={"corners": invalid_corners},
+        )
+        unchanged = client.get(f"/api/plot-runs/{pending['id']}").json()
+
+    assert confirm_response.status_code == 400
+    assert "convex, non-crossing" in confirm_response.json()["detail"]
+    assert unchanged["status"] == "awaiting_capture_review"
+    assert unchanged["capture"]["review"]["review_status"] == "pending"
+    assert unchanged["capture"]["normalized"] is None
+
+
 def test_plot_run_capture_review_reuse_last_endpoint(tmp_path):
     with create_test_client(
         tmp_path,

--- a/apps/api/tests/test_capture_normalization.py
+++ b/apps/api/tests/test_capture_normalization.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import cv2
 import numpy as np
+import pytest
+
+from learn_to_draw_api.models import (
+    InvalidArtifactError,
+    NormalizationCorners,
+    NormalizationMetadata,
+)
 
 from learn_to_draw_api.services.capture_normalization import (
     CaptureNormalizationService,
@@ -635,3 +642,183 @@ def test_capture_normalization_falls_back_to_full_frame_when_no_rectangle_found(
     assert result.metadata.output.width == 2048
     assert result.metadata.output.height == 1950
     assert result.metadata.corners.top_left == (0.0, 0.0)
+
+
+@pytest.mark.parametrize(
+    ("page_width_mm", "page_height_mm", "expected_size"),
+    [
+        (210.0, 297.0, (1448, 2048)),
+        (297.0, 210.0, (2048, 1448)),
+    ],
+)
+def test_manual_registration_maps_directly_to_canonical_page(
+    page_width_mm,
+    page_height_mm,
+    expected_size,
+):
+    service = CaptureNormalizationService()
+    image = np.full((720, 960, 3), 245, dtype=np.uint8)
+    corners = NormalizationCorners(
+        top_left=(120.0, 80.0),
+        top_right=(850.0, 105.0),
+        bottom_right=(900.0, 650.0),
+        bottom_left=(75.0, 675.0),
+    )
+
+    result = service.register_with_corners(
+        content=_encode_png(image),
+        target=target_from_page_size(
+            page_width_mm=page_width_mm,
+            page_height_mm=page_height_mm,
+            source="prepared_svg",
+        ),
+        corners=corners,
+    )
+
+    width, height = expected_size
+    assert (result.metadata.output.width, result.metadata.output.height) == expected_size
+    assert _decode_png(result.rectified_color).shape[:2] == (height, width)
+    assert _decode_png(result.rectified_grayscale).shape[:2] == (height, width)
+    assert result.metadata.method == "manual_corners_v2"
+    assert result.metadata.confidence is None
+    assert result.metadata.frame is not None
+    assert result.metadata.frame.version == 2
+    assert result.metadata.frame.origin == "top-left"
+    assert result.metadata.transform.source_space == "raw_capture_px"
+    assert result.metadata.transform.destination_space == "page_px"
+    assert result.metadata.transform.pixels_per_mm_x == pytest.approx(
+        (width - 1) / page_width_mm
+    )
+    assert result.metadata.transform.pixels_per_mm_y == pytest.approx(
+        (height - 1) / page_height_mm
+    )
+
+    matrix = np.array(result.metadata.transform.matrix)
+    inverse = np.array(result.metadata.transform.inverse_matrix)
+    assert matrix @ inverse == pytest.approx(np.eye(3), abs=1e-6)
+    source = np.array(
+        [[corners.top_left, corners.top_right, corners.bottom_right, corners.bottom_left]],
+        dtype=np.float64,
+    )
+    projected = cv2.perspectiveTransform(source, matrix)[0]
+    assert projected == pytest.approx(
+        np.array(
+            [
+                [0.0, 0.0],
+                [float(width - 1), 0.0],
+                [float(width - 1), float(height - 1)],
+                [0.0, float(height - 1)],
+            ]
+        ),
+        abs=1e-3,
+    )
+
+
+def test_manual_registration_seeds_five_percent_inset_quad():
+    corners = CaptureNormalizationService().initial_registration_corners(
+        image_width=1001,
+        image_height=501,
+    )
+
+    assert corners == NormalizationCorners(
+        top_left=(50.0, 25.0),
+        top_right=(950.0, 25.0),
+        bottom_right=(950.0, 475.0),
+        bottom_left=(50.0, 475.0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("corners", "message"),
+    [
+        (
+            NormalizationCorners(
+                top_left=(-1.0, 20.0),
+                top_right=(180.0, 20.0),
+                bottom_right=(180.0, 180.0),
+                bottom_left=(20.0, 180.0),
+            ),
+            "inside the capture bounds",
+        ),
+        (
+            NormalizationCorners(
+                top_left=(20.0, 20.0),
+                top_right=(180.0, 180.0),
+                bottom_right=(180.0, 20.0),
+                bottom_left=(20.0, 180.0),
+            ),
+            "convex, non-crossing",
+        ),
+        (
+            NormalizationCorners(
+                top_left=(20.0, 20.0),
+                top_right=(180.0, 20.0),
+                bottom_right=(100.0, 80.0),
+                bottom_left=(20.0, 180.0),
+            ),
+            "convex, non-crossing",
+        ),
+        (
+            NormalizationCorners(
+                top_left=(20.0, 20.0),
+                top_right=(25.0, 20.0),
+                bottom_right=(25.0, 180.0),
+                bottom_left=(20.0, 180.0),
+            ),
+            "at least 8 pixels",
+        ),
+        (
+            NormalizationCorners(
+                top_left=(20.0, 20.0),
+                top_right=(35.0, 20.0),
+                bottom_right=(35.0, 35.0),
+                bottom_left=(20.0, 35.0),
+            ),
+            "at least 1%",
+        ),
+        (
+            NormalizationCorners(
+                top_left=(float("nan"), 20.0),
+                top_right=(180.0, 20.0),
+                bottom_right=(180.0, 180.0),
+                bottom_left=(20.0, 180.0),
+            ),
+            "finite coordinates",
+        ),
+    ],
+)
+def test_manual_registration_rejects_invalid_quads(corners, message):
+    with pytest.raises(InvalidArtifactError, match=message):
+        CaptureNormalizationService().validate_registration_corners(
+            corners=corners,
+            image_width=200,
+            image_height=200,
+        )
+
+
+def test_v1_normalization_metadata_remains_parseable():
+    metadata = NormalizationMetadata.model_validate(
+        {
+            "method": "paper_edges_v1",
+            "confidence": 0.42,
+            "corners": {
+                "top_left": [10.0, 10.0],
+                "top_right": [190.0, 10.0],
+                "bottom_right": [190.0, 190.0],
+                "bottom_left": [10.0, 190.0],
+            },
+            "transform": {"matrix": [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]},
+            "output": {"width": 200, "height": 200, "aspect_ratio": 1.0},
+            "target_frame_source": "prepared_svg",
+            "frame": {
+                "kind": "page_aligned",
+                "version": 1,
+                "page_width_mm": 200.0,
+                "page_height_mm": 200.0,
+            },
+        }
+    )
+
+    assert metadata.frame is not None and metadata.frame.version == 1
+    assert metadata.transform.inverse_matrix is None
+    assert metadata.transform.source_space is None


### PR DESCRIPTION
Closes #36
Parent: #34

## Summary

- Add a validated, direct four-corner registration path that emits page-aligned V2 captures.
- Persist forward and inverse transforms with explicit pixel coordinate spaces and pixels-per-mm values.
- Add the manual confirmation endpoint while retaining legacy review endpoints until the frontend slice.
- Preserve V1 artifact parsing and prove invalid registration cannot advance run state.
- Persist run metadata through atomic replacement so asynchronous updates cannot expose truncated JSON to readers.

Slice plan: implement the backend geometry and versioned contract first, without switching or breaking the current frontend workflow.

## Checks

- [x] make api-test — 127 passed
- [ ] make web-test — not required for this backend-only slice; CI web job passed
- [ ] make web-build — not required for this backend-only slice; CI web job passed
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why
- [x] make api-lint — passed

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior
- [x] I called out version-sensitive behavior when relevant
- [x] I updated docs or config notes if behavior changed — docs are intentionally part of #35 when the workflow switches
- [x] This PR is a narrow, reviewable slice

Hardware assumptions: page corners describe a flat plane and all four corners are visible. No AxiDraw API behavior changes in this slice. Real CameraBridge/AxiDraw validation remains tracked on #34 and blocks completion of the final slice.