### PR TITLE
Seed manual registration with automatic corner proposals

### DIFF
--- a/apps/api/src/learn_to_draw_api/api.py
+++ b/apps/api/src/learn_to_draw_api/api.py
@@ -14,6 +14,9 @@ from learn_to_draw_api.config import AppConfig
 from learn_to_draw_api.errors import register_exception_handlers
 from learn_to_draw_api.routes import build_api_router
 from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
+from learn_to_draw_api.services.capture_registration_proposal import (
+    CaptureRegistrationProposalService,
+)
 from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.camera_device_settings import (
@@ -82,6 +85,7 @@ def create_app(
     capture_service = CaptureService(
         store=capture_store,
         normalization_service=CaptureNormalizationService(),
+        proposal_service=CaptureRegistrationProposalService(),
     )
     plot_asset_store = PlotAssetStore(
         assets_dir=app_config.plot_assets_dir,

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -147,6 +147,13 @@ CaptureReviewStatus = Literal["pending", "confirmed"]
 CaptureReviewConfirmationSource = Literal["auto", "adjusted", "reused_last", "manual"]
 
 
+class CaptureReviewProposal(BaseModel):
+    status: Literal["suggested", "fallback"]
+    method: Literal["light_page_edges_v1", "inset_5_percent_v1"]
+    stability_max_px: Optional[float] = Field(default=None, ge=0)
+    fallback_reason: Optional[str] = None
+
+
 class CaptureReview(BaseModel):
     registration_version: int = Field(default=1, ge=1)
     review_mode: Optional[Literal["manual_corners"]] = None
@@ -158,6 +165,7 @@ class CaptureReview(BaseModel):
     detector_method: Optional[NormalizationMethod] = None
     detector_confidence: Optional[float] = Field(default=None, ge=0, le=1)
     reuse_last_available: bool = False
+    proposal: Optional[CaptureReviewProposal] = None
 
 
 class CaptureMetadata(BaseModel):

--- a/apps/api/src/learn_to_draw_api/services/capture_registration_proposal.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_registration_proposal.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import cv2
+import numpy as np
+
+from learn_to_draw_api.models import NormalizationCorners
+
+
+@dataclass(frozen=True)
+class RegistrationProposalAttempt:
+    corners: Optional[NormalizationCorners]
+    stability_max_px: Optional[float]
+    fallback_reason: Optional[str]
+
+
+class CaptureRegistrationProposalService:
+    _THRESHOLD_SHIFTS = (-12.0, -6.0, 0.0, 6.0, 12.0)
+    _APPROXIMATION_RATIOS = (0.002, 0.003, 0.004, 0.006, 0.008, 0.01, 0.015, 0.02, 0.03)
+
+    def propose(
+        self,
+        *,
+        content: bytes,
+        expected_width: int,
+        expected_height: int,
+    ) -> RegistrationProposalAttempt:
+        image = self._decode_image(content)
+        if image is None:
+            return self._unavailable("capture_not_decodable")
+        image_height, image_width = image.shape[:2]
+        if (image_width, image_height) != (expected_width, expected_height):
+            return self._unavailable("capture_dimensions_mismatch")
+
+        luma = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)[:, :, 0]
+        blurred_luma = cv2.GaussianBlur(luma, (0, 0), 5.0)
+        otsu_threshold, _ = cv2.threshold(
+            blurred_luma,
+            0,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        gray = cv2.GaussianBlur(
+            cv2.cvtColor(image, cv2.COLOR_BGR2GRAY).astype(np.float32),
+            (0, 0),
+            1.0,
+        )
+        proposals = []
+        rejection_reasons = []
+        for shift in self._THRESHOLD_SHIFTS:
+            proposal, rejection_reason = self._proposal_at_threshold(
+                blurred_luma=blurred_luma,
+                gray=gray,
+                threshold=float(np.clip(otsu_threshold + shift, 25, 230)),
+            )
+            if proposal is None:
+                rejection_reasons.append(rejection_reason or "proposal_unavailable")
+            else:
+                proposals.append(proposal)
+
+        if len(proposals) != len(self._THRESHOLD_SHIFTS):
+            return self._unavailable(self._most_common_reason(rejection_reasons))
+        proposal_stack = np.stack(proposals)
+        median_proposal = np.median(proposal_stack, axis=0)
+        stability = np.linalg.norm(
+            proposal_stack - median_proposal[None, :, :],
+            axis=2,
+        )
+        stability_max_px = float(stability.max())
+        stability_limit_px = max(2.0, max(image_width, image_height) / 384.0)
+        if stability_max_px > stability_limit_px:
+            return self._unavailable("unstable_across_thresholds")
+
+        return RegistrationProposalAttempt(
+            corners=self._numpy_to_corners(median_proposal),
+            stability_max_px=round(stability_max_px, 3),
+            fallback_reason=None,
+        )
+
+    def _proposal_at_threshold(
+        self,
+        *,
+        blurred_luma: np.ndarray,
+        gray: np.ndarray,
+        threshold: float,
+    ) -> tuple[Optional[np.ndarray], Optional[str]]:
+        image_height, image_width = blurred_luma.shape
+        _, bright_mask = cv2.threshold(
+            blurred_luma,
+            threshold,
+            255,
+            cv2.THRESH_BINARY,
+        )
+        close_size = self._odd_kernel_size(max(image_width, image_height) / 62.0, 7)
+        open_size = self._odd_kernel_size(max(image_width, image_height) / 213.0, 3)
+        bright_mask = cv2.morphologyEx(
+            bright_mask,
+            cv2.MORPH_CLOSE,
+            np.ones((close_size, close_size), dtype=np.uint8),
+            iterations=2,
+        )
+        bright_mask = cv2.morphologyEx(
+            bright_mask,
+            cv2.MORPH_OPEN,
+            np.ones((open_size, open_size), dtype=np.uint8),
+            iterations=1,
+        )
+        contours, _ = cv2.findContours(
+            bright_mask,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_NONE,
+        )
+        image_area = float(image_width * image_height)
+        candidates = sorted(contours, key=cv2.contourArea, reverse=True)
+        contour = next(
+            (
+                candidate
+                for candidate in candidates
+                if cv2.contourArea(candidate) >= image_area * 0.12
+            ),
+            None,
+        )
+        if contour is None:
+            return None, "no_large_bright_region"
+
+        x, y, width, height = cv2.boundingRect(contour)
+        border_count = sum(
+            (
+                x <= 1,
+                y <= 1,
+                x + width >= image_width - 1,
+                y + height >= image_height - 1,
+            )
+        )
+        if border_count >= 2:
+            return None, "bright_region_touches_multiple_borders"
+
+        hull = cv2.convexHull(contour)
+        perimeter = cv2.arcLength(hull, True)
+        coarse = None
+        for ratio in self._APPROXIMATION_RATIOS:
+            approximation = cv2.approxPolyDP(hull, ratio * perimeter, True).reshape(-1, 2)
+            if len(approximation) == 4:
+                coarse = self._order_corners(approximation.astype(np.float32))
+                break
+        if coarse is None:
+            return None, "bright_region_not_quadrilateral"
+
+        try:
+            lines = [
+                self._fit_side(gray, coarse[index], coarse[(index + 1) % 4])
+                for index in range(4)
+            ]
+            refined = np.array(
+                [
+                    self._intersect(lines[3], lines[0]),
+                    self._intersect(lines[0], lines[1]),
+                    self._intersect(lines[1], lines[2]),
+                    self._intersect(lines[2], lines[3]),
+                ],
+                dtype=np.float32,
+            )
+        except (cv2.error, ValueError, np.linalg.LinAlgError):
+            return None, "edge_refinement_failed"
+        if not np.isfinite(refined).all():
+            return None, "edge_refinement_failed"
+        if (
+            np.any(refined[:, 0] < 0)
+            or np.any(refined[:, 0] > image_width - 1)
+            or np.any(refined[:, 1] < 0)
+            or np.any(refined[:, 1] > image_height - 1)
+        ):
+            return None, "physical_corner_outside_capture"
+        return refined, None
+
+    def _fit_side(
+        self,
+        gray: np.ndarray,
+        start: np.ndarray,
+        end: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        vector = end.astype(np.float64) - start.astype(np.float64)
+        length = float(np.linalg.norm(vector))
+        if length < 8.0:
+            raise ValueError("Candidate edge is too short.")
+        tangent = vector / length
+        normal = np.array([-tangent[1], tangent[0]])
+        sample_count = max(100, int(round(length * 0.75)))
+        positions = np.linspace(0.06, 0.94, sample_count)
+        search_radius = max(gray.shape) * 42.0 / 1920.0
+        offsets = np.linspace(-search_radius, search_radius, 337)
+        centers = start[None, :] + positions[:, None] * vector[None, :]
+        points = centers[:, None, :] + offsets[None, :, None] * normal[None, None, :]
+        values = cv2.remap(
+            gray,
+            points[:, :, 0].astype(np.float32),
+            points[:, :, 1].astype(np.float32),
+            cv2.INTER_LINEAR,
+        )
+        gradient = np.abs(values[:, 4:] - values[:, :-4])
+        indexes = np.argmax(gradient, axis=1) + 2
+        rows = np.arange(sample_count)
+        candidates = points[rows, indexes]
+        strengths = gradient[rows, indexes - 2]
+        chosen_offsets = offsets[indexes]
+
+        strength_floor = np.percentile(strengths, 40)
+        strong_offsets = chosen_offsets[strengths >= strength_floor]
+        if strong_offsets.size == 0:
+            raise ValueError("Candidate edge has no usable gradient samples.")
+        median_offset = np.median(strong_offsets)
+        selected = candidates[
+            (strengths >= strength_floor)
+            & (np.abs(chosen_offsets - median_offset) <= max(2.0, search_radius / 8.4))
+        ]
+        if len(selected) < 8:
+            raise ValueError("Candidate edge has too few coherent samples.")
+        for _ in range(3):
+            fitted = cv2.fitLine(
+                selected.astype(np.float32),
+                cv2.DIST_HUBER,
+                0,
+                0.01,
+                0.01,
+            ).reshape(-1)
+            direction = fitted[:2].astype(np.float64)
+            origin = fitted[2:].astype(np.float64)
+            delta = selected - origin
+            residual = np.abs(direction[0] * delta[:, 1] - direction[1] * delta[:, 0])
+            cutoff = max(1.0, float(np.percentile(residual, 80)))
+            selected = selected[residual <= cutoff]
+        return origin, direction / np.linalg.norm(direction)
+
+    def _intersect(
+        self,
+        first: tuple[np.ndarray, np.ndarray],
+        second: tuple[np.ndarray, np.ndarray],
+    ) -> np.ndarray:
+        first_origin, first_direction = first
+        second_origin, second_direction = second
+        parameters = np.linalg.solve(
+            np.column_stack((first_direction, -second_direction)),
+            second_origin - first_origin,
+        )
+        return first_origin + parameters[0] * first_direction
+
+    def _order_corners(self, points: np.ndarray) -> np.ndarray:
+        center = points.mean(axis=0)
+        angles = np.arctan2(points[:, 1] - center[1], points[:, 0] - center[0])
+        ordered = points[np.argsort(angles)]
+        top_left_index = int(np.argmin(ordered.sum(axis=1)))
+        return np.roll(ordered, -top_left_index, axis=0)
+
+    def _numpy_to_corners(self, points: np.ndarray) -> NormalizationCorners:
+        rounded = np.round(points.astype(np.float64), 3)
+        return NormalizationCorners(
+            top_left=tuple(rounded[0]),
+            top_right=tuple(rounded[1]),
+            bottom_right=tuple(rounded[2]),
+            bottom_left=tuple(rounded[3]),
+        )
+
+    def _decode_image(self, content: bytes) -> Optional[np.ndarray]:
+        buffer = np.frombuffer(content, dtype=np.uint8)
+        if buffer.size == 0:
+            return None
+        return cv2.imdecode(buffer, cv2.IMREAD_COLOR)
+
+    def _odd_kernel_size(self, raw_size: float, minimum: int) -> int:
+        size = max(minimum, int(round(raw_size)))
+        return size if size % 2 == 1 else size + 1
+
+    def _most_common_reason(self, reasons: list[str]) -> str:
+        if not reasons:
+            return "proposal_unavailable"
+        return max(set(reasons), key=lambda reason: (reasons.count(reason), reason))
+
+    def _unavailable(self, reason: str) -> RegistrationProposalAttempt:
+        return RegistrationProposalAttempt(
+            corners=None,
+            stability_max_px=None,
+            fallback_reason=reason,
+        )

--- a/apps/api/src/learn_to_draw_api/services/capture_service.py
+++ b/apps/api/src/learn_to_draw_api/services/capture_service.py
@@ -6,8 +6,13 @@ from learn_to_draw_api.adapters.camera import CaptureArtifact
 from learn_to_draw_api.models import (
     CaptureMetadata,
     CaptureReview,
+    CaptureReviewProposal,
+    InvalidArtifactError,
     NormalizationCorners,
     NormalizedCaptureArtifacts,
+)
+from learn_to_draw_api.services.capture_registration_proposal import (
+    CaptureRegistrationProposalService,
 )
 from learn_to_draw_api.services.capture_normalization import (
     CaptureNormalizationService,
@@ -22,9 +27,11 @@ class CaptureService:
         *,
         store: CaptureStore,
         normalization_service: CaptureNormalizationService,
+        proposal_service: CaptureRegistrationProposalService,
     ) -> None:
         self._store = store
         self._normalization_service = normalization_service
+        self._proposal_service = proposal_service
 
     def persist_raw_capture(self, artifact: CaptureArtifact) -> CaptureMetadata:
         return self._store.save(artifact)
@@ -38,6 +45,47 @@ class CaptureService:
         return self._normalization_service.initial_registration_corners(
             image_width=image_width,
             image_height=image_height,
+        )
+
+    def propose_registration_corners(
+        self,
+        *,
+        content: bytes,
+        image_width: int,
+        image_height: int,
+    ) -> tuple[NormalizationCorners, CaptureReviewProposal]:
+        attempt = self._proposal_service.propose(
+            content=content,
+            expected_width=image_width,
+            expected_height=image_height,
+        )
+        if attempt.corners is not None:
+            try:
+                self._normalization_service.validate_registration_corners(
+                    corners=attempt.corners,
+                    image_width=image_width,
+                    image_height=image_height,
+                )
+            except InvalidArtifactError:
+                fallback_reason = "invalid_proposal_geometry"
+            else:
+                return attempt.corners, CaptureReviewProposal(
+                    status="suggested",
+                    method="light_page_edges_v1",
+                    stability_max_px=attempt.stability_max_px,
+                    fallback_reason=None,
+                )
+        else:
+            fallback_reason = attempt.fallback_reason or "proposal_unavailable"
+
+        return self.initial_registration_corners(
+            image_width=image_width,
+            image_height=image_height,
+        ), CaptureReviewProposal(
+            status="fallback",
+            method="inset_5_percent_v1",
+            stability_max_px=None,
+            fallback_reason=fallback_reason,
         )
 
     def save_capture_review(

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
@@ -130,7 +130,8 @@ class PlotRunExecutor:
                 capture_artifact = self._camera.capture()
                 capture_completed = datetime.now(timezone.utc)
                 capture_metadata = self._capture_service.persist_raw_capture(capture_artifact)
-                initial_corners = self._capture_service.initial_registration_corners(
+                initial_corners, proposal = self._capture_service.propose_registration_corners(
+                    content=capture_artifact.content,
                     image_width=capture_metadata.width,
                     image_height=capture_metadata.height,
                 )
@@ -142,6 +143,7 @@ class PlotRunExecutor:
                     proposed_corners=initial_corners,
                     confirmed_corners=None,
                     confirmation_source=None,
+                    proposal=proposal,
                 )
                 capture_metadata = self._capture_service.save_capture_review(
                     capture_metadata.id,

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -768,6 +768,11 @@ def test_plot_run_capture_review_confirm_endpoint_creates_v2_registration(tmp_pa
         pending = wait_for_run_status(
             client, run_response.json()["id"], {"awaiting_capture_review"}
         )
+        assert pending["capture"]["review"]["proposal"]["status"] == "fallback"
+        assert (
+            pending["capture"]["review"]["proposal"]["method"]
+            == "inset_5_percent_v1"
+        )
         corners = pending["capture"]["review"]["proposed_corners"]
         confirm_response = client.post(
             f"/api/plot-runs/{pending['id']}/capture-review/confirm",
@@ -780,6 +785,7 @@ def test_plot_run_capture_review_confirm_endpoint_creates_v2_registration(tmp_pa
     assert completed["capture"]["review"]["registration_version"] == 2
     assert completed["capture"]["review"]["review_mode"] == "manual_corners"
     assert completed["capture"]["review"]["confirmation_source"] == "manual"
+    assert completed["capture"]["review"]["proposal"]["status"] == "fallback"
     metadata = completed["capture"]["normalized"]["metadata"]
     assert metadata["method"] == "manual_corners_v2"
     assert metadata["frame"]["version"] == 2

--- a/apps/api/tests/test_capture_normalization.py
+++ b/apps/api/tests/test_capture_normalization.py
@@ -330,6 +330,7 @@ def test_legacy_capture_models_remain_parseable():
 
     assert review.registration_version == 1
     assert review.review_mode is None
+    assert review.proposal is None
     assert metadata.frame is not None and metadata.frame.version == 1
     assert metadata.transform.inverse_matrix is None
     assert metadata.transform.source_space is None

--- a/apps/api/tests/test_capture_registration_proposal.py
+++ b/apps/api/tests/test_capture_registration_proposal.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from learn_to_draw_api.services.capture_normalization import (
+    CaptureNormalizationService,
+    target_from_page_size,
+)
+from learn_to_draw_api.services.capture_registration_proposal import (
+    CaptureRegistrationProposalService,
+)
+
+
+FIXTURE_DIRECTORY = Path(__file__).parent / "fixtures" / "manual_registration_v2"
+
+
+def _encode_jpeg(image: np.ndarray) -> bytes:
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
+def _synthetic_page(
+    corners: np.ndarray,
+    *,
+    width: int = 960,
+    height: int = 720,
+) -> bytes:
+    image = np.full((height, width, 3), 25, dtype=np.uint8)
+    cv2.fillConvexPoly(image, corners.astype(np.int32), (235, 235, 235))
+    return _encode_jpeg(image)
+
+
+def test_proposal_finds_synthetic_light_page_without_manual_prior():
+    expected = np.array(
+        [[140.0, 80.0], [800.0, 60.0], [880.0, 640.0], [70.0, 670.0]],
+        dtype=np.float32,
+    )
+
+    result = CaptureRegistrationProposalService().propose(
+        content=_synthetic_page(expected),
+        expected_width=960,
+        expected_height=720,
+    )
+
+    assert result.fallback_reason is None
+    assert result.corners is not None
+    proposed = np.array(
+        [
+            result.corners.top_left,
+            result.corners.top_right,
+            result.corners.bottom_right,
+            result.corners.bottom_left,
+        ]
+    )
+    assert proposed == pytest.approx(expected, abs=1.0)
+    assert result.stability_max_px is not None
+    assert result.stability_max_px < 0.2
+
+
+@pytest.mark.parametrize(
+    ("content", "reason"),
+    [
+        (
+            _encode_jpeg(np.full((480, 640, 3), 245, dtype=np.uint8)),
+            "bright_region_touches_multiple_borders",
+        ),
+        (
+            _synthetic_page(
+                np.array([[-30, 80], [800, 60], [880, 640], [-50, 670]]),
+            ),
+            "physical_corner_outside_capture",
+        ),
+    ],
+)
+def test_proposal_declines_missing_or_clipped_pages(content, reason):
+    result = CaptureRegistrationProposalService().propose(
+        content=content,
+        expected_width=640 if reason.startswith("bright") else 960,
+        expected_height=480 if reason.startswith("bright") else 720,
+    )
+
+    assert result.corners is None
+    assert result.stability_max_px is None
+    assert result.fallback_reason == reason
+
+
+def test_proposal_declines_threshold_instability(monkeypatch):
+    service = CaptureRegistrationProposalService()
+    base = np.array(
+        [[140.0, 80.0], [800.0, 60.0], [880.0, 640.0], [70.0, 670.0]],
+        dtype=np.float32,
+    )
+    proposals = [base.copy() for _ in range(5)]
+    proposals[-1][2] += np.array([30.0, 30.0])
+
+    def unstable_proposal(**_kwargs):
+        return proposals.pop(0), None
+
+    monkeypatch.setattr(service, "_proposal_at_threshold", unstable_proposal)
+    result = service.propose(
+        content=_synthetic_page(base),
+        expected_width=960,
+        expected_height=720,
+    )
+
+    assert result.corners is None
+    assert result.fallback_reason == "unstable_across_thresholds"
+
+
+def test_real_fixture_proposal_improves_rigid_aligned_checkpoint_geometry():
+    ground_truth = json.loads(
+        (FIXTURE_DIRECTORY / "us_letter_landscape_c930e.json").read_text()
+    )
+    source = ground_truth["source"]
+    capture = (FIXTURE_DIRECTORY / source["capture_file"]).read_bytes()
+    proposal = CaptureRegistrationProposalService().propose(
+        content=capture,
+        expected_width=source["capture_width_px"],
+        expected_height=source["capture_height_px"],
+    )
+
+    assert proposal.corners is not None
+    assert proposal.fallback_reason is None
+    assert proposal.stability_max_px == pytest.approx(0.711, abs=0.01)
+
+    page = ground_truth["page"]
+    normalized = CaptureNormalizationService().register_with_corners(
+        content=capture,
+        target=target_from_page_size(
+            page_width_mm=page["width_mm"],
+            page_height_mm=page["height_mm"],
+            source="prepared_svg",
+        ),
+        corners=proposal.corners,
+    )
+    observed_raw = np.array(
+        [[checkpoint["observed_raw_px"] for checkpoint in ground_truth["checkpoints"]]],
+        dtype=np.float64,
+    )
+    observed_page_px = cv2.perspectiveTransform(
+        observed_raw,
+        np.array(normalized.metadata.transform.matrix),
+    )[0]
+    pixels_per_mm = np.array(
+        [
+            normalized.metadata.transform.pixels_per_mm_x,
+            normalized.metadata.transform.pixels_per_mm_y,
+        ]
+    )
+    observed_page_mm = observed_page_px / pixels_per_mm
+    commanded_page_mm = np.array(
+        [checkpoint["commanded_page_mm"] for checkpoint in ground_truth["checkpoints"]],
+        dtype=np.float64,
+    )
+    commanded_centered = commanded_page_mm - commanded_page_mm.mean(axis=0)
+    observed_centered = observed_page_mm - observed_page_mm.mean(axis=0)
+    u, _, vt = np.linalg.svd(commanded_centered.T @ observed_centered)
+    rotation = u @ vt
+    translation = (
+        observed_page_mm.mean(axis=0)
+        - commanded_page_mm.mean(axis=0) @ rotation
+    )
+    checkpoint_errors_mm = np.linalg.norm(
+        observed_page_mm - (commanded_page_mm @ rotation + translation),
+        axis=1,
+    )
+
+    assert checkpoint_errors_mm == pytest.approx(
+        [0.589, 0.481, 0.631, 0.631, 0.666],
+        abs=0.01,
+    )
+    assert checkpoint_errors_mm.max() < 0.7

--- a/apps/api/tests/test_plot_workflow_service.py
+++ b/apps/api/tests/test_plot_workflow_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import cv2
 import numpy as np
+import pytest
 
 from learn_to_draw_api.adapters.camera import CaptureArtifact
 from learn_to_draw_api.adapters.mock_camera import MockCamera
@@ -16,6 +17,9 @@ from learn_to_draw_api.models import (
     PlotterWorkspaceRequest,
 )
 from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
+from learn_to_draw_api.services.capture_registration_proposal import (
+    CaptureRegistrationProposalService,
+)
 from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.plot_workflow import (
@@ -87,6 +91,18 @@ def _blank_jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
     return encoded.tobytes()
 
 
+def _page_jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
+    image = np.full((height, width, 3), 25, dtype=np.uint8)
+    cv2.fillConvexPoly(
+        image,
+        np.array([[90, 50], [530, 40], [590, 430], [45, 445]], dtype=np.int32),
+        (235, 235, 235),
+    )
+    ok, encoded = cv2.imencode(".jpg", image)
+    assert ok
+    return encoded.tobytes()
+
+
 class LowConfidenceCamera:
     driver = "mock-camera"
 
@@ -112,6 +128,20 @@ class LowConfidenceCamera:
             timestamp=MockCamera(capture_delay_s=0).capture().timestamp,
             filename=f"review-capture-{self._capture_count}.jpg",
             content=_blank_jpeg_bytes(),
+            media_type="image/jpeg",
+            width=640,
+            height=480,
+        )
+
+
+class AutomaticProposalCamera(LowConfidenceCamera):
+    def capture(self) -> CaptureArtifact:
+        self._capture_count += 1
+        return CaptureArtifact(
+            capture_id=f"proposal-capture-{self._capture_count}",
+            timestamp=MockCamera(capture_delay_s=0).capture().timestamp,
+            filename=f"proposal-capture-{self._capture_count}.jpg",
+            content=_page_jpeg_bytes(),
             media_type="image/jpeg",
             width=640,
             height=480,
@@ -150,6 +180,7 @@ def _build_service(tmp_path, *, plotter=None, camera=None, config_overrides=None
         capture_service=CaptureService(
             store=capture_store,
             normalization_service=CaptureNormalizationService(),
+            proposal_service=CaptureRegistrationProposalService(),
         ),
         asset_store=PlotAssetStore(tmp_path / "plot_assets", "/plot-assets"),
         run_store=PlotRunStore(tmp_path / "plot_runs"),
@@ -352,8 +383,39 @@ def test_plot_workflow_service_always_pauses_for_manual_capture_registration(tmp
     assert pending.capture.review.review_mode == "manual_corners"
     assert pending.capture.review.review_status == "pending"
     assert pending.capture.review.confirmed_corners is None
+    assert pending.capture.review.proposal is not None
+    assert pending.capture.review.proposal.status == "fallback"
+    assert pending.capture.review.proposal.method == "inset_5_percent_v1"
+    assert pending.capture.review.proposal.fallback_reason is not None
     assert pending.stage_states["capture"].status == "completed"
     assert pending.stage_states["capture_review"].status == "in_progress"
+
+
+def test_plot_workflow_service_seeds_manual_review_with_automatic_proposal(tmp_path):
+    service = _build_service(tmp_path, camera=AutomaticProposalCamera())
+    asset = service.create_pattern_asset(PatternAssetCreateRequest(pattern_id="test-grid"))
+
+    run = service.create_run(asset.id)
+    pending = _wait_for_run_status(service, run.id, {"awaiting_capture_review"})
+
+    assert pending.capture is not None and pending.capture.review is not None
+    review = pending.capture.review
+    assert review.review_required is True
+    assert review.review_status == "pending"
+    assert review.proposal is not None
+    assert review.proposal.status == "suggested"
+    assert review.proposal.method == "light_page_edges_v1"
+    assert review.proposal.stability_max_px == pytest.approx(0.121, abs=0.02)
+    assert review.proposal.fallback_reason is None
+    assert review.proposed_corners.top_left == pytest.approx((89.535, 49.418), abs=0.1)
+
+    service.confirm_capture_review(
+        run.id,
+        PlotRunCaptureReviewConfirmRequest(corners=review.proposed_corners),
+    )
+    completed = _wait_for_terminal_run(service, run.id)
+    assert completed.capture is not None and completed.capture.review is not None
+    assert completed.capture.review.confirmation_source == "manual"
 
 
 def test_plot_workflow_service_confirms_proposed_capture_review_and_completes(tmp_path):

--- a/apps/api/tests/test_services.py
+++ b/apps/api/tests/test_services.py
@@ -18,6 +18,9 @@ from learn_to_draw_api.models import (
     InvalidArtifactError,
 )
 from learn_to_draw_api.services.capture_normalization import CaptureNormalizationService
+from learn_to_draw_api.services.capture_registration_proposal import (
+    CaptureRegistrationProposalService,
+)
 from learn_to_draw_api.services.capture_service import CaptureService
 from learn_to_draw_api.services.captures import CaptureStore
 from learn_to_draw_api.services.hardware import HardwareService
@@ -79,6 +82,7 @@ def _capture_service(store: CaptureStore) -> CaptureService:
     return CaptureService(
         store=store,
         normalization_service=CaptureNormalizationService(),
+        proposal_service=CaptureRegistrationProposalService(),
     )
 
 

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -2179,6 +2179,18 @@ button {
   font-size: 0.84rem;
 }
 
+.capture-review-proposal-message {
+  margin: 0;
+  color: #ffd7a0;
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.capture-review-modal-header .capture-review-proposal-message {
+  margin-top: 8px;
+  color: #ffd7a0;
+}
+
 .capture-review-actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/features/plot-workflow/CaptureReviewEditor.tsx
+++ b/apps/web/src/features/plot-workflow/CaptureReviewEditor.tsx
@@ -18,6 +18,19 @@ const CORNER_OPTIONS: readonly [CornerKey, string][] = [
 
 const MAGNIFIER_WINDOW_PX = 120;
 
+const PROPOSAL_FALLBACK_MESSAGES: Record<string, string> = {
+  capture_not_decodable: "The captured image could not be analyzed.",
+  capture_dimensions_mismatch: "The captured image dimensions were inconsistent.",
+  no_large_bright_region: "A distinct light page was not visible.",
+  bright_region_touches_multiple_borders: "The page could not be separated from the image border.",
+  bright_region_not_quadrilateral: "The visible page boundary was not clear enough.",
+  edge_refinement_failed: "The page edges were not clear enough to refine.",
+  physical_corner_outside_capture: "One or more physical page corners were outside the image.",
+  unstable_across_thresholds: "The page boundary changed too much under image analysis.",
+  invalid_proposal_geometry: "The suggested page geometry was invalid.",
+  proposal_unavailable: "The page boundary was not clear enough.",
+};
+
 const MAGNIFIER_POSITIONS: Record<CornerKey, string> = {
   top_left: "bottom-right",
   top_right: "bottom-left",
@@ -77,6 +90,16 @@ export function CaptureReviewEditor({
   onConfirm,
 }: CaptureReviewEditorProps) {
   const startingCorners = review.confirmed_corners ?? review.proposed_corners;
+  const activeProposal = revision ? null : review.proposal;
+  const proposalMessage =
+    activeProposal?.status === "suggested"
+      ? "Automatic corner suggestion ready — verify all four points before registering."
+      : activeProposal?.status === "fallback"
+        ? `Automatic suggestion unavailable. ${
+          PROPOSAL_FALLBACK_MESSAGES[activeProposal.fallback_reason ?? "proposal_unavailable"]
+          ?? PROPOSAL_FALLBACK_MESSAGES.proposal_unavailable
+        } Place all four corners manually.`
+        : null;
   const [draftCorners, setDraftCorners] = useState<NormalizationCorners>(() =>
     cloneCorners(startingCorners),
   );
@@ -350,7 +373,8 @@ export function CaptureReviewEditor({
         <header className="capture-review-modal-header">
           <div>
             <h3>{revision ? "Adjust captured page" : "Register captured page"}</h3>
-            <p>Choose a corner, then click or drag it onto the physical paper corner.</p>
+            <p>Choose a corner, then click or drag it to the intersection of the paper edges.</p>
+            {proposalMessage ? <p className="capture-review-proposal-message">{proposalMessage}</p> : null}
           </div>
           <button
             type="button"
@@ -387,8 +411,9 @@ export function CaptureReviewEditor({
         <div className="capture-review-modal-footer">
           <div>
             <p className="capture-review-caption">
-              Use the detail view to place the crosshair exactly on the paper corner. Arrow keys
-              work anywhere in this dialog and nudge by 1 raw pixel; hold Shift for 10.
+              Use the detail view to place the crosshair at the intersection of the straight paper
+              edges; this may be just beyond a curled corner tip. Arrow keys work anywhere in this
+              dialog and nudge by 1 raw pixel; hold Shift for 10.
             </p>
             {error ? (
               <p className="capture-review-error" role="alert">
@@ -427,8 +452,17 @@ export function CaptureReviewEditor({
           <p className="capture-review-caption">
             {revision ? "Refine the saved manual page registration." : "Manual page registration required."}
           </p>
+          {proposalMessage ? (
+            <p className="capture-review-proposal-message" role="status">
+              {proposalMessage}
+              {activeProposal?.status === "suggested"
+              && activeProposal.stability_max_px != null
+                ? ` Stable within ${activeProposal.stability_max_px.toFixed(1)} raw px across image thresholds.`
+                : ""}
+            </p>
+          ) : null}
           <p className="capture-review-caption">
-            Place each labeled point on the matching physical paper corner.
+            Place each labeled point at the intersection of the matching straight paper edges.
           </p>
         </div>
         <div className="capture-review-actions">

--- a/apps/web/src/types/hardware.ts
+++ b/apps/web/src/types/hardware.ts
@@ -85,6 +85,12 @@ export interface CaptureReview {
     | null;
   detector_confidence?: number | null;
   reuse_last_available?: boolean;
+  proposal?: {
+    status: "suggested" | "fallback";
+    method: "light_page_edges_v1" | "inset_5_percent_v1";
+    stability_max_px?: number | null;
+    fallback_reason?: string | null;
+  } | null;
 }
 
 export interface NormalizationCorners {

--- a/apps/web/tests/captureReviewEditor.test.tsx
+++ b/apps/web/tests/captureReviewEditor.test.tsx
@@ -161,6 +161,59 @@ describe("manual capture registration editor", () => {
     expect(screen.getByRole("button", { name: /^top right$/i })).toBeDisabled();
   });
 
+  it("labels an automatic proposal as a suggestion that still requires verification", () => {
+    render(
+      <CaptureReviewEditor
+        capture={capture}
+        review={{
+          ...review,
+          proposal: {
+            status: "suggested",
+            method: "light_page_edges_v1",
+            stability_max_px: 0.711,
+            fallback_reason: null,
+          },
+        }}
+        busy={false}
+        error={null}
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /automatic corner suggestion ready.*verify all four points/i,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(/stable within 0.7 raw px/i);
+    fireEvent.click(screen.getByRole("button", { name: /register page/i }));
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      /intersection of the straight paper edges/i,
+    );
+  });
+
+  it("explains when automatic proposal falls back to manual placement", () => {
+    render(
+      <CaptureReviewEditor
+        capture={capture}
+        review={{
+          ...review,
+          proposal: {
+            status: "fallback",
+            method: "inset_5_percent_v1",
+            stability_max_px: null,
+            fallback_reason: "physical_corner_outside_capture",
+          },
+        }}
+        busy={false}
+        error={null}
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /automatic suggestion unavailable.*corners were outside the image.*manually/i,
+    );
+  });
+
   it("keeps the modal and draft open when polling returns equivalent review data", () => {
     const onConfirm = vi.fn().mockResolvedValue(undefined);
     const { rerender } = render(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,9 @@ The app currently supports a single backend-owned plotting workflow with a few n
 
 ## Manual Capture Registration V2
 
-Automatic paper detection is not part of the active capture path. Each non-skipped plot-run capture gets a versioned `manual_corners` review seeded five percent inside the raw image. The operator places named TL/TR/BR/BL points on the visible physical page corners, and the backend validates that the quad is finite, in bounds, convex, non-crossing, large enough, and has usable edge lengths before changing run state.
+Automatic page acceptance is not part of the capture path. For each non-skipped plot-run capture, the backend first attempts a `light_page_edges_v1` corner proposal: it segments a large light page, extracts a coarse quadrilateral, robustly fits the four straight page edges, and requires the result to remain stable across nearby image thresholds. A stable result seeds the versioned `manual_corners` review; an unavailable, clipped, or unstable result falls back to the five-percent inset quad. The operator must still verify named TL/TR/BR/BL points, and the backend validates that the confirmed quad is finite, in bounds, convex, non-crossing, large enough, and has usable edge lengths before changing run state.
+
+`CaptureReview.proposal` records whether `proposed_corners` came from a stable suggestion or the inset fallback, together with the proposal method, raw-pixel stability when available, and a specific fallback reason. It is optional so existing V1 and V2 artifacts remain readable. Proposal provenance never implies acceptance: new confirmations continue to persist `confirmation_source: manual`.
 
 Confirmation uses `POST /api/plot-runs/{run_id}/capture-review/confirm`. The existing asynchronous executor then maps the confirmed raw-capture pixels directly to the full canonical page with one homography. The canonical raster keeps the prepared page aspect ratio, uses a 2048-pixel long side, has a top-left origin, and is not trimmed, rotated, or resized again.
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -127,4 +127,12 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Separated physical page pose from registration accuracy: the page-true overlay still exposes absolute placement, while hardware validation may remove translation and rotation—but not scale or deformation—before evaluating checkpoint residuals
 - Allowed completed V2 runs to refine confirmed corners and regenerate normalized derivatives from the same immutable raw capture without plotting or capturing again
 
+## Automatic Corner Proposal Slice
+
+- Added a backend-owned `light_page_edges_v1` proposal pass that combines light-page segmentation, coarse quadrilateral extraction, robust edge fitting, and threshold-stability checks
+- Seeded pending manual reviews from stable proposals while retaining the five-percent inset fallback for missing, clipped, or ambiguous pages
+- Added explicit proposal provenance without reusing legacy detector fields or changing the requirement for manual confirmation
+- Labeled suggestions and fallback reasons in the existing corner editor, including guidance to verify the intersection of straight page edges through curled tips
+- Covered synthetic success/failure cases, workflow fallback and confirmation behavior, legacy parsing, and the selected real C930e/AxiDraw fixture
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Seeds pending V2 manual capture reviews from a backend-owned automatic page-corner proposal when the image evidence is stable.
- Uses light-page segmentation, coarse quadrilateral extraction, robust straight-edge fitting, and five-threshold stability checks; missing, clipped, or ambiguous pages fall back to the existing 5%-inset quad.
- Persists explicit suggestion/fallback provenance without reusing legacy detector fields, and keeps every confirmation manual.
- Labels suggestions and fallback reasons in the existing editor and explains how to verify straight-edge intersections through curled corner tips.
- Implements the expanded plan in #40 based on the completed spike evidence in #39.

Closes #40
Spike: #39

## Checks

- [x] `make api-test` — 120 passed
- [x] `make api-lint` — passed
- [x] `make web-test` — 36 passed
- [x] `make web-lint` — passed
- [x] `make web-build` — passed
- [x] Selected C930e/AxiDraw fixture — proposal stability 0.711 raw px; rigid-aligned maximum checkpoint residual below 0.7 mm
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why — no checks skipped

## Architecture

- [x] Backend remains the sole owner of hardware access and proposal generation
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers; this slice changes no plotter behavior
- [x] Mock adapters remain covered and fall back safely to manual placement

## Risk Review

- [x] Light paper against a darker surface is the supported proposal condition; unsupported scenes fall back without failing the run
- [x] Threshold stability is an ambiguity signal, not a calibrated probability
- [x] Automatic proposals never bypass manual confirmation or change `confirmation_source: manual`
- [x] Existing V1 and V2 artifacts without proposal metadata remain readable
- [x] Docs were updated; no environment variables or hardware tuning controls were added
- [x] This PR is a narrow, reviewable slice
