### PR TITLE
Add prompt-first agentic drawing session v2

### DIFF
--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -355,10 +355,14 @@ class PlotRun(BaseModel):
 
 
 DrawingSessionStatus = Literal[
+    "planning",
+    "awaiting_approval",
     "running",
     "awaiting_capture_review",
     "observed",
     "proposal_ready",
+    "paused",
+    "stopping",
     "completed",
     "failed",
 ]
@@ -389,24 +393,103 @@ class DrawingIteration(BaseModel):
     next_proposal: Optional[DrawingIterationProposal] = None
 
 
+DrawingSessionEventType = Literal[
+    "session_created",
+    "user_guidance",
+    "plan_ready",
+    "plan_failed",
+    "session_approved",
+    "plot_started",
+    "observation_ready",
+    "agent_decision",
+    "session_paused",
+    "session_resumed",
+    "stop_requested",
+    "session_completed",
+    "session_failed",
+]
+
+
+class DrawingSessionEvent(BaseModel):
+    id: str
+    type: DrawingSessionEventType
+    created_at: datetime
+    message: str
+    asset_id: Optional[str] = None
+    run_id: Optional[str] = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class DrawingSessionPlan(BaseModel):
+    summary: str
+    paper_strategy: str
+    completion_intent: str
+
+
+class DrawingSessionProposal(BaseModel):
+    asset: PlotAsset
+    created_at: datetime
+    advisor_driver: str
+    advisor_model: Optional[str] = None
+
+
+class DrawingSessionAuthorization(BaseModel):
+    approved_at: Optional[datetime] = None
+    stop_requested: bool = False
+    last_heartbeat_at: Optional[datetime] = None
+
+
 class DrawingSession(BaseModel):
     id: str
+    session_version: Literal[1, 2] = 1
     intent: str
     mode: Literal["additive"] = "additive"
-    iteration_limit: int = Field(ge=2, le=10)
+    iteration_limit: Optional[int] = Field(default=None, ge=2, le=10)
     status: DrawingSessionStatus
     created_at: datetime
     updated_at: datetime
-    iterations: list[DrawingIteration]
+    iterations: list[DrawingIteration] = Field(default_factory=list)
     advisor: DrawingAdvisorStatus
     error: Optional[str] = None
+    plan: Optional[DrawingSessionPlan] = None
+    current_proposal: Optional[DrawingSessionProposal] = None
+    current_run_id: Optional[str] = None
+    pass_count: int = Field(default=0, ge=0)
+    planning_generation: int = Field(default=0, ge=0)
+    authorization: DrawingSessionAuthorization = Field(
+        default_factory=DrawingSessionAuthorization
+    )
+    queued_guidance: list[str] = Field(default_factory=list)
+    events: list[DrawingSessionEvent] = Field(default_factory=list)
+    approved_at: Optional[datetime] = None
+    paused_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
 
 
 class DrawingSessionCreateRequest(BaseModel):
     intent: str = Field(min_length=3, max_length=1000)
-    initial_asset_id: str = Field(min_length=1)
-    iteration_limit: int = Field(default=3, ge=2, le=10)
+    initial_asset_id: Optional[str] = Field(default=None, min_length=1)
+    iteration_limit: Optional[int] = Field(default=None, ge=2, le=10)
     mode: Literal["additive"] = "additive"
+
+
+class DrawingSessionMessageRequest(BaseModel):
+    text: str = Field(min_length=1, max_length=2000)
+
+
+class DrawingSessionSummary(BaseModel):
+    id: str
+    session_version: Literal[1, 2]
+    intent: str
+    status: DrawingSessionStatus
+    pass_count: int = Field(ge=0)
+    created_at: datetime
+    updated_at: datetime
+    preview_url: Optional[str] = None
+
+
+class DrawingSessionListResponse(BaseModel):
+    sessions: list[DrawingSessionSummary]
 
 
 class LatestDrawingSessionResponse(BaseModel):

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -8,6 +8,8 @@ from learn_to_draw_api.models import (
     CameraDeviceSelectionRequest,
     DrawingSession,
     DrawingSessionCreateRequest,
+    DrawingSessionListResponse,
+    DrawingSessionMessageRequest,
     HealthResponse,
     HardwareStatus,
     LatestPlotRunResponse,
@@ -170,6 +172,10 @@ def build_api_router(
     def post_drawing_session(request: DrawingSessionCreateRequest) -> DrawingSession:
         return drawing_session_service.create(request)
 
+    @router.get("/api/drawing-sessions", response_model=DrawingSessionListResponse)
+    def get_drawing_sessions() -> DrawingSessionListResponse:
+        return drawing_session_service.list()
+
     @router.get(
         "/api/drawing-sessions/latest",
         response_model=LatestDrawingSessionResponse,
@@ -180,6 +186,23 @@ def build_api_router(
     @router.get("/api/drawing-sessions/{session_id}", response_model=DrawingSession)
     def get_drawing_session(session_id: str) -> DrawingSession:
         return drawing_session_service.get(session_id)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/messages",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_message(
+        session_id: str,
+        request: DrawingSessionMessageRequest,
+    ) -> DrawingSession:
+        return drawing_session_service.add_message(session_id, request)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/approve",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_approve(session_id: str) -> DrawingSession:
+        return drawing_session_service.approve(session_id)
 
     @router.post(
         "/api/drawing-sessions/{session_id}/advice",

--- a/apps/api/src/learn_to_draw_api/services/drawing_advisor.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_advisor.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 import base64
 from dataclasses import dataclass
 import json
-from typing import Optional
+from typing import Literal, Optional
 
 import httpx
 
@@ -18,10 +18,54 @@ class DrawingAdviceDraft:
     svg_text: str
 
 
+@dataclass(frozen=True)
+class InitialDrawingPlanDraft:
+    summary: str
+    paper_strategy: str
+    completion_intent: str
+    svg_text: str
+
+
+@dataclass(frozen=True)
+class DrawingAssessmentDraft:
+    assessment: str
+    decision: Literal["continue", "complete", "pause"]
+    reason: str
+    svg_text: Optional[str] = None
+    requested_human_action: Optional[str] = None
+
+
 class DrawingAdvisor(ABC):
     @property
     @abstractmethod
     def status(self) -> DrawingAdvisorStatus:
+        raise NotImplementedError
+
+    @abstractmethod
+    def plan_initial(
+        self,
+        *,
+        intent: str,
+        guidance: list[str],
+        drawable_width_mm: float,
+        drawable_height_mm: float,
+    ) -> InitialDrawingPlanDraft:
+        raise NotImplementedError
+
+    @abstractmethod
+    def assess_iteration(
+        self,
+        *,
+        intent: str,
+        plan_summary: str,
+        observed_image: bytes,
+        observed_media_type: str,
+        iteration_number: int,
+        drawable_width_mm: float,
+        drawable_height_mm: float,
+        prior_interpretations: list[str],
+        guidance: list[str],
+    ) -> DrawingAssessmentDraft:
         raise NotImplementedError
 
     @abstractmethod
@@ -53,6 +97,12 @@ class DisabledDrawingAdvisor(DrawingAdvisor):
         )
 
     def propose_next_layer(self, **_kwargs) -> DrawingAdviceDraft:
+        raise ServiceUnavailableError(self.status.message or "Drawing advisor is unavailable.")
+
+    def plan_initial(self, **_kwargs) -> InitialDrawingPlanDraft:
+        raise ServiceUnavailableError(self.status.message or "Drawing advisor is unavailable.")
+
+    def assess_iteration(self, **_kwargs) -> DrawingAssessmentDraft:
         raise ServiceUnavailableError(self.status.message or "Drawing advisor is unavailable.")
 
 
@@ -87,6 +137,64 @@ class MockDrawingAdvisor(DrawingAdvisor):
                 "add one simple focal contour near the center."
             ),
             svg_text=svg_text,
+        )
+
+    def plan_initial(
+        self,
+        *,
+        intent: str,
+        guidance: list[str],
+        drawable_width_mm: float,
+        drawable_height_mm: float,
+    ) -> InitialDrawingPlanDraft:
+        margin = round(min(drawable_width_mm, drawable_height_mm) * 0.18, 3)
+        center_x = round(drawable_width_mm / 2, 3)
+        center_y = round(drawable_height_mm / 2, 3)
+        radius = round(min(drawable_width_mm, drawable_height_mm) * 0.12, 3)
+        svg_text = (
+            f'<svg xmlns="http://www.w3.org/2000/svg" '
+            f'width="{drawable_width_mm}mm" height="{drawable_height_mm}mm" '
+            f'viewBox="0 0 {drawable_width_mm} {drawable_height_mm}">'
+            f'<circle cx="{center_x}" cy="{center_y}" r="{radius}"/>'
+            f'<line x1="{margin}" y1="{center_y}" '
+            f'x2="{drawable_width_mm - margin}" y2="{center_y}"/>'
+            "</svg>"
+        )
+        return InitialDrawingPlanDraft(
+            summary=f'Build “{intent}” from a simple focal gesture, then respond to the drawing.',
+            paper_strategy="Keep the sheet in place and add restrained layers.",
+            completion_intent="Stop when the subject reads clearly and the page still has breathing room.",
+            svg_text=svg_text,
+        )
+
+    def assess_iteration(
+        self,
+        *,
+        intent: str,
+        iteration_number: int,
+        drawable_width_mm: float,
+        drawable_height_mm: float,
+        guidance: list[str],
+        **_kwargs,
+    ) -> DrawingAssessmentDraft:
+        if iteration_number >= 2:
+            return DrawingAssessmentDraft(
+                assessment=f'The mock drawing for “{intent}” has a clear focal structure.',
+                decision="complete",
+                reason="The deterministic mock completes after two observed passes.",
+            )
+        advice = self.propose_next_layer(
+            intent=intent,
+            iteration_number=iteration_number,
+            drawable_width_mm=drawable_width_mm,
+            drawable_height_mm=drawable_height_mm,
+        )
+        guidance_note = f" Guidance received: {guidance[-1]}" if guidance else ""
+        return DrawingAssessmentDraft(
+            assessment=f"{advice.interpretation}{guidance_note}",
+            decision="continue",
+            reason="One restrained additive pass will develop the composition.",
+            svg_text=advice.svg_text,
         )
 
 
@@ -213,6 +321,185 @@ class OpenAIDrawingAdvisor(DrawingAdvisor):
             interpretation=interpretation.strip(),
             svg_text=svg_text.strip(),
         )
+
+    def plan_initial(
+        self,
+        *,
+        intent: str,
+        guidance: list[str],
+        drawable_width_mm: float,
+        drawable_height_mm: float,
+    ) -> InitialDrawingPlanDraft:
+        revisions = "\n".join(f"- {item}" for item in guidance[-10:]) or "- None"
+        prompt = (
+            f"Drawing intent: {intent}\n"
+            f"Drawable SVG canvas: {drawable_width_mm} mm wide by "
+            f"{drawable_height_mm} mm high.\n"
+            f"Requested revisions:\n{revisions}\n\n"
+            "Plan a physical pen drawing and provide only its first plotted layer. Describe a "
+            "practical paper strategy and a subjective completion intent. The first layer must "
+            "be useful on its own and leave room for later observed adjustments. The SVG root "
+            "width and height must exactly match the drawable canvas in mm, its viewBox must "
+            "start at 0 0 with those dimensions, and every mark must stay inside it. Use only "
+            "svg, g, path, line, polyline, polygon, circle, ellipse, and rect elements, direct "
+            "coordinates, fill=none, and black strokes. Do not include transforms or text."
+        )
+        parsed = self._request_structured(
+            prompt=prompt,
+            schema_name="initial_drawing_plan",
+            schema={
+                "type": "object",
+                "properties": {
+                    "summary": {"type": "string"},
+                    "paper_strategy": {"type": "string"},
+                    "completion_intent": {"type": "string"},
+                    "svg": {"type": "string"},
+                },
+                "required": ["summary", "paper_strategy", "completion_intent", "svg"],
+                "additionalProperties": False,
+            },
+        )
+        values = [
+            parsed.get("summary"),
+            parsed.get("paper_strategy"),
+            parsed.get("completion_intent"),
+            parsed.get("svg"),
+        ]
+        if not all(isinstance(value, str) and value.strip() for value in values):
+            raise ServiceUnavailableError("Drawing advisor returned an incomplete initial plan.")
+        return InitialDrawingPlanDraft(
+            summary=values[0].strip(),
+            paper_strategy=values[1].strip(),
+            completion_intent=values[2].strip(),
+            svg_text=values[3].strip(),
+        )
+
+    def assess_iteration(
+        self,
+        *,
+        intent: str,
+        plan_summary: str,
+        observed_image: bytes,
+        observed_media_type: str,
+        iteration_number: int,
+        drawable_width_mm: float,
+        drawable_height_mm: float,
+        prior_interpretations: list[str],
+        guidance: list[str],
+    ) -> DrawingAssessmentDraft:
+        history = "\n".join(f"- {item}" for item in prior_interpretations[-8:]) or "- None"
+        queued = "\n".join(f"- {item}" for item in guidance) or "- None"
+        prompt = (
+            f"Drawing intent: {intent}\nPlan: {plan_summary}\n"
+            f"Observed pass: {iteration_number}\n"
+            f"Drawable SVG canvas: {drawable_width_mm} mm wide by "
+            f"{drawable_height_mm} mm high.\n"
+            f"Earlier assessments:\n{history}\nQueued guidance:\n{queued}\n\n"
+            "Assess the registered photograph. Decide continue, complete, or pause. Continue "
+            "only when another additive black-line layer materially improves the work. Complete "
+            "when the intent reads and another pass risks overworking it. Pause when a person "
+            "must change paper or correct a physical condition. For continue, return a safe "
+            "incremental SVG on the exact canvas. Otherwise return null for svg."
+        )
+        parsed = self._request_structured(
+            prompt=prompt,
+            schema_name="drawing_assessment",
+            schema={
+                "type": "object",
+                "properties": {
+                    "assessment": {"type": "string"},
+                    "decision": {"type": "string", "enum": ["continue", "complete", "pause"]},
+                    "reason": {"type": "string"},
+                    "svg": {"type": ["string", "null"]},
+                    "requested_human_action": {"type": ["string", "null"]},
+                },
+                "required": [
+                    "assessment",
+                    "decision",
+                    "reason",
+                    "svg",
+                    "requested_human_action",
+                ],
+                "additionalProperties": False,
+            },
+            image=(observed_image, observed_media_type),
+        )
+        assessment = parsed.get("assessment")
+        decision = parsed.get("decision")
+        reason = parsed.get("reason")
+        svg_text = parsed.get("svg")
+        action = parsed.get("requested_human_action")
+        if (
+            not isinstance(assessment, str)
+            or decision not in {"continue", "complete", "pause"}
+            or not isinstance(reason, str)
+        ):
+            raise ServiceUnavailableError("Drawing advisor returned an incomplete assessment.")
+        if decision == "continue" and not isinstance(svg_text, str):
+            raise ServiceUnavailableError("A continue decision must include an SVG layer.")
+        return DrawingAssessmentDraft(
+            assessment=assessment.strip(),
+            decision=decision,
+            reason=reason.strip(),
+            svg_text=svg_text.strip() if isinstance(svg_text, str) else None,
+            requested_human_action=action.strip() if isinstance(action, str) else None,
+        )
+
+    def _request_structured(
+        self,
+        *,
+        prompt: str,
+        schema_name: str,
+        schema: dict,
+        image: Optional[tuple[bytes, str]] = None,
+    ) -> dict:
+        if not self.status.available or not self._api_key or not self._model:
+            raise ServiceUnavailableError(
+                self.status.message or "OpenAI drawing advisor is not configured."
+            )
+        content = [{"type": "input_text", "text": prompt}]
+        if image is not None:
+            encoded_image = base64.b64encode(image[0]).decode("ascii")
+            content.append(
+                {
+                    "type": "input_image",
+                    "image_url": f"data:{image[1]};base64,{encoded_image}",
+                    "detail": "high",
+                }
+            )
+        payload = {
+            "model": self._model,
+            "store": False,
+            "instructions": (
+                "You are the creative planning and visual assessment component inside a local "
+                "pen-plotter system. Return structured creative data only. You cannot control "
+                "hardware or claim that a physical action occurred."
+            ),
+            "input": [{"role": "user", "content": content}],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": schema_name,
+                    "strict": True,
+                    "schema": schema,
+                }
+            },
+            "max_output_tokens": 6000,
+        }
+        try:
+            response = httpx.post(
+                "https://api.openai.com/v1/responses",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=60,
+            )
+            response.raise_for_status()
+            return json.loads(_extract_output_text(response.json()))
+        except (httpx.HTTPError, ValueError, KeyError, TypeError) as exc:
+            raise ServiceUnavailableError(f"Drawing advisor request failed: {exc}") from exc
 
 
 def _extract_output_text(payload: dict) -> str:

--- a/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import math
 from pathlib import Path
-from threading import RLock
+from threading import RLock, Thread
 from typing import Optional
 import xml.etree.ElementTree as ET
 from uuid import uuid4
@@ -13,9 +13,17 @@ from learn_to_draw_api.models import (
     AppNotFoundError,
     DrawingIteration,
     DrawingIterationProposal,
+    DrawingSessionAuthorization,
+    DrawingSessionEvent,
+    DrawingSessionListResponse,
+    DrawingSessionMessageRequest,
+    DrawingSessionPlan,
+    DrawingSessionProposal,
+    DrawingSessionSummary,
     DrawingSession,
     DrawingSessionCreateRequest,
     InvalidArtifactError,
+    ServiceUnavailableError,
 )
 from learn_to_draw_api.services.drawing_advisor import DrawingAdvisor
 from learn_to_draw_api.services.plot_workflow import PlotWorkflowService
@@ -62,13 +70,17 @@ class DrawingSessionStore:
         return session
 
     def latest(self) -> Optional[DrawingSession]:
+        sessions = self.list()
+        return sessions[0] if sessions else None
+
+    def list(self) -> list[DrawingSession]:
         sessions: list[DrawingSession] = []
         for path in self._sessions_dir.glob("*.json"):
             session = DrawingSession.model_validate_json(path.read_text(encoding="utf-8"))
             self._cache[session.id] = session
             sessions.append(session)
         sessions.sort(key=lambda item: item.created_at, reverse=True)
-        return sessions[0] if sessions else None
+        return sessions
 
 
 class DrawingSessionService:
@@ -90,15 +102,18 @@ class DrawingSessionService:
         intent = request.intent.strip()
         if len(intent) < 3:
             raise InvalidArtifactError("Drawing intent must contain at least 3 characters.")
+        if request.initial_asset_id is None:
+            return self._create_v2(intent)
         with self._lock:
             asset = self._plot_workflow.get_asset(request.initial_asset_id)
             run = self._plot_workflow.create_run(asset.id)
             now = datetime.now(timezone.utc)
             session = DrawingSession(
                 id=uuid4().hex,
+                session_version=1,
                 intent=intent,
                 mode=request.mode,
-                iteration_limit=request.iteration_limit,
+                iteration_limit=request.iteration_limit or 3,
                 status="running",
                 created_at=now,
                 updated_at=now,
@@ -111,8 +126,34 @@ class DrawingSessionService:
                     )
                 ],
                 advisor=self._advisor.status,
+                pass_count=1,
+                current_run_id=run.id,
             )
             return self._store.save(session)
+
+    def _create_v2(self, intent: str) -> DrawingSession:
+        with self._lock:
+            now = datetime.now(timezone.utc)
+            session = DrawingSession(
+                id=uuid4().hex,
+                session_version=2,
+                intent=intent,
+                status="planning",
+                created_at=now,
+                updated_at=now,
+                advisor=self._advisor.status,
+                planning_generation=1,
+                authorization=DrawingSessionAuthorization(),
+                events=[
+                    self._event(
+                        "session_created",
+                        "Creative session created. Planning the first pass.",
+                    )
+                ],
+            )
+            self._store.save(session)
+            self._dispatch_plan(session.id, session.planning_generation)
+            return session
 
     def get(self, session_id: str) -> DrawingSession:
         with self._lock:
@@ -123,9 +164,113 @@ class DrawingSessionService:
             session = self._store.latest()
             return self._sync(session) if session is not None else None
 
+    def list(self) -> DrawingSessionListResponse:
+        with self._lock:
+            summaries = []
+            for stored in self._store.list():
+                session = self._sync(stored)
+                preview_url = None
+                if session.current_proposal is not None:
+                    preview_url = session.current_proposal.asset.public_url
+                elif session.iterations:
+                    preview_url = session.iterations[-1].asset.public_url
+                summaries.append(
+                    DrawingSessionSummary(
+                        id=session.id,
+                        session_version=session.session_version,
+                        intent=session.intent,
+                        status=session.status,
+                        pass_count=(
+                            session.pass_count
+                            if session.session_version == 2
+                            else len(session.iterations)
+                        ),
+                        created_at=session.created_at,
+                        updated_at=session.updated_at,
+                        preview_url=preview_url,
+                    )
+                )
+            return DrawingSessionListResponse(sessions=summaries)
+
+    def add_message(
+        self,
+        session_id: str,
+        request: DrawingSessionMessageRequest,
+    ) -> DrawingSession:
+        message = request.text.strip()
+        if not message:
+            raise InvalidArtifactError("Guidance must not be empty.")
+        with self._lock:
+            session = self._sync(self._store.get(session_id))
+            if session.session_version != 2:
+                raise AppConflictError("Messages are available only for V2 drawing sessions.")
+            if session.status in {"completed", "failed", "stopping"}:
+                raise AppConflictError("This drawing session is not accepting guidance.")
+            session.queued_guidance.append(message)
+            session.events.append(self._event("user_guidance", message))
+            session.updated_at = datetime.now(timezone.utc)
+            if session.authorization.approved_at is None:
+                session.status = "planning"
+                session.error = None
+                session.plan = None
+                session.current_proposal = None
+                session.planning_generation += 1
+                generation = session.planning_generation
+                self._store.save(session)
+                self._dispatch_plan(session.id, generation)
+            else:
+                self._store.save(session)
+            return session
+
+    def approve(self, session_id: str) -> DrawingSession:
+        with self._lock:
+            session = self._sync(self._store.get(session_id))
+            if session.session_version != 2:
+                raise AppConflictError("Use the legacy iteration endpoint for V1 sessions.")
+            if session.status != "awaiting_approval" or session.current_proposal is None:
+                raise AppConflictError("This drawing session has no first pass ready to approve.")
+            if session.authorization.approved_at is not None:
+                raise AppConflictError("This drawing session has already been approved.")
+            asset = self._plot_workflow.get_asset(session.current_proposal.asset.id)
+            run = self._plot_workflow.create_run(asset.id)
+            now = datetime.now(timezone.utc)
+            session.authorization.approved_at = now
+            session.authorization.stop_requested = False
+            session.approved_at = now
+            session.current_run_id = run.id
+            session.pass_count = 1
+            session.iterations.append(
+                DrawingIteration(
+                    number=1,
+                    asset=asset,
+                    run_id=run.id,
+                    created_at=now,
+                )
+            )
+            session.events.extend(
+                [
+                    self._event(
+                        "session_approved",
+                        "Open-ended attended drawing session approved.",
+                    ),
+                    self._event(
+                        "plot_started",
+                        "Started the approved first pass.",
+                        asset_id=asset.id,
+                        run_id=run.id,
+                    ),
+                ]
+            )
+            session.status = "running"
+            session.updated_at = now
+            session.error = None
+            return self._store.save(session)
+
     def request_advice(self, session_id: str) -> DrawingSession:
         with self._lock:
             session = self._sync(self._store.get(session_id))
+            if session.session_version != 1:
+                raise AppConflictError("Advice is coordinated automatically for V2 sessions.")
             if session.status != "observed":
                 raise AppConflictError(
                     "Advice is available only after the current iteration has a registered observation."
@@ -194,6 +339,8 @@ class DrawingSessionService:
     def approve_next_iteration(self, session_id: str) -> DrawingSession:
         with self._lock:
             session = self._sync(self._store.get(session_id))
+            if session.session_version != 1:
+                raise AppConflictError("Use session approval for V2 drawing sessions.")
             if session.status != "proposal_ready":
                 raise AppConflictError("This drawing session has no proposal ready to plot.")
             current_iteration = session.iterations[-1]
@@ -220,6 +367,8 @@ class DrawingSessionService:
             return self._store.save(session)
 
     def _sync(self, session: DrawingSession) -> DrawingSession:
+        if session.session_version == 2:
+            return self._sync_v2(session)
         current_iteration = session.iterations[-1]
         run = self._plot_workflow.get_run(current_iteration.run_id)
         previous_status = session.status
@@ -247,6 +396,143 @@ class DrawingSessionService:
             session.updated_at = datetime.now(timezone.utc)
             self._store.save(session)
         return session
+
+    def _sync_v2(self, session: DrawingSession) -> DrawingSession:
+        if session.current_run_id is None:
+            session.advisor = self._advisor.status
+            return session
+        run = self._plot_workflow.get_run(session.current_run_id)
+        previous_status = session.status
+        if run.status == "awaiting_capture_review":
+            session.status = "awaiting_capture_review"
+        elif run.status in ACTIVE_PLOT_RUN_STATUSES:
+            session.status = "running"
+        elif run.status == "failed":
+            session.status = "failed"
+            session.error = run.error
+        elif session.status not in {"completed", "failed"}:
+            session.status = "paused"
+            session.paused_at = datetime.now(timezone.utc)
+            session.error = None
+            if previous_status != "paused":
+                session.events.append(
+                    self._event(
+                        "observation_ready",
+                        "The registered first-pass observation is ready.",
+                        run_id=run.id,
+                    )
+                )
+                session.events.append(
+                    self._event(
+                        "session_paused",
+                        "Automatic continuation is not enabled in this contract slice.",
+                        run_id=run.id,
+                    )
+                )
+        session.advisor = self._advisor.status
+        if session.status != previous_status:
+            session.updated_at = datetime.now(timezone.utc)
+            self._store.save(session)
+        return session
+
+    def _dispatch_plan(self, session_id: str, generation: int) -> None:
+        Thread(
+            target=self._plan_session,
+            args=(session_id, generation),
+            daemon=True,
+            name=f"drawing-plan-{session_id[:8]}",
+        ).start()
+
+    def _plan_session(self, session_id: str, generation: int) -> None:
+        try:
+            with self._lock:
+                session = self._store.get(session_id)
+                if session.session_version != 2 or session.planning_generation != generation:
+                    return
+                intent = session.intent
+                guidance = list(session.queued_guidance)
+                workspace = self._workspace_service.current_validated()
+                plot_area = workspace.to_plot_area()
+            draft = self._advisor.plan_initial(
+                intent=intent,
+                guidance=guidance,
+                drawable_width_mm=plot_area.draw_width_mm,
+                drawable_height_mm=plot_area.draw_height_mm,
+            )
+            safe_svg = validate_and_normalize_advisor_svg(
+                draft.svg_text,
+                drawable_width_mm=plot_area.draw_width_mm,
+                drawable_height_mm=plot_area.draw_height_mm,
+            )
+            asset = self._plot_workflow.create_generated_asset(
+                name=f"{intent[:48]} — first pass",
+                svg_text=safe_svg,
+            )
+            with self._lock:
+                session = self._store.get(session_id)
+                if session.planning_generation != generation or session.status != "planning":
+                    return
+                now = datetime.now(timezone.utc)
+                session.plan = DrawingSessionPlan(
+                    summary=draft.summary.strip(),
+                    paper_strategy=draft.paper_strategy.strip(),
+                    completion_intent=draft.completion_intent.strip(),
+                )
+                session.current_proposal = DrawingSessionProposal(
+                    asset=asset,
+                    created_at=now,
+                    advisor_driver=self._advisor.status.driver,
+                    advisor_model=self._advisor.status.model,
+                )
+                session.status = "awaiting_approval"
+                session.error = None
+                session.advisor = self._advisor.status
+                session.updated_at = now
+                session.events.append(
+                    self._event(
+                        "plan_ready",
+                        "The drawing plan and first-pass preview are ready.",
+                        asset_id=asset.id,
+                        details={
+                            "summary": session.plan.summary,
+                            "paper_strategy": session.plan.paper_strategy,
+                            "completion_intent": session.plan.completion_intent,
+                        },
+                    )
+                )
+                self._store.save(session)
+        except (InvalidArtifactError, ServiceUnavailableError, AppConflictError) as exc:
+            with self._lock:
+                session = self._store.get(session_id)
+                if session.planning_generation != generation:
+                    return
+                now = datetime.now(timezone.utc)
+                session.status = "paused"
+                session.paused_at = now
+                session.error = str(exc)
+                session.advisor = self._advisor.status
+                session.updated_at = now
+                session.events.append(self._event("plan_failed", str(exc)))
+                self._store.save(session)
+
+    @staticmethod
+    def _event(
+        event_type,
+        message: str,
+        *,
+        asset_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        details: Optional[dict] = None,
+    ) -> DrawingSessionEvent:
+        return DrawingSessionEvent(
+            id=uuid4().hex,
+            type=event_type,
+            created_at=datetime.now(timezone.utc),
+            message=message,
+            asset_id=asset_id,
+            run_id=run_id,
+            details=details or {},
+        )
 
 
 def validate_and_normalize_advisor_svg(

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -70,6 +70,17 @@ def wait_for_run_status(client: TestClient, run_id: str, statuses: set[str]):
     raise AssertionError(f"Plot run did not reach expected state: {statuses}")
 
 
+def wait_for_session_status(client: TestClient, session_id: str, statuses: set[str]):
+    for _ in range(200):
+        response = client.get(f"/api/drawing-sessions/{session_id}")
+        assert response.status_code == 200
+        payload = response.json()
+        if payload["status"] in statuses:
+            return payload
+        time.sleep(0.01)
+    raise AssertionError(f"Drawing session did not reach expected state: {statuses}")
+
+
 def _jpeg_bytes(width: int = 640, height: int = 480) -> bytes:
     image = np.full((height, width, 3), 245, dtype=np.uint8)
     cv2.rectangle(image, (80, 60), (width - 80, height - 60), (32, 32, 32), 6)
@@ -1010,6 +1021,76 @@ def test_drawing_session_runs_observes_proposes_and_approves_next_layer(tmp_path
         first_run_id,
         second_run_id,
     ]
+    assert reloaded["session_version"] == 1
+
+
+def test_v2_drawing_session_plans_revises_and_approves_without_early_motion(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=MockPlotter(plot_delay_s=0),
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created_response = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A curious pelican riding a bicycle"},
+        )
+        assert created_response.status_code == 200
+        created = created_response.json()
+        assert created["session_version"] == 2
+        assert created["iterations"] == []
+        assert client.get("/api/plot-runs").json()["runs"] == []
+
+        planned = wait_for_session_status(
+            client,
+            created["id"],
+            {"awaiting_approval"},
+        )
+        first_asset_id = planned["current_proposal"]["asset"]["id"]
+        assert planned["plan"]["paper_strategy"]
+        assert planned["iteration_limit"] is None
+        assert client.get("/api/plot-runs").json()["runs"] == []
+
+        message_response = client.post(
+            f"/api/drawing-sessions/{created['id']}/messages",
+            json={"text": "Make the pose feel less formal."},
+        )
+        assert message_response.status_code == 200
+        revised = wait_for_session_status(
+            client,
+            created["id"],
+            {"awaiting_approval"},
+        )
+        assert revised["planning_generation"] == 2
+        assert revised["current_proposal"]["asset"]["id"] != first_asset_id
+        assert revised["queued_guidance"] == ["Make the pose feel less formal."]
+
+        summaries = client.get("/api/drawing-sessions").json()["sessions"]
+        assert summaries[0]["id"] == created["id"]
+        assert summaries[0]["preview_url"] == revised["current_proposal"]["asset"]["public_url"]
+
+        approved_response = client.post(
+            f"/api/drawing-sessions/{created['id']}/approve"
+        )
+        assert approved_response.status_code == 200
+        approved = approved_response.json()
+        assert approved["status"] == "running"
+        assert approved["authorization"]["approved_at"] is not None
+        assert approved["pass_count"] == 1
+        assert len(approved["iterations"]) == 1
+
+
+def test_v2_drawing_session_disabled_advisor_pauses_without_motion(tmp_path):
+    with create_test_client(tmp_path) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A quiet field of flowers"},
+        ).json()
+        paused = wait_for_session_status(client, created["id"], {"paused"})
+
+        assert "Drawing advisor is disabled" in paused["error"]
+        assert paused["current_proposal"] is None
+        assert client.get("/api/plot-runs").json()["runs"] == []
 
 
 def test_drawing_session_disabled_advisor_leaves_observation_retryable(tmp_path):

--- a/apps/api/tests/test_drawing_sessions.py
+++ b/apps/api/tests/test_drawing_sessions.py
@@ -104,3 +104,84 @@ def test_openai_advisor_sends_registered_image_and_parses_structured_output(monk
     image_input = captured["json"]["input"][0]["content"][1]
     assert image_input["image_url"].startswith("data:image/png;base64,")
     assert "secret" not in json.dumps(captured["json"])
+
+
+def test_openai_advisor_plans_first_pass_without_an_image(monkeypatch):
+    captured = {}
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "output_text": json.dumps(
+                    {
+                        "summary": "Begin with the pelican and bicycle silhouette.",
+                        "paper_strategy": "Keep the same sheet in place.",
+                        "completion_intent": "Stop when the gesture reads clearly.",
+                        "svg": _svg(),
+                    }
+                )
+            }
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    advisor = OpenAIDrawingAdvisor(api_key="secret", model="vision-model")
+
+    result = advisor.plan_initial(
+        intent="A pelican riding a bicycle",
+        guidance=["Keep it loose."],
+        drawable_width_mm=170,
+        drawable_height_mm=257,
+    )
+
+    assert result.summary.startswith("Begin with")
+    assert captured["json"]["text"]["format"]["name"] == "initial_drawing_plan"
+    assert captured["json"]["input"][0]["content"] == [
+        {
+            "type": "input_text",
+            "text": captured["json"]["input"][0]["content"][0]["text"],
+        }
+    ]
+
+
+def test_openai_advisor_assessment_requires_svg_for_continue(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "output_text": json.dumps(
+                    {
+                        "assessment": "The composition needs one more gesture.",
+                        "decision": "continue",
+                        "reason": "The bicycle does not read yet.",
+                        "svg": _svg(),
+                        "requested_human_action": None,
+                    }
+                )
+            }
+
+    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: Response())
+    advisor = OpenAIDrawingAdvisor(api_key="secret", model="vision-model")
+
+    result = advisor.assess_iteration(
+        intent="A pelican riding a bicycle",
+        plan_summary="Start with the silhouette.",
+        observed_image=b"png-bytes",
+        observed_media_type="image/png",
+        iteration_number=1,
+        drawable_width_mm=170,
+        drawable_height_mm=257,
+        prior_interpretations=[],
+        guidance=["Make it playful."],
+    )
+
+    assert result.decision == "continue"
+    assert result.svg_text == _svg()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,8 +25,8 @@ The current backend structure centers on:
 - `services/captures.py` for persisted raw capture storage, normalized-derivative metadata, and latest-capture lookup
 - `services/capture_service.py` and `services/capture_normalization/` for backend-owned manual page registration
 - `services/plot_workflow.py` for asset storage, run creation, preparation, plotting, and capture flow
-- `services/drawing_sessions.py` for bounded same-sheet iteration state and reuse of existing plot runs
-- `services/drawing_advisor.py` for the read-only visual-advisor boundary; provider output cannot invoke hardware
+- `services/drawing_sessions.py` for versioned creative-session state and reuse of existing plot runs
+- `services/drawing_advisor.py` for prompt-first planning and read-only visual assessment; provider output cannot invoke hardware
 - `services/plotter_calibration.py`, `services/plotter_device_settings.py`, and `services/plotter_workspace.py` for persisted plotter state
 
 ## Frontend Responsibilities
@@ -66,7 +66,7 @@ Local persisted state is organized by purpose:
 - `artifacts/captures`: saved raw capture metadata plus normalized derivative artifacts such as rectified grayscale and debug overlays
 - `artifacts/plot_assets`: uploaded or built-in plot sources
 - `artifacts/plot_runs`: run records and prepared output where applicable
-- `artifacts/drawing_sessions`: intent, ordered PlotRun references, interpretations, proposal provenance, and approval state
+- `artifacts/drawing_sessions`: versioned intent, plans, ordered PlotRun references, typed events, proposal provenance, and authorization state
 - `artifacts/calibration`: persisted plotter calibration values
 - `artifacts/device_settings`: persisted plotter device settings such as safe-bounds overrides plus the selected CameraBridge device preference
 - `artifacts/workspace`: persisted page size and margin setup
@@ -84,7 +84,7 @@ The app currently supports a single backend-owned plotting workflow with a few n
 - `workspace`: physical page size and margins are persisted; the page may extend beyond machine travel, but its margin-bounded drawable coordinates must remain inside the current operational safe bounds
 - `device settings`: stable machine information and operational safe bounds are backend-owned and surfaced read-only except for narrow safe overrides
 - `calibration`: persisted plotter calibration remains backend-owned and separate from transient runtime overrides
-- `drawing sessions`: a bounded additive sequence groups existing normal PlotRuns; an operator starts the first pass, may request read-only advice after a registered observation, previews the proposed SVG layer, and explicitly approves each later plot
+- `drawing sessions`: V2 begins from creative intent, persists an agent-authored plan and safe first-pass preview before motion, and requires explicit authorization before creating its first normal PlotRun; V1 bounded sessions remain readable
 
 ## Manual Capture Registration V2
 
@@ -106,15 +106,15 @@ Prepared plot SVGs contain only intentional artwork geometry. Full-page source b
 
 V1 capture and run JSON remains readable without migration. Its detector fields and transforms are legacy evidence only: the dashboard labels V1 registration as legacy, keeps it side by side, and never enables the exact overlay for it. Existing persisted artifacts and former review-memory files are left untouched on disk, but no active runtime reads or rewrites them.
 
-## Bounded Iterative Drawing Sessions
+## Versioned Agentic Drawing Sessions
 
-A `DrawingSession` records a text intent, additive mode, an iteration limit from 2 through 10, and an ordered list of iterations. Each iteration references a normal `PlotRun` and its exact asset; sessions do not own a second plotter executor. Existing active-run conflicts, preparation, workspace validation, capture, registration, and normalization therefore apply unchanged.
+V2 `DrawingSession` records begin from intent alone. Creation persists `planning` state and dispatches provider work without moving hardware. The drawing advisor returns a concise plan, paper strategy, completion intent, and first-pass SVG. That SVG is untrusted: the backend validates its exact drawable-area canvas, supported passive elements, direct coordinates, safe stroke styling, and in-bounds geometry before storing it as a generated asset and exposing `awaiting_approval`.
 
-After the current PlotRun completes with a registered observation, the operator may request advice. The backend sends the V2 rectified grayscale page, intent, pass number, drawable dimensions, and a bounded history of prior interpretations through the configured `DrawingAdvisor`. The default advisor is disabled. A deterministic mock supports local tests, and the optional OpenAI adapter uses image input plus strict structured output through the Responses API.
+Guidance submitted before approval is appended to the session event timeline, invalidates the current proposal, and starts a newer planning generation. A stale provider response cannot replace the latest generation. Approval is the first operation that creates a normal PlotRun; all existing preparation, active-run exclusion, hardware adapters, capture registration, and persistence remain authoritative. The current contract slice pauses after the registered first observation rather than starting an unattended next pass.
 
-Advisor output is untrusted. It is limited to interpretation text and an SVG proposal, never tools or commands. The backend rejects unsupported elements and active content, forces plot-safe stroke styling, requires physical dimensions and a viewBox exactly matching the current drawable area, and rejects marks outside that area. Only then is the proposal stored as a generated plot asset. It remains a preview until the operator explicitly approves it; approval starts the next normal PlotRun through the existing workflow.
+V2 persistence adds an append-only typed event timeline, plan and proposal references, authorization timestamps, current-run identity, pass count, and queued guidance. SVGs and images remain separate stored artifacts. Session-list responses expose compact gallery summaries without embedding artifact data. Provider calls remain read-only and receive no hardware tools.
 
-Additive mode reflects the physical constraint that ink cannot be erased. A proposed layer contains new marks only and is prepared at 1:1 drawable-area scale with the persisted page margins. Provider failure or invalid output leaves the completed observation intact and retryable. This first proof does not implement unattended plotting, separate-attempt grids, cross-session learning, or automatic paper handling.
+Existing session JSON without `session_version` parses as V1. Its bounded two-to-ten-pass, request-advice, and approve-next-iteration behavior remains available through the legacy endpoints and is not migrated or proactively rewritten.
 
 ## Extension Points
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -151,4 +151,12 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Added dashboard controls for session creation, pass history, interpretation, proposal preview, and explicit approval before each additional physical plot
 - Kept provider failures retryable and left unattended plotting, erasure, separate-attempt layouts, and cross-session learning out of scope
 
+## Prompt-First Agentic Session Contract Slice
+
+- Added a versioned V2 drawing-session contract that starts from creative intent and produces an agent-authored plan plus safe first-pass SVG before any plotter motion
+- Added asynchronous planning, pre-approval conversational revisions with stale-response protection, a compact session-list contract, and one-time first-pass approval
+- Split the advisor boundary into prompt-first planning and structured observation assessment while retaining the legacy V1 advice method
+- Added typed append-only session events, proposal and authorization metadata, and open-ended V2 persistence while keeping V1 bounded session JSON readable without migration
+- Kept all provider output behind the existing SVG safety validator and reused normal PlotRuns only after explicit approval
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary\n\n- Adds a versioned V2 drawing-session contract that starts from creative intent and plans a safe first pass before any plot run exists.\n- Adds asynchronous plan/revision work, typed events, proposal and authorization metadata, session summaries, messages, and approval.\n- Splits the advisor boundary into prompt-first planning and structured observation assessment while preserving V1 bounded-session behavior.\n- Implements the pre-edit plan recorded on #48.\n\nCloses #48\nParent: #47\n\n## Checks\n\n- [x] make api-test — 134 passed\n- [ ] make web-test — not required; no frontend files changed\n- [ ] make web-build — not required; no frontend files changed\n- [x] make api-lint — passed\n- [x] I listed the verification I actually ran in the PR body\n- [x] I noted checks I could not run and why\n\n## Architecture\n\n- [x] Backend remains the sole owner of hardware access\n- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers\n- [x] Mock adapters still work, including deterministic V2 plan/assessment behavior\n\n## Risk Review\n\n- [x] No hardware behavior changed in this slice\n- [x] V1 JSON continues parsing without migration; V2 is explicit through session_version 2\n- [x] Architecture and history docs are updated\n- [x] This PR is a narrow, reviewable slice