### PR TITLE
Add autonomous session orchestration and capture recovery

### DIFF
--- a/apps/api/src/learn_to_draw_api/api.py
+++ b/apps/api/src/learn_to_draw_api/api.py
@@ -130,7 +130,9 @@ def create_app(
     @asynccontextmanager
     async def lifespan(_: FastAPI):
         hardware_service.startup()
+        drawing_session_service.start()
         yield
+        drawing_session_service.stop()
         hardware_service.shutdown()
 
     app = FastAPI(title="LearnToDraw API", lifespan=lifespan)

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -347,6 +347,7 @@ class PlotRun(BaseModel):
     asset: PlotAsset
     prepared_artifact: Optional[PreparedArtifactRecord] = None
     capture: Optional[CaptureMetadata] = None
+    capture_attempts: list[CaptureMetadata] = Field(default_factory=list)
     observed_result: Optional[ObservedResultRecord] = None
     error: Optional[str] = None
     stage_states: dict[str, PlotStageState] = Field(default_factory=dict)
@@ -454,12 +455,14 @@ class DrawingSession(BaseModel):
     plan: Optional[DrawingSessionPlan] = None
     current_proposal: Optional[DrawingSessionProposal] = None
     current_run_id: Optional[str] = None
+    assessing_run_id: Optional[str] = None
     pass_count: int = Field(default=0, ge=0)
     planning_generation: int = Field(default=0, ge=0)
     authorization: DrawingSessionAuthorization = Field(
         default_factory=DrawingSessionAuthorization
     )
     queued_guidance: list[str] = Field(default_factory=list)
+    requested_human_action: Optional[str] = None
     events: list[DrawingSessionEvent] = Field(default_factory=list)
     approved_at: Optional[datetime] = None
     paused_at: Optional[datetime] = None
@@ -475,6 +478,10 @@ class DrawingSessionCreateRequest(BaseModel):
 
 class DrawingSessionMessageRequest(BaseModel):
     text: str = Field(min_length=1, max_length=2000)
+
+
+class DrawingSessionStopRequest(BaseModel):
+    mode: Literal["after_pass", "emergency"]
 
 
 class DrawingSessionSummary(BaseModel):

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -10,6 +10,7 @@ from learn_to_draw_api.models import (
     DrawingSessionCreateRequest,
     DrawingSessionListResponse,
     DrawingSessionMessageRequest,
+    DrawingSessionStopRequest,
     HealthResponse,
     HardwareStatus,
     LatestPlotRunResponse,
@@ -168,6 +169,10 @@ def build_api_router(
     ) -> PlotRunCaptureReviewResponse:
         return plot_workflow_service.confirm_capture_review(run_id, request)
 
+    @router.post("/api/plot-runs/{run_id}/capture/retry", response_model=PlotRun)
+    def post_plot_run_capture_retry(run_id: str) -> PlotRun:
+        return plot_workflow_service.retry_capture(run_id)
+
     @router.post("/api/drawing-sessions", response_model=DrawingSession)
     def post_drawing_session(request: DrawingSessionCreateRequest) -> DrawingSession:
         return drawing_session_service.create(request)
@@ -203,6 +208,30 @@ def build_api_router(
     )
     def post_drawing_session_approve(session_id: str) -> DrawingSession:
         return drawing_session_service.approve(session_id)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/heartbeat",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_heartbeat(session_id: str) -> DrawingSession:
+        return drawing_session_service.heartbeat(session_id)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/stop",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_stop(
+        session_id: str,
+        request: DrawingSessionStopRequest,
+    ) -> DrawingSession:
+        return drawing_session_service.stop_session(session_id, request)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/resume",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_resume(session_id: str) -> DrawingSession:
+        return drawing_session_service.resume(session_id)
 
     @router.post(
         "/api/drawing-sessions/{session_id}/advice",

--- a/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import math
 from pathlib import Path
-from threading import RLock, Thread
+from threading import Event, RLock, Thread
 from typing import Optional
 import xml.etree.ElementTree as ET
 from uuid import uuid4
@@ -19,11 +19,11 @@ from learn_to_draw_api.models import (
     DrawingSessionMessageRequest,
     DrawingSessionPlan,
     DrawingSessionProposal,
+    DrawingSessionStopRequest,
     DrawingSessionSummary,
     DrawingSession,
     DrawingSessionCreateRequest,
     InvalidArtifactError,
-    ServiceUnavailableError,
 )
 from learn_to_draw_api.services.drawing_advisor import DrawingAdvisor
 from learn_to_draw_api.services.plot_workflow import PlotWorkflowService
@@ -44,6 +44,9 @@ ACTIVE_PLOT_RUN_STATUSES = {
 }
 ALLOWED_ADVISOR_SVG_TAGS = SVG_SHAPE_TAGS | {"svg", "g", "title", "desc"}
 DIMENSION_EPSILON_MM = 0.01
+ATTENTION_GRACE_SECONDS = 30
+COORDINATOR_POLL_SECONDS = 0.05
+ACTIVE_SESSION_STATUSES = {"running", "awaiting_capture_review", "stopping"}
 
 
 class DrawingSessionStore:
@@ -97,6 +100,28 @@ class DrawingSessionService:
         self._workspace_service = workspace_service
         self._advisor = advisor
         self._lock = RLock()
+        self._coordinator_stop = Event()
+        self._coordinator_thread: Optional[Thread] = None
+
+    def start(self) -> None:
+        with self._lock:
+            if self._coordinator_thread is not None and self._coordinator_thread.is_alive():
+                return
+            self._recover_after_restart()
+            self._coordinator_stop.clear()
+            self._coordinator_thread = Thread(
+                target=self._run_coordinator,
+                daemon=True,
+                name="drawing-session-coordinator",
+            )
+            self._coordinator_thread.start()
+
+    def stop(self) -> None:
+        self._coordinator_stop.set()
+        thread = self._coordinator_thread
+        if thread is not None:
+            thread.join(timeout=1)
+        self._coordinator_thread = None
 
     def create(self, request: DrawingSessionCreateRequest) -> DrawingSession:
         intent = request.intent.strip()
@@ -231,11 +256,13 @@ class DrawingSessionService:
                 raise AppConflictError("This drawing session has no first pass ready to approve.")
             if session.authorization.approved_at is not None:
                 raise AppConflictError("This drawing session has already been approved.")
+            self._assert_no_other_active_session(session.id)
             asset = self._plot_workflow.get_asset(session.current_proposal.asset.id)
             run = self._plot_workflow.create_run(asset.id)
             now = datetime.now(timezone.utc)
             session.authorization.approved_at = now
             session.authorization.stop_requested = False
+            session.authorization.last_heartbeat_at = now
             session.approved_at = now
             session.current_run_id = run.id
             session.pass_count = 1
@@ -265,6 +292,91 @@ class DrawingSessionService:
             session.updated_at = now
             session.error = None
             return self._store.save(session)
+
+    def heartbeat(self, session_id: str) -> DrawingSession:
+        with self._lock:
+            session = self._store.get(session_id)
+            if session.session_version != 2:
+                raise AppConflictError("Heartbeat is available only for V2 drawing sessions.")
+            if session.status in {"completed", "failed"}:
+                return session
+            now = datetime.now(timezone.utc)
+            session.authorization.last_heartbeat_at = now
+            session.updated_at = now
+            return self._store.save(session)
+
+    def stop_session(
+        self,
+        session_id: str,
+        request: DrawingSessionStopRequest,
+    ) -> DrawingSession:
+        if request.mode == "emergency":
+            raise AppConflictError(
+                "Emergency plot interruption is not available until the interruptible worker is enabled."
+            )
+        with self._lock:
+            session = self._sync(self._store.get(session_id))
+            if session.session_version != 2:
+                raise AppConflictError("Stop control is available only for V2 drawing sessions.")
+            if session.status in {"completed", "failed"}:
+                return session
+            now = datetime.now(timezone.utc)
+            session.authorization.stop_requested = True
+            session.updated_at = now
+            session.events.append(
+                self._event(
+                    "stop_requested",
+                    "Stop requested. No additional pass will begin.",
+                    run_id=session.current_run_id,
+                    details={"mode": request.mode},
+                )
+            )
+            if session.current_run_id is None:
+                self._pause_session(
+                    session,
+                    "Stopped before plotting began.",
+                )
+            else:
+                run = self._plot_workflow.get_run(session.current_run_id)
+                if run.status in ACTIVE_PLOT_RUN_STATUSES:
+                    session.status = "stopping"
+                else:
+                    self._pause_session(
+                        session,
+                        "Stopped after the current pass.",
+                        run_id=run.id,
+                    )
+            return self._store.save(session)
+
+    def resume(self, session_id: str) -> DrawingSession:
+        with self._lock:
+            session = self._sync(self._store.get(session_id))
+            if session.session_version != 2:
+                raise AppConflictError("Resume is available only for V2 drawing sessions.")
+            if session.status != "paused":
+                raise AppConflictError("This drawing session is not paused.")
+            self._assert_no_other_active_session(session.id)
+            now = datetime.now(timezone.utc)
+            session.authorization.stop_requested = False
+            session.authorization.last_heartbeat_at = now
+            session.paused_at = None
+            session.error = None
+            session.requested_human_action = None
+            session.assessing_run_id = None
+            session.updated_at = now
+            session.events.append(
+                self._event("session_resumed", "The attended drawing session resumed.")
+            )
+            if session.authorization.approved_at is None:
+                session.status = "planning"
+                session.planning_generation += 1
+                generation = session.planning_generation
+                self._store.save(session)
+                self._dispatch_plan(session.id, generation)
+            else:
+                session.status = "running"
+                self._store.save(session)
+            return session
 
     def request_advice(self, session_id: str) -> DrawingSession:
         with self._lock:
@@ -406,34 +518,382 @@ class DrawingSessionService:
         if run.status == "awaiting_capture_review":
             session.status = "awaiting_capture_review"
         elif run.status in ACTIVE_PLOT_RUN_STATUSES:
-            session.status = "running"
+            session.status = (
+                "stopping" if session.authorization.stop_requested else "running"
+            )
         elif run.status == "failed":
-            session.status = "failed"
-            session.error = run.error
-        elif session.status not in {"completed", "failed"}:
-            session.status = "paused"
-            session.paused_at = datetime.now(timezone.utc)
-            session.error = None
-            if previous_status != "paused":
-                session.events.append(
-                    self._event(
-                        "observation_ready",
-                        "The registered first-pass observation is ready.",
-                        run_id=run.id,
-                    )
+            if session.status != "paused":
+                self._pause_session(
+                    session,
+                    run.error or "The current plot run failed.",
+                    run_id=run.id,
                 )
-                session.events.append(
-                    self._event(
-                        "session_paused",
-                        "Automatic continuation is not enabled in this contract slice.",
-                        run_id=run.id,
-                    )
-                )
+        elif (
+            run.status == "completed"
+            and session.status == "awaiting_capture_review"
+        ):
+            session.status = (
+                "stopping" if session.authorization.stop_requested else "running"
+            )
         session.advisor = self._advisor.status
         if session.status != previous_status:
             session.updated_at = datetime.now(timezone.utc)
             self._store.save(session)
         return session
+
+    def _run_coordinator(self) -> None:
+        while not self._coordinator_stop.wait(COORDINATOR_POLL_SECONDS):
+            try:
+                session_ids = [
+                    session.id
+                    for session in self._store.list()
+                    if session.session_version == 2
+                    and session.authorization.approved_at is not None
+                    and session.status in ACTIVE_SESSION_STATUSES
+                ]
+                for session_id in session_ids:
+                    self._coordinate_session(session_id)
+            except Exception:
+                # A single malformed persisted record must not terminate coordination for
+                # every other local session. Individual session failures are handled below.
+                continue
+
+    def _coordinate_session(self, session_id: str) -> None:
+        with self._lock:
+            session = self._store.get(session_id)
+            if (
+                session.session_version != 2
+                or session.authorization.approved_at is None
+                or session.status not in ACTIVE_SESSION_STATUSES
+                or session.current_run_id is None
+            ):
+                return
+            run = self._plot_workflow.get_run(session.current_run_id)
+            if run.status == "awaiting_capture_review":
+                if session.status != "awaiting_capture_review":
+                    session.status = "awaiting_capture_review"
+                    session.updated_at = datetime.now(timezone.utc)
+                    session.events.append(
+                        self._event(
+                            "session_paused",
+                            "Place the four physical page corners to continue.",
+                            run_id=run.id,
+                        )
+                    )
+                    self._store.save(session)
+                return
+            if run.status in ACTIVE_PLOT_RUN_STATUSES:
+                next_status = (
+                    "stopping" if session.authorization.stop_requested else "running"
+                )
+                if session.status != next_status:
+                    session.status = next_status
+                    session.updated_at = datetime.now(timezone.utc)
+                    self._store.save(session)
+                return
+            if run.status == "failed":
+                self._pause_session(
+                    session,
+                    run.error or "The current plot run failed.",
+                    run_id=run.id,
+                )
+                self._store.save(session)
+                return
+            if run.status != "completed":
+                return
+            if session.authorization.stop_requested:
+                self._pause_session(
+                    session,
+                    "Stopped after the current pass.",
+                    run_id=run.id,
+                )
+                self._store.save(session)
+                return
+            if not self._has_recent_heartbeat(session):
+                self._pause_session(
+                    session,
+                    "Creative screen disconnected. Resume when an operator is present.",
+                    run_id=run.id,
+                )
+                self._store.save(session)
+                return
+            if session.assessing_run_id == run.id:
+                return
+            capture = run.observed_result.capture if run.observed_result else run.capture
+            if (
+                capture is None
+                or capture.normalized is None
+                or capture.review is None
+                or capture.review.review_status != "confirmed"
+            ):
+                session.status = "awaiting_capture_review"
+                session.updated_at = datetime.now(timezone.utc)
+                self._store.save(session)
+                return
+            image_path = Path(capture.file_path).with_name(
+                f"{capture.id}-rectified-grayscale.png"
+            )
+            if not image_path.exists():
+                self._pause_session(
+                    session,
+                    "The registered observed image is unavailable. Retake the capture.",
+                    run_id=run.id,
+                )
+                self._store.save(session)
+                return
+            guidance = list(session.queued_guidance)
+            session.queued_guidance = []
+            session.assessing_run_id = run.id
+            session.status = "running"
+            session.updated_at = datetime.now(timezone.utc)
+            if not self._event_exists(session, "observation_ready", run.id):
+                session.events.append(
+                    self._event(
+                        "observation_ready",
+                        f"Registered observation for pass {session.pass_count} is ready.",
+                        run_id=run.id,
+                        details={
+                            "capture_id": capture.id,
+                            "normalized_url": capture.normalized.rectified_grayscale_url,
+                        },
+                    )
+                )
+            self._store.save(session)
+            intent = session.intent
+            plan_summary = session.plan.summary if session.plan else session.intent
+            iteration_number = session.pass_count
+            workspace = self._workspace_service.current_validated()
+            plot_area = workspace.to_plot_area()
+            prior_interpretations = [
+                str(event.details.get("assessment"))
+                for event in session.events
+                if event.type == "agent_decision" and event.details.get("assessment")
+            ]
+
+        try:
+            assessment = self._advisor.assess_iteration(
+                intent=intent,
+                plan_summary=plan_summary,
+                observed_image=image_path.read_bytes(),
+                observed_media_type="image/png",
+                iteration_number=iteration_number,
+                drawable_width_mm=plot_area.draw_width_mm,
+                drawable_height_mm=plot_area.draw_height_mm,
+                prior_interpretations=prior_interpretations,
+                guidance=guidance,
+            )
+            safe_svg = None
+            if assessment.decision == "continue":
+                if not assessment.svg_text:
+                    raise InvalidArtifactError(
+                        "A continue decision did not include a drawing layer."
+                    )
+                safe_svg = validate_and_normalize_advisor_svg(
+                    assessment.svg_text,
+                    drawable_width_mm=plot_area.draw_width_mm,
+                    drawable_height_mm=plot_area.draw_height_mm,
+                )
+            self._apply_assessment(
+                session_id=session_id,
+                run_id=run.id,
+                assessment=assessment,
+                safe_svg=safe_svg,
+                consumed_guidance=guidance,
+            )
+        except Exception as exc:
+            self._pause_assessment_failure(
+                session_id=session_id,
+                run_id=run.id,
+                consumed_guidance=guidance,
+                message=str(exc),
+            )
+
+    def _apply_assessment(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        assessment,
+        safe_svg: Optional[str],
+        consumed_guidance: list[str],
+    ) -> None:
+        asset = None
+        if assessment.decision == "continue" and safe_svg is not None:
+            with self._lock:
+                session = self._store.get(session_id)
+                next_number = session.pass_count + 1
+                asset_name = f"{session.intent[:48]} — pass {next_number}"
+            asset = self._plot_workflow.create_generated_asset(
+                name=asset_name,
+                svg_text=safe_svg,
+            )
+        with self._lock:
+            session = self._store.get(session_id)
+            if session.assessing_run_id != run_id or session.current_run_id != run_id:
+                return
+            now = datetime.now(timezone.utc)
+            session.assessing_run_id = None
+            session.events.append(
+                self._event(
+                    "agent_decision",
+                    assessment.reason,
+                    asset_id=asset.id if asset is not None else None,
+                    run_id=run_id,
+                    details={
+                        "assessment": assessment.assessment,
+                        "decision": assessment.decision,
+                        "reason": assessment.reason,
+                        "guidance": consumed_guidance,
+                        "requested_human_action": assessment.requested_human_action,
+                    },
+                )
+            )
+            if assessment.decision == "complete":
+                session.status = "completed"
+                session.completed_at = now
+                session.error = None
+                session.events.append(
+                    self._event(
+                        "session_completed",
+                        assessment.reason,
+                        run_id=run_id,
+                    )
+                )
+            elif assessment.decision == "pause":
+                session.requested_human_action = assessment.requested_human_action
+                self._pause_session(session, assessment.reason, run_id=run_id)
+            elif asset is not None:
+                if session.authorization.stop_requested:
+                    self._pause_session(
+                        session,
+                        "Stopped after the current pass.",
+                        run_id=run_id,
+                    )
+                elif not self._has_recent_heartbeat(session):
+                    self._pause_session(
+                        session,
+                        "Creative screen disconnected. Resume when an operator is present.",
+                        run_id=run_id,
+                    )
+                else:
+                    self._assert_no_other_active_session(session.id)
+                    next_run = self._plot_workflow.create_run(asset.id)
+                    previous_iteration = session.iterations[-1]
+                    previous_iteration.next_proposal = DrawingIterationProposal(
+                        interpretation=assessment.assessment,
+                        asset=asset,
+                        advisor_driver=self._advisor.status.driver,
+                        advisor_model=self._advisor.status.model,
+                        created_at=now,
+                        approved_at=now,
+                        approved_run_id=next_run.id,
+                    )
+                    session.iterations.append(
+                        DrawingIteration(
+                            number=session.pass_count + 1,
+                            asset=asset,
+                            run_id=next_run.id,
+                            created_at=now,
+                        )
+                    )
+                    session.current_proposal = DrawingSessionProposal(
+                        asset=asset,
+                        created_at=now,
+                        advisor_driver=self._advisor.status.driver,
+                        advisor_model=self._advisor.status.model,
+                    )
+                    session.pass_count += 1
+                    session.current_run_id = next_run.id
+                    session.status = "running"
+                    session.error = None
+                    session.events.append(
+                        self._event(
+                            "plot_started",
+                            f"Started pass {session.pass_count}.",
+                            asset_id=asset.id,
+                            run_id=next_run.id,
+                        )
+                    )
+            session.updated_at = now
+            self._store.save(session)
+
+    def _pause_assessment_failure(
+        self,
+        *,
+        session_id: str,
+        run_id: str,
+        consumed_guidance: list[str],
+        message: str,
+    ) -> None:
+        with self._lock:
+            session = self._store.get(session_id)
+            if session.assessing_run_id != run_id:
+                return
+            session.assessing_run_id = None
+            session.queued_guidance = consumed_guidance + session.queued_guidance
+            self._pause_session(session, message, run_id=run_id)
+            self._store.save(session)
+
+    def _recover_after_restart(self) -> None:
+        for session in self._store.list():
+            if session.session_version != 2 or session.status not in ACTIVE_SESSION_STATUSES:
+                continue
+            session.assessing_run_id = None
+            self._pause_session(
+                session,
+                "Backend restarted. Confirm readiness before resuming this session.",
+                run_id=session.current_run_id,
+            )
+            self._store.save(session)
+
+    def _assert_no_other_active_session(self, session_id: str) -> None:
+        for candidate in self._store.list():
+            if (
+                candidate.id != session_id
+                and candidate.session_version == 2
+                and candidate.status in ACTIVE_SESSION_STATUSES
+            ):
+                raise AppConflictError("Another creative drawing session is active.")
+
+    @staticmethod
+    def _has_recent_heartbeat(session: DrawingSession) -> bool:
+        heartbeat = session.authorization.last_heartbeat_at
+        if heartbeat is None:
+            return False
+        return (datetime.now(timezone.utc) - heartbeat).total_seconds() <= ATTENTION_GRACE_SECONDS
+
+    @staticmethod
+    def _event_exists(
+        session: DrawingSession,
+        event_type: str,
+        run_id: str,
+    ) -> bool:
+        return any(
+            event.type == event_type and event.run_id == run_id
+            for event in session.events
+        )
+
+    def _pause_session(
+        self,
+        session: DrawingSession,
+        message: str,
+        *,
+        run_id: Optional[str] = None,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        session.status = "paused"
+        session.paused_at = now
+        session.error = message
+        session.updated_at = now
+        if not (
+            session.events
+            and session.events[-1].type == "session_paused"
+            and session.events[-1].message == message
+            and session.events[-1].run_id == run_id
+        ):
+            session.events.append(
+                self._event("session_paused", message, run_id=run_id)
+            )
 
     def _dispatch_plan(self, session_id: str, generation: int) -> None:
         Thread(
@@ -501,7 +961,7 @@ class DrawingSessionService:
                     )
                 )
                 self._store.save(session)
-        except (InvalidArtifactError, ServiceUnavailableError, AppConflictError) as exc:
+        except Exception as exc:
             with self._lock:
                 session = self._store.get(session_id)
                 if session.planning_generation != generation:

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow.py
@@ -185,6 +185,34 @@ class PlotWorkflowService:
             run=run,
         )
 
+    def retry_capture(self, run_id: str) -> PlotRun:
+        with self._lock:
+            run = self._run_store.get(run_id)
+            plot_stage = run.stage_states.get("plot")
+            if plot_stage is None or plot_stage.status != "completed":
+                raise AppConflictError(
+                    "A capture can be retaken only after plotting has completed."
+                )
+            if run.capture_mode == "skip":
+                raise AppConflictError("Capture is disabled for this plot run.")
+            if run.status not in {"completed", "failed", "awaiting_capture_review"}:
+                raise AppConflictError("This plot run is not ready for a capture retry.")
+            active_run = self._get_active_run_locked()
+            if active_run is not None and active_run.id != run.id:
+                raise AppConflictError("A plot run is already active.")
+            if run.capture is not None and all(
+                item.id != run.capture.id for item in run.capture_attempts
+            ):
+                run.capture_attempts.append(run.capture)
+            run.status = "capturing"
+            run.error = None
+            run.updated_at = datetime.now(timezone.utc)
+            self._active_run_id = run.id
+            self._run_store.save(run)
+            worker = Thread(target=self._retry_capture_in_thread, args=(run.id,), daemon=True)
+            worker.start()
+            return run
+
     def _execute_run_in_thread(self, run_id: str) -> None:
         try:
             self._executor.execute_run(run_id)
@@ -290,6 +318,32 @@ class PlotWorkflowService:
             run.stage_states["capture_review"] = PlotStageState(
                 status="failed",
                 started_at=run.stage_states["capture_review"].started_at,
+                completed_at=datetime.now(timezone.utc),
+                message=str(exc),
+            )
+            self._run_store.save(run)
+        finally:
+            with self._lock:
+                if self._active_run_id == run_id:
+                    try:
+                        run = self._run_store.get(run_id)
+                    except AppNotFoundError:
+                        self._active_run_id = None
+                    else:
+                        if run.status not in ACTIVE_RUN_STATUSES:
+                            self._active_run_id = None
+
+    def _retry_capture_in_thread(self, run_id: str) -> None:
+        try:
+            self._executor.retry_capture(run_id)
+        except Exception as exc:
+            run = self._run_store.get(run_id)
+            run.status = "failed"
+            run.error = str(exc)
+            run.updated_at = datetime.now(timezone.utc)
+            run.stage_states["capture"] = PlotStageState(
+                status="failed",
+                started_at=run.stage_states["capture"].started_at,
                 completed_at=datetime.now(timezone.utc),
                 message=str(exc),
             )

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
@@ -118,97 +118,11 @@ class PlotRunExecutor:
                     message="Capture skipped for diagnostic run.",
                 )
             else:
-                run.status = "capturing"
-                run.updated_at = datetime.now(timezone.utc)
-                run = self._set_stage_state(
+                self._capture_run(
                     run,
-                    stage="capture",
-                    status="in_progress",
+                    page_width_mm=preparation.page_width_mm,
+                    page_height_mm=preparation.page_height_mm,
                     message="Capturing plotted page.",
-                )
-                capture_started = datetime.now(timezone.utc)
-                capture_artifact = self._camera.capture()
-                capture_completed = datetime.now(timezone.utc)
-                capture_metadata = self._capture_service.persist_raw_capture(capture_artifact)
-                initial_corners, proposal = self._capture_service.propose_registration_corners(
-                    content=capture_artifact.content,
-                    image_width=capture_metadata.width,
-                    image_height=capture_metadata.height,
-                )
-                automatically_confirmed = proposal.status == "suggested"
-                if automatically_confirmed:
-                    self._capture_service.validate_registration_corners(
-                        corners=initial_corners,
-                        image_width=capture_metadata.width,
-                        image_height=capture_metadata.height,
-                    )
-                review = CaptureReview(
-                    registration_version=2,
-                    review_mode="manual_corners",
-                    review_required=not automatically_confirmed,
-                    review_status="confirmed" if automatically_confirmed else "pending",
-                    proposed_corners=initial_corners,
-                    confirmed_corners=initial_corners if automatically_confirmed else None,
-                    confirmation_source="auto" if automatically_confirmed else None,
-                    proposal=proposal,
-                )
-                capture_metadata = self._capture_service.save_capture_review(
-                    capture_metadata.id,
-                    review=review,
-                )
-                run.capture = capture_metadata
-                capture_duration_ms = duration_ms(capture_started, capture_completed)
-                run.observed_result = ObservedResultRecord(
-                    capture=capture_metadata,
-                    camera_driver=self._camera.driver,
-                    captured_at=capture_metadata.timestamp,
-                    duration_ms=capture_duration_ms,
-                )
-                run.camera_run_details = {
-                    "driver": self._camera.driver,
-                    "capture_id": capture_metadata.id,
-                    "resolution": f"{capture_metadata.width}x{capture_metadata.height}",
-                    "duration_ms": capture_duration_ms,
-                }
-                run = self._set_stage_state(
-                    run,
-                    stage="capture",
-                    status="completed",
-                    message="Capture completed.",
-                )
-                run.camera_run_details = {
-                    **run.camera_run_details,
-                    "capture_review_required": not automatically_confirmed,
-                    "capture_registration_source": (
-                        "automatic" if automatically_confirmed else "manual"
-                    ),
-                }
-                if automatically_confirmed:
-                    current_stage = "capture_review"
-                    run = self._set_stage_state(
-                        run,
-                        stage="capture_review",
-                        status="in_progress",
-                        message="Applying stable automatic page registration.",
-                    )
-                    normalization_target = target_from_page_size(
-                        page_width_mm=preparation.page_width_mm,
-                        page_height_mm=preparation.page_height_mm,
-                        source="prepared_svg",
-                    )
-                    self._finalize_capture_review(
-                        run,
-                        normalization_target=normalization_target,
-                    )
-                    return
-
-                run.status = "awaiting_capture_review"
-                run.updated_at = datetime.now(timezone.utc)
-                self._set_stage_state(
-                    run,
-                    stage="capture_review",
-                    status="in_progress",
-                    message="Place the four page corners to register this capture.",
                 )
                 return
 
@@ -250,6 +164,118 @@ class PlotRunExecutor:
             else:
                 self._run_store.save(run)
 
+    def retry_capture(self, run_id: str) -> PlotRun:
+        run = self._run_store.get(run_id)
+        preparation = run.plotter_run_details.get("preparation", {})
+        return self._capture_run(
+            run,
+            page_width_mm=float(preparation["page_width_mm"]),
+            page_height_mm=float(preparation["page_height_mm"]),
+            message="Retaking the plotted-page observation without plotting again.",
+        )
+
+    def _capture_run(
+        self,
+        run: PlotRun,
+        *,
+        page_width_mm: float,
+        page_height_mm: float,
+        message: str,
+    ) -> PlotRun:
+        run.status = "capturing"
+        run.error = None
+        run.updated_at = datetime.now(timezone.utc)
+        run = self._set_stage_state(
+            run,
+            stage="capture",
+            status="in_progress",
+            message=message,
+        )
+        capture_started = datetime.now(timezone.utc)
+        capture_artifact = self._camera.capture()
+        capture_completed = datetime.now(timezone.utc)
+        capture_metadata = self._capture_service.persist_raw_capture(capture_artifact)
+        initial_corners, proposal = self._capture_service.propose_registration_corners(
+            content=capture_artifact.content,
+            image_width=capture_metadata.width,
+            image_height=capture_metadata.height,
+        )
+        automatically_confirmed = proposal.status == "suggested"
+        if automatically_confirmed:
+            self._capture_service.validate_registration_corners(
+                corners=initial_corners,
+                image_width=capture_metadata.width,
+                image_height=capture_metadata.height,
+            )
+        review = CaptureReview(
+            registration_version=2,
+            review_mode="manual_corners",
+            review_required=not automatically_confirmed,
+            review_status="confirmed" if automatically_confirmed else "pending",
+            proposed_corners=initial_corners,
+            confirmed_corners=initial_corners if automatically_confirmed else None,
+            confirmation_source="auto" if automatically_confirmed else None,
+            proposal=proposal,
+        )
+        capture_metadata = self._capture_service.save_capture_review(
+            capture_metadata.id,
+            review=review,
+        )
+        run.capture = capture_metadata
+        if all(item.id != capture_metadata.id for item in run.capture_attempts):
+            run.capture_attempts.append(capture_metadata)
+        capture_duration_ms = duration_ms(capture_started, capture_completed)
+        run.observed_result = ObservedResultRecord(
+            capture=capture_metadata,
+            camera_driver=self._camera.driver,
+            captured_at=capture_metadata.timestamp,
+            duration_ms=capture_duration_ms,
+        )
+        run.camera_run_details = {
+            "driver": self._camera.driver,
+            "capture_id": capture_metadata.id,
+            "capture_attempt_count": len(run.capture_attempts),
+            "resolution": f"{capture_metadata.width}x{capture_metadata.height}",
+            "duration_ms": capture_duration_ms,
+        }
+        run = self._set_stage_state(
+            run,
+            stage="capture",
+            status="completed",
+            message="Capture completed.",
+        )
+        run.camera_run_details = {
+            **run.camera_run_details,
+            "capture_review_required": not automatically_confirmed,
+            "capture_registration_source": (
+                "automatic" if automatically_confirmed else "manual"
+            ),
+        }
+        run = self._set_stage_state(
+            run,
+            stage="capture_review",
+            status="in_progress",
+            message=(
+                "Applying stable automatic page registration."
+                if automatically_confirmed
+                else "Place the four page corners to register this capture."
+            ),
+        )
+        if automatically_confirmed:
+            normalization_target = target_from_page_size(
+                page_width_mm=page_width_mm,
+                page_height_mm=page_height_mm,
+                source="prepared_svg",
+            )
+            return self._finalize_capture_review(
+                run,
+                normalization_target=normalization_target,
+            )
+        run.status = "awaiting_capture_review"
+        run.updated_at = datetime.now(timezone.utc)
+        self._run_store.save(run)
+        return run
+
     def finalize_capture_review(self, run_id: str) -> PlotRun:
         run = self._run_store.get(run_id)
         preparation = run.plotter_run_details.get("preparation", {})
@@ -284,6 +310,10 @@ class PlotRunExecutor:
             review=review,
         )
         run.capture = updated_capture
+        run.capture_attempts = [
+            updated_capture if item.id == updated_capture.id else item
+            for item in run.capture_attempts
+        ]
         if run.observed_result is not None:
             run.observed_result = run.observed_result.model_copy(
                 update={"capture": updated_capture}

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from datetime import datetime, timezone
 
@@ -13,6 +14,7 @@ from learn_to_draw_api.adapters.mock_plotter import MockPlotter
 from learn_to_draw_api.adapters.camera import CaptureArtifact
 from learn_to_draw_api.api import create_app
 from learn_to_draw_api.config import AppConfig
+from learn_to_draw_api.services import drawing_sessions as drawing_sessions_module
 from learn_to_draw_api.models import (
     DeviceStatus,
     HardwareOperationError,
@@ -77,6 +79,30 @@ def wait_for_session_status(client: TestClient, session_id: str, statuses: set[s
         payload = response.json()
         if payload["status"] in statuses:
             return payload
+        time.sleep(0.01)
+    raise AssertionError(f"Drawing session did not reach expected state: {statuses}")
+
+
+def drive_v2_session_until(
+    client: TestClient,
+    session_id: str,
+    statuses: set[str],
+):
+    confirmed_run_ids = set()
+    for _ in range(500):
+        client.post(f"/api/drawing-sessions/{session_id}/heartbeat")
+        session = client.get(f"/api/drawing-sessions/{session_id}").json()
+        if session["status"] in statuses:
+            return session
+        run_id = session.get("current_run_id")
+        if session["status"] == "awaiting_capture_review" and run_id not in confirmed_run_ids:
+            run = client.get(f"/api/plot-runs/{run_id}").json()
+            response = client.post(
+                f"/api/plot-runs/{run_id}/capture-review/confirm",
+                json={"corners": run["capture"]["review"]["proposed_corners"]},
+            )
+            assert response.status_code == 200
+            confirmed_run_ids.add(run_id)
         time.sleep(0.01)
     raise AssertionError(f"Drawing session did not reach expected state: {statuses}")
 
@@ -300,6 +326,16 @@ class LowConfidenceCamera:
             width=640,
             height=480,
         )
+
+
+class CountingPlotter(MockPlotter):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.plot_count = 0
+
+    def plot(self, document):
+        self.plot_count += 1
+        return super().plot(document)
 
 
 def test_capture_endpoint_persists_real_camera_artifact(tmp_path):
@@ -1091,6 +1127,182 @@ def test_v2_drawing_session_disabled_advisor_pauses_without_motion(tmp_path):
         assert "Drawing advisor is disabled" in paused["error"]
         assert paused["current_proposal"] is None
         assert client.get("/api/plot-runs").json()["runs"] == []
+
+
+def test_v2_session_auto_continues_consumes_guidance_and_completes(tmp_path):
+    plotter = CountingPlotter(plot_delay_s=0.03)
+    with create_test_client(
+        tmp_path,
+        plotter=plotter,
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A loose field of flowers"},
+        ).json()
+        planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
+        approved = client.post(
+            f"/api/drawing-sessions/{planned['id']}/approve"
+        ).json()
+        guidance_response = client.post(
+            f"/api/drawing-sessions/{planned['id']}/messages",
+            json={"text": "Make the flowers less regular."},
+        )
+        assert guidance_response.status_code == 200
+
+        completed = drive_v2_session_until(
+            client,
+            approved["id"],
+            {"completed"},
+        )
+
+    assert completed["pass_count"] == 2
+    assert plotter.plot_count == 2
+    decisions = [
+        event for event in completed["events"] if event["type"] == "agent_decision"
+    ]
+    assert decisions[0]["details"]["guidance"] == [
+        "Make the flowers less regular."
+    ]
+    assert decisions[-1]["details"]["decision"] == "complete"
+    assert completed["queued_guidance"] == []
+
+
+def test_v2_stop_after_pass_prevents_another_plot(tmp_path):
+    plotter = CountingPlotter(plot_delay_s=0.05)
+    with create_test_client(
+        tmp_path,
+        plotter=plotter,
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A single thoughtful flower"},
+        ).json()
+        planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
+        approved = client.post(
+            f"/api/drawing-sessions/{planned['id']}/approve"
+        ).json()
+        stopped = client.post(
+            f"/api/drawing-sessions/{approved['id']}/stop",
+            json={"mode": "after_pass"},
+        )
+        assert stopped.status_code == 200
+
+        paused = drive_v2_session_until(client, approved["id"], {"paused"})
+
+    assert paused["authorization"]["stop_requested"] is True
+    assert paused["pass_count"] == 1
+    assert plotter.plot_count == 1
+
+
+def test_v2_attention_timeout_pauses_before_a_second_plot(tmp_path, monkeypatch):
+    monkeypatch.setattr(drawing_sessions_module, "ATTENTION_GRACE_SECONDS", 0)
+    plotter = CountingPlotter(plot_delay_s=0)
+    with create_test_client(
+        tmp_path,
+        plotter=plotter,
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "An attended drawing"},
+        ).json()
+        planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
+        approved = client.post(
+            f"/api/drawing-sessions/{planned['id']}/approve"
+        ).json()
+        first_run = wait_for_run_status(
+            client,
+            approved["current_run_id"],
+            {"awaiting_capture_review"},
+        )
+        client.post(
+            f"/api/plot-runs/{first_run['id']}/capture-review/confirm",
+            json={"corners": first_run["capture"]["review"]["proposed_corners"]},
+        )
+        paused = wait_for_session_status(client, approved["id"], {"paused"})
+
+    assert "disconnected" in paused["error"]
+    assert paused["pass_count"] == 1
+    assert plotter.plot_count == 1
+
+
+def test_capture_retry_preserves_attempts_and_does_not_replot(tmp_path):
+    plotter = CountingPlotter(plot_delay_s=0)
+    with create_test_client(
+        tmp_path,
+        plotter=plotter,
+        camera=LowConfidenceCamera(),
+    ) as client:
+        asset = client.post(
+            "/api/plot-assets/patterns",
+            json={"pattern_id": "tiny-square"},
+        ).json()
+        run = client.post("/api/plot-runs", json={"asset_id": asset["id"]}).json()
+        first = wait_for_run_status(
+            client,
+            run["id"],
+            {"awaiting_capture_review"},
+        )
+        first_capture_id = first["capture"]["id"]
+
+        retry_response = client.post(f"/api/plot-runs/{run['id']}/capture/retry")
+        assert retry_response.status_code == 200
+        second = wait_for_run_status(
+            client,
+            run["id"],
+            {"awaiting_capture_review"},
+        )
+
+    assert second["capture"]["id"] != first_capture_id
+    assert [item["id"] for item in second["capture_attempts"]] == [
+        first_capture_id,
+        second["capture"]["id"],
+    ]
+    assert plotter.plot_count == 1
+
+
+def test_v2_backend_restart_requires_explicit_resume(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=CountingPlotter(plot_delay_s=0),
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A restart-safe drawing"},
+        ).json()
+        planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
+        approved = client.post(
+            f"/api/drawing-sessions/{planned['id']}/approve"
+        ).json()
+        completed = drive_v2_session_until(client, approved["id"], {"completed"})
+
+    session_path = tmp_path / "drawing-sessions" / f"{completed['id']}.json"
+    persisted = json.loads(session_path.read_text(encoding="utf-8"))
+    persisted["status"] = "running"
+    persisted["completed_at"] = None
+    session_path.write_text(json.dumps(persisted), encoding="utf-8")
+    restarted_plotter = CountingPlotter(plot_delay_s=0)
+
+    with create_test_client(
+        tmp_path,
+        plotter=restarted_plotter,
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as restarted_client:
+        recovered = restarted_client.get(
+            f"/api/drawing-sessions/{completed['id']}"
+        ).json()
+
+    assert recovered["status"] == "paused"
+    assert "Backend restarted" in recovered["error"]
+    assert restarted_plotter.plot_count == 0
 
 
 def test_drawing_session_disabled_advisor_leaves_observation_retryable(tmp_path):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ The current backend structure centers on:
 - `services/captures.py` for persisted raw capture storage, normalized-derivative metadata, and latest-capture lookup
 - `services/capture_service.py` and `services/capture_normalization/` for backend-owned manual page registration
 - `services/plot_workflow.py` for asset storage, run creation, preparation, plotting, and capture flow
-- `services/drawing_sessions.py` for versioned creative-session state and reuse of existing plot runs
+- `services/drawing_sessions.py` for versioned creative-session state, attended autonomous coordination, and reuse of existing plot runs
 - `services/drawing_advisor.py` for prompt-first planning and read-only visual assessment; provider output cannot invoke hardware
 - `services/plotter_calibration.py`, `services/plotter_device_settings.py`, and `services/plotter_workspace.py` for persisted plotter state
 
@@ -84,7 +84,7 @@ The app currently supports a single backend-owned plotting workflow with a few n
 - `workspace`: physical page size and margins are persisted; the page may extend beyond machine travel, but its margin-bounded drawable coordinates must remain inside the current operational safe bounds
 - `device settings`: stable machine information and operational safe bounds are backend-owned and surfaced read-only except for narrow safe overrides
 - `calibration`: persisted plotter calibration remains backend-owned and separate from transient runtime overrides
-- `drawing sessions`: V2 begins from creative intent, persists an agent-authored plan and safe first-pass preview before motion, and requires explicit authorization before creating its first normal PlotRun; V1 bounded sessions remain readable
+- `drawing sessions`: V2 begins from creative intent, requires explicit authorization for an attended open-ended session, then serially observes and decides whether to continue, complete, or pause; V1 bounded sessions remain readable
 
 ## Manual Capture Registration V2
 
@@ -110,9 +110,15 @@ V1 capture and run JSON remains readable without migration. Its detector fields 
 
 V2 `DrawingSession` records begin from intent alone. Creation persists `planning` state and dispatches provider work without moving hardware. The drawing advisor returns a concise plan, paper strategy, completion intent, and first-pass SVG. That SVG is untrusted: the backend validates its exact drawable-area canvas, supported passive elements, direct coordinates, safe stroke styling, and in-bounds geometry before storing it as a generated asset and exposing `awaiting_approval`.
 
-Guidance submitted before approval is appended to the session event timeline, invalidates the current proposal, and starts a newer planning generation. A stale provider response cannot replace the latest generation. Approval is the first operation that creates a normal PlotRun; all existing preparation, active-run exclusion, hardware adapters, capture registration, and persistence remain authoritative. The current contract slice pauses after the registered first observation rather than starting an unattended next pass.
+Guidance submitted before approval is appended to the session event timeline, invalidates the current proposal, and starts a newer planning generation. A stale provider response cannot replace the latest generation. Approval is the first operation that creates a normal PlotRun; all existing preparation, active-run exclusion, hardware adapters, capture registration, and persistence remain authoritative.
 
 V2 persistence adds an append-only typed event timeline, plan and proposal references, authorization timestamps, current-run identity, pass count, and queued guidance. SVGs and images remain separate stored artifacts. Session-list responses expose compact gallery summaries without embedding artifact data. Provider calls remain read-only and receive no hardware tools.
+
+After a registered observation completes, a single backend coordinator sends the rectified grayscale page, current plan, bounded interpretation history, and atomically consumed guidance through `assess_iteration`. `continue` requires a validated incremental SVG and creates exactly one next normal PlotRun. `complete` ends the session. `pause` records its reason and any requested human action. Provider, hardware, registration, and artifact failures pause rather than permitting another physical pass.
+
+Authorization remains attended. The creative client posts a heartbeat; if it is absent for 30 seconds, the current physical pass and its capture may finish, but another pass cannot begin. Stop-after-pass uses the same boundary. Backend startup converts persisted active V2 sessions to a paused recovery state, so process restart never restarts hardware automatically. Resume refreshes attendance, clears the soft-stop request, and re-enters coordination only after normal readiness checks.
+
+A plot run may retake its capture after plotting completed. The run retains an ordered `capture_attempts` history, keeps `capture` as the selected current attempt for compatibility, and sends only that current attempt through registration and normalization. Retake never invokes the plotter. Earlier capture files and metadata remain immutable evidence.
 
 Existing session JSON without `session_version` parses as V1. Its bounded two-to-ten-pass, request-advice, and approve-next-iteration behavior remains available through the legacy endpoints and is not migrated or proactively rewritten.
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -159,4 +159,12 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Added typed append-only session events, proposal and authorization metadata, and open-ended V2 persistence while keeping V1 bounded session JSON readable without migration
 - Kept all provider output behind the existing SVG safety validator and reused normal PlotRuns only after explicit approval
 
+## Autonomous Session Orchestration And Capture Recovery Slice
+
+- Added a single backend coordinator that turns registered V2 observations into strict continue, complete, or pause decisions and creates at most one validated next PlotRun
+- Made one approval open-ended but attended through a 30-second creative-screen heartbeat, stop-after-pass, restart-to-pause recovery, and explicit resume
+- Queued guidance during physical work and consumed it exactly once at the next observation assessment, with restoration on provider or validation failure
+- Added capture-only retry after a completed plot and preserved ordered immutable capture attempts while keeping the existing current-capture contract
+- Kept manual registration, active-run exclusion, normal PlotRuns, mock adapters, and backend-only hardware ownership as the safety boundaries
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary\n\n- Adds a single backend coordinator for V2 continue, complete, and pause decisions.\n- Adds atomic queued guidance, 30-second attendance heartbeat, stop-after-pass, restart recovery, and explicit resume.\n- Adds capture-only retry with ordered immutable attempts while retaining capture as the current selection.\n- Reuses normal PlotRuns and manual/automatic registration; no hardware path moves into the browser.\n- Implements the expanded pre-edit plan recorded on #49.\n\nCloses #49\nParent: #47\n\n## Checks\n\n- [x] make api-test — 139 passed\n- [x] make api-lint — passed\n- [ ] make web-test — not required; no frontend files changed\n- [ ] make web-build — not required; no frontend files changed\n- [x] I listed the verification I actually ran\n- [x] I noted checks not run and why\n\n## Architecture\n\n- [x] Backend remains the sole owner of coordination, plotting, capture, and persistence\n- [x] Existing real-adapter behavior is unchanged\n- [x] Mock plotting, capture, registration, stop, heartbeat, retry, and restart paths are covered\n\n## Risk Review\n\n- [x] No real-hardware interruption behavior is introduced in this slice\n- [x] V1 session and existing PlotRun JSON remain readable through defaults\n- [x] Provider, validation, registration, hardware, restart, and attendance failures pause safely\n- [x] Architecture and history docs are updated\n- [x] This PR is a narrow reviewable backend slice