### PR TITLE
Add interruptible AxiDraw plotting and emergency stop

### DIFF
--- a/apps/api/src/learn_to_draw_api/adapters/axidraw_client.py
+++ b/apps/api/src/learn_to_draw_api/adapters/axidraw_client.py
@@ -54,6 +54,9 @@ class AxiDrawPlotExecution:
     native_res_factor: Optional[float]
     motion_scale: Optional[float]
     details: dict[str, Any]
+    interrupted: bool = False
+    interruption_reason: Optional[str] = None
+    progress_svg: Optional[str] = None
 
 
 class PyAxiDrawClient:
@@ -104,6 +107,25 @@ class PyAxiDrawClient:
             "config_source": self._config_source,
             "calibration_source": self._resolve_calibration_source(),
             "native_res_factor": self._effective_native_res_factor,
+            "motion_scale": self._motion_scale,
+        }
+
+    def worker_settings(self) -> dict[str, Any]:
+        return {
+            "port": self._port,
+            "speed_pendown": self._speed_pendown,
+            "speed_penup": self._speed_penup,
+            "model": self._model,
+            "pen_pos_up": self._pen_pos_up,
+            "pen_pos_down": self._pen_pos_down,
+            "pen_rate_raise": self._pen_rate_raise,
+            "pen_rate_lower": self._pen_rate_lower,
+            "pen_delay_up": self._pen_delay_up,
+            "pen_delay_down": self._pen_delay_down,
+            "penlift": self._penlift,
+            "config_path": str(self._config_path) if self._config_path is not None else None,
+            "native_res_factor": self._native_res_factor_override,
+            "calibration_source": self._explicit_calibration_source,
             "motion_scale": self._motion_scale,
         }
 
@@ -251,7 +273,12 @@ class PyAxiDrawClient:
         finally:
             _safe_disconnect(ad)
 
-    def run_plot_document(self, svg_text: str) -> AxiDrawPlotExecution:
+    def run_plot_document(
+        self,
+        svg_text: str,
+        *,
+        interruptible: bool = False,
+    ) -> AxiDrawPlotExecution:
         ad = None
         try:
             ad, api_surface, plot_api_supported, manual_api_supported = self._new_axidraw()
@@ -262,7 +289,16 @@ class PyAxiDrawClient:
                     "AxiDraw API package with 'pip install .' and retry."
                 )
             self._apply_common_options(ad)
-            self._run_documented_plot(ad, svg_text)
+            output_svg, error_code = self._run_documented_plot(
+                ad,
+                svg_text,
+                interruptible=interruptible,
+            )
+            interrupted = error_code in {102, 103}
+            if error_code not in {0, 102, 103}:
+                raise PyAxiDrawClientError(
+                    f"AxiDraw plot_run() stopped with error code {error_code}."
+                )
             return AxiDrawPlotExecution(
                 port=self._port,
                 api_surface=api_surface,
@@ -272,7 +308,14 @@ class PyAxiDrawClient:
                 calibration_source=self._resolve_calibration_source(),
                 native_res_factor=self._effective_native_res_factor,
                 motion_scale=self._motion_scale,
-                details={"result": "plot_run"},
+                details={"result": "plot_run", "error_code": error_code},
+                interrupted=interrupted,
+                interruption_reason=(
+                    "physical_pause" if error_code == 102 else "keyboard_interrupt"
+                )
+                if interrupted
+                else None,
+                progress_svg=output_svg if interrupted else None,
             )
         except ImportError as exc:
             raise PyAxiDrawClientError(
@@ -313,15 +356,28 @@ class PyAxiDrawClient:
         config_path = self._resolve_config_path()
         ad.load_config(str(config_path))
 
-    def _run_documented_plot(self, ad: Any, svg_text: str) -> None:
+    def _run_documented_plot(
+        self,
+        ad: Any,
+        svg_text: str,
+        *,
+        interruptible: bool,
+    ) -> tuple[Optional[str], int]:
         # Official Plot context: plot_setup(svg_input) -> set options -> plot_run().
         ad.plot_setup(svg_text)
         ad.options.mode = "plot"
         if hasattr(ad.options, "auto_rotate"):
             ad.options.auto_rotate = False
-        result = ad.plot_run(output=False)
+        if interruptible:
+            ad.keyboard_pause = True
+            errors = getattr(ad, "errors", None)
+            if errors is not None and hasattr(errors, "keyboard"):
+                errors.keyboard = False
+        result = ad.plot_run(output=interruptible)
         if result is False:
             raise PyAxiDrawClientError("AxiDraw plot_run() reported failure.")
+        error_code = getattr(getattr(ad, "errors", None), "code", 0)
+        return (result if isinstance(result, str) else None, int(error_code or 0))
 
     def _run_documented_manual(self, ad: Any, manual_cmd: str) -> None:
         # Official Plot context: plot_setup() -> options.mode/manual_cmd -> plot_run().

--- a/apps/api/src/learn_to_draw_api/adapters/axidraw_plot_worker.py
+++ b/apps/api/src/learn_to_draw_api/adapters/axidraw_plot_worker.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import multiprocessing
+import os
+import queue
+import signal
+from threading import Lock
+from typing import Callable
+
+from learn_to_draw_api.adapters.axidraw_client import (
+    AxiDrawPlotExecution,
+    PyAxiDrawClient,
+    PyAxiDrawClientError,
+)
+
+
+class AxiDrawProcessPlotRunner:
+    """Runs Plot context in its own signal-owning process."""
+
+    def __init__(
+        self,
+        *,
+        settings_provider: Callable[[], dict],
+        context=None,
+        signal_sender: Callable[[int, int], None] = os.kill,
+    ) -> None:
+        self._settings_provider = settings_provider
+        self._context = context or multiprocessing.get_context("spawn")
+        self._signal_sender = signal_sender
+        self._lock = Lock()
+        self._active_process = None
+        self._stop_requested = False
+
+    def run(self, svg_text: str) -> AxiDrawPlotExecution:
+        result_queue = self._context.Queue(maxsize=1)
+        process = self._context.Process(
+            target=_run_plot_worker,
+            args=(self._settings_provider(), svg_text, result_queue),
+            daemon=True,
+        )
+        with self._lock:
+            if self._active_process is not None and self._active_process.is_alive():
+                raise PyAxiDrawClientError("An AxiDraw plot worker is already active.")
+            self._active_process = process
+            self._stop_requested = False
+            process.start()
+        try:
+            payload = None
+            while payload is None:
+                try:
+                    payload = result_queue.get(timeout=0.1)
+                except queue.Empty:
+                    if not process.is_alive():
+                        try:
+                            payload = result_queue.get(timeout=1)
+                        except queue.Empty as exc:
+                            raise PyAxiDrawClientError(
+                                "AxiDraw plot worker exited without a result "
+                                f"(exit code {process.exitcode})."
+                            ) from exc
+            process.join(timeout=1)
+            if payload.get("ok") is not True:
+                raise PyAxiDrawClientError(
+                    str(payload.get("error") or "AxiDraw plot worker failed.")
+                )
+            return AxiDrawPlotExecution(**payload["execution"])
+        finally:
+            with self._lock:
+                if self._active_process is process:
+                    self._active_process = None
+                    self._stop_requested = False
+            result_queue.close()
+
+    def request_stop(self) -> bool:
+        with self._lock:
+            process = self._active_process
+            if process is None or not process.is_alive() or process.pid is None:
+                return False
+            if self._stop_requested:
+                return True
+            self._stop_requested = True
+            self._signal_sender(process.pid, signal.SIGINT)
+            return True
+
+
+class InlineAxiDrawPlotRunner:
+    """Compatibility runner for injected clients used outside the real adapter factory."""
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    def run(self, svg_text: str) -> AxiDrawPlotExecution:
+        return self._client.run_plot_document(svg_text)
+
+    def request_stop(self) -> bool:
+        return False
+
+
+def _run_plot_worker(settings: dict, svg_text: str, result_queue) -> None:
+    try:
+        client = PyAxiDrawClient(**settings)
+        execution = client.run_plot_document(svg_text, interruptible=True)
+        result_queue.put({"ok": True, "execution": asdict(execution)})
+    except BaseException as exc:
+        result_queue.put({"ok": False, "error": str(exc)})

--- a/apps/api/src/learn_to_draw_api/adapters/axidraw_plotter.py
+++ b/apps/api/src/learn_to_draw_api/adapters/axidraw_plotter.py
@@ -10,6 +10,10 @@ from learn_to_draw_api.adapters.axidraw_client import (
     PyAxiDrawClient,
     PyAxiDrawClientError,
 )
+from learn_to_draw_api.adapters.axidraw_plot_worker import (
+    AxiDrawProcessPlotRunner,
+    InlineAxiDrawPlotRunner,
+)
 from learn_to_draw_api.models import (
     DeviceStatus,
     HardwareBusyError,
@@ -29,8 +33,17 @@ class AxiDrawPlotter:
         *,
         client: Optional[PyAxiDrawClient] = None,
         port: Optional[str] = None,
+        plot_runner=None,
     ) -> None:
         self._client = client or PyAxiDrawClient(port=port)
+        if plot_runner is not None:
+            self._plot_runner = plot_runner
+        elif hasattr(self._client, "worker_settings"):
+            self._plot_runner = AxiDrawProcessPlotRunner(
+                settings_provider=self._client.worker_settings
+            )
+        else:
+            self._plot_runner = InlineAxiDrawPlotRunner(self._client)
         self._port = port
         config_details = self._client.config_details()
         self._connected = False
@@ -168,10 +181,13 @@ class AxiDrawPlotter:
         started_at = datetime.now(timezone.utc)
         self._touch()
         try:
-            execution = self._client.run_plot_document(document.svg_text)
+            execution = self._plot_runner.run(document.svg_text)
             completed_at = datetime.now(timezone.utc)
             self._apply_plot_execution(execution)
-            self._details["last_action_status"] = "succeeded"
+            interrupted = bool(getattr(execution, "interrupted", False))
+            self._details["last_action_status"] = (
+                "cancelled" if interrupted else "succeeded"
+            )
             self._touch()
             return PlotResult(
                 started_at=started_at,
@@ -182,6 +198,9 @@ class AxiDrawPlotter:
                     "port": execution.port or self._details["port"],
                     **execution.details,
                 },
+                interrupted=interrupted,
+                interruption_reason=getattr(execution, "interruption_reason", None),
+                progress_svg=getattr(execution, "progress_svg", None),
             )
         except PyAxiDrawClientError as exc:
             self._error = str(exc)
@@ -191,6 +210,15 @@ class AxiDrawPlotter:
         finally:
             self._busy = False
             self._touch()
+
+    def request_stop(self) -> bool:
+        if not self._busy:
+            return False
+        requested = self._plot_runner.request_stop()
+        if requested:
+            self._details["last_action_status"] = "stopping"
+            self._touch()
+        return requested
 
     def _ensure_ready(self) -> None:
         if self._busy:

--- a/apps/api/src/learn_to_draw_api/adapters/mock_plotter.py
+++ b/apps/api/src/learn_to_draw_api/adapters/mock_plotter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import time
+from threading import Event
 from typing import Optional
 
 from learn_to_draw_api.models import (
@@ -58,6 +59,7 @@ class MockPlotter:
             "last_test_action_status": None,
         }
         self._last_updated = datetime.now(timezone.utc)
+        self._stop_requested = Event()
 
     def connect(self) -> None:
         if not self.available:
@@ -154,9 +156,10 @@ class MockPlotter:
         self._details["last_action_status"] = "in_progress"
         self._details["last_plotted_asset_id"] = document.asset_id
         started_at = datetime.now(timezone.utc)
+        self._stop_requested.clear()
         self._touch()
         try:
-            time.sleep(self._plot_delay_s)
+            interrupted = self._stop_requested.wait(self._plot_delay_s)
             if self._fail_on_plot:
                 self._error = "Mock plotter failed while plotting."
                 self._details["last_action_status"] = "failed"
@@ -175,10 +178,21 @@ class MockPlotter:
                     "svg_width": document.width,
                     "svg_height": document.height,
                 },
+                interrupted=interrupted,
+                interruption_reason="operator_emergency_stop" if interrupted else None,
+                progress_svg=document.svg_text if interrupted else None,
             )
         finally:
             self._busy = False
             self._touch()
+
+    def request_stop(self) -> bool:
+        if not self._busy:
+            return False
+        self._stop_requested.set()
+        self._details["last_action_status"] = "stopping"
+        self._touch()
+        return True
 
     def _touch(self) -> None:
         self._last_updated = datetime.now(timezone.utc)

--- a/apps/api/src/learn_to_draw_api/adapters/plotter.py
+++ b/apps/api/src/learn_to_draw_api/adapters/plotter.py
@@ -28,3 +28,6 @@ class PlotterAdapter(Protocol):
 
     def plot(self, document: PlotDocument) -> PlotResult:
         ...
+
+    def request_stop(self) -> bool:
+        ...

--- a/apps/api/src/learn_to_draw_api/adapters/unavailable_plotter.py
+++ b/apps/api/src/learn_to_draw_api/adapters/unavailable_plotter.py
@@ -66,5 +66,8 @@ class UnavailablePlotter:
     def plot(self, document: PlotDocument) -> PlotResult:
         raise HardwareUnavailableError(self._message)
 
+    def request_stop(self) -> bool:
+        raise HardwareUnavailableError(self._message)
+
     def _touch(self) -> None:
         self._last_updated = datetime.now(timezone.utc)

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -294,6 +294,9 @@ class PlotResult(BaseModel):
     completed_at: datetime
     document_id: str
     details: dict[str, Any] = Field(default_factory=dict)
+    interrupted: bool = False
+    interruption_reason: Optional[str] = None
+    progress_svg: Optional[str] = None
 
 
 PlotRunPurpose = Literal["normal", "diagnostic"]
@@ -301,8 +304,10 @@ PlotRunCaptureMode = Literal["auto", "skip"]
 PlotRunStatus = Literal[
     "pending",
     "plotting",
+    "stopping",
     "capturing",
     "awaiting_capture_review",
+    "cancelled",
     "completed",
     "failed",
 ]
@@ -331,7 +336,7 @@ class PlotAsset(BaseModel):
 
 
 class PlotStageState(BaseModel):
-    status: Literal["pending", "in_progress", "completed", "failed"]
+    status: Literal["pending", "in_progress", "completed", "failed", "cancelled"]
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     message: Optional[str] = None
@@ -349,6 +354,8 @@ class PlotRun(BaseModel):
     capture: Optional[CaptureMetadata] = None
     capture_attempts: list[CaptureMetadata] = Field(default_factory=list)
     observed_result: Optional[ObservedResultRecord] = None
+    progress_artifact: Optional[PreparedArtifactRecord] = None
+    interruption_reason: Optional[str] = None
     error: Optional[str] = None
     stage_states: dict[str, PlotStageState] = Field(default_factory=dict)
     plotter_run_details: dict[str, Any] = Field(default_factory=dict)

--- a/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
@@ -39,6 +39,7 @@ from learn_to_draw_api.services.plotter_workspace import PlotterWorkspaceService
 ACTIVE_PLOT_RUN_STATUSES = {
     "pending",
     "plotting",
+    "stopping",
     "capturing",
     "awaiting_capture_review",
 }
@@ -310,10 +311,6 @@ class DrawingSessionService:
         session_id: str,
         request: DrawingSessionStopRequest,
     ) -> DrawingSession:
-        if request.mode == "emergency":
-            raise AppConflictError(
-                "Emergency plot interruption is not available until the interruptible worker is enabled."
-            )
         with self._lock:
             session = self._sync(self._store.get(session_id))
             if session.session_version != 2:
@@ -336,6 +333,16 @@ class DrawingSessionService:
                     session,
                     "Stopped before plotting began.",
                 )
+            elif request.mode == "emergency":
+                run = self._plot_workflow.request_stop(session.current_run_id)
+                if run.status in {"cancelled", "completed", "failed"}:
+                    self._pause_session(
+                        session,
+                        "Emergency stop completed. Inspect the machine before resuming.",
+                        run_id=run.id,
+                    )
+                else:
+                    session.status = "stopping"
             else:
                 run = self._plot_workflow.get_run(session.current_run_id)
                 if run.status in ACTIVE_PLOT_RUN_STATUSES:
@@ -528,6 +535,13 @@ class DrawingSessionService:
                     run.error or "The current plot run failed.",
                     run_id=run.id,
                 )
+        elif run.status == "cancelled":
+            if session.status != "paused":
+                self._pause_session(
+                    session,
+                    "Emergency stop completed. Inspect the machine before resuming.",
+                    run_id=run.id,
+                )
         elif (
             run.status == "completed"
             and session.status == "awaiting_capture_review"
@@ -595,6 +609,14 @@ class DrawingSessionService:
                 self._pause_session(
                     session,
                     run.error or "The current plot run failed.",
+                    run_id=run.id,
+                )
+                self._store.save(session)
+                return
+            if run.status == "cancelled":
+                self._pause_session(
+                    session,
+                    "Emergency stop completed. Inspect the machine before resuming.",
                     run_id=run.id,
                 )
                 self._store.save(session)

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow.py
@@ -213,6 +213,35 @@ class PlotWorkflowService:
             worker.start()
             return run
 
+    def request_stop(self, run_id: str) -> PlotRun:
+        with self._lock:
+            run = self._run_store.get(run_id)
+            if run.status in {"cancelled", "completed", "failed"}:
+                return run
+            if run.status not in {"pending", "plotting", "stopping"}:
+                raise AppConflictError(
+                    "Emergency stop is available only before or during plotting."
+                )
+            if run.status == "stopping":
+                return run
+            was_plotting = run.status == "plotting"
+            run.status = "stopping"
+            run.interruption_reason = "operator_emergency_stop"
+            run.updated_at = datetime.now(timezone.utc)
+            if "plot" in run.stage_states:
+                plot_stage = run.stage_states["plot"]
+                run.stage_states["plot"] = plot_stage.model_copy(
+                    update={"message": "Emergency stop requested."}
+                )
+            self._run_store.save(run)
+            if was_plotting:
+                try:
+                    self._plotter.request_stop()
+                except Exception as exc:
+                    run.error = f"Emergency stop request failed: {exc}"
+                    self._run_store.save(run)
+            return run
+
     def _execute_run_in_thread(self, run_id: str) -> None:
         try:
             self._executor.execute_run(run_id)

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_execution.py
@@ -75,6 +75,19 @@ class PlotRunExecutor:
             )
 
             current_stage = "plot"
+            if run.status == "stopping":
+                run.status = "cancelled"
+                run.interruption_reason = (
+                    run.interruption_reason or "operator_emergency_stop"
+                )
+                run = self._set_stage_state(
+                    run,
+                    stage="plot",
+                    status="cancelled",
+                    message="Plot cancelled before motion began.",
+                )
+                self._run_store.save(run)
+                return
             run.status = "plotting"
             run.updated_at = datetime.now(timezone.utc)
             run = self._set_stage_state(
@@ -99,6 +112,27 @@ class PlotRunExecutor:
                 ),
                 "details": plot_result.details,
             }
+            if plot_result.interrupted or run.status == "stopping":
+                if plot_result.progress_svg:
+                    run.progress_artifact = self._run_store.save_progress_svg(
+                        run.id,
+                        plot_result.progress_svg,
+                    )
+                run.status = "cancelled"
+                run.interruption_reason = (
+                    run.interruption_reason
+                    or plot_result.interruption_reason
+                    or "plot_interrupted"
+                )
+                run.error = None
+                run = self._set_stage_state(
+                    run,
+                    stage="plot",
+                    status="cancelled",
+                    message="Plot paused after its current line segment.",
+                )
+                self._run_store.save(run)
+                return
             run = self._set_stage_state(
                 run,
                 stage="plot",
@@ -348,7 +382,7 @@ class PlotRunExecutor:
         run.stage_states[stage] = PlotStageState(
             status=status,
             started_at=previous.started_at or (now if status == "in_progress" else None),
-            completed_at=now if status in {"completed", "failed"} else None,
+            completed_at=now if status in {"completed", "failed", "cancelled"} else None,
             message=message,
         )
         run.updated_at = now

--- a/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
+++ b/apps/api/src/learn_to_draw_api/services/plot_workflow_runs.py
@@ -14,7 +14,13 @@ from learn_to_draw_api.models import (
 )
 
 
-ACTIVE_RUN_STATUSES = {"pending", "plotting", "capturing", "awaiting_capture_review"}
+ACTIVE_RUN_STATUSES = {
+    "pending",
+    "plotting",
+    "stopping",
+    "capturing",
+    "awaiting_capture_review",
+}
 
 
 class PlotRunStore:
@@ -44,6 +50,15 @@ class PlotRunStore:
         return PreparedArtifactRecord(
             file_path=str(prepared_path),
             public_url=f"{self._artifacts_url_prefix}/{quote(prepared_path.name)}",
+        )
+
+    def save_progress_svg(self, run_id: str, svg_text: str) -> PreparedArtifactRecord:
+        with self._lock:
+            progress_path = self._runs_dir / f"{run_id}-paused-progress.svg"
+            progress_path.write_text(svg_text, encoding="utf-8")
+        return PreparedArtifactRecord(
+            file_path=str(progress_path),
+            public_url=f"{self._artifacts_url_prefix}/{quote(progress_path.name)}",
         )
 
     def get(self, run_id: str) -> PlotRun:

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1198,6 +1198,51 @@ def test_v2_stop_after_pass_prevents_another_plot(tmp_path):
     assert plotter.plot_count == 1
 
 
+def test_v2_emergency_stop_cancels_plot_without_capture_or_continuation(tmp_path):
+    plotter = CountingPlotter(plot_delay_s=1)
+    with create_test_client(
+        tmp_path,
+        plotter=plotter,
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A drawing that can be interrupted"},
+        ).json()
+        planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
+        approved = client.post(
+            f"/api/drawing-sessions/{planned['id']}/approve"
+        ).json()
+        active_run = wait_for_run_status(
+            client,
+            approved["current_run_id"],
+            {"plotting"},
+        )
+
+        stop_response = client.post(
+            f"/api/drawing-sessions/{approved['id']}/stop",
+            json={"mode": "emergency"},
+        )
+        assert stop_response.status_code == 200
+        cancelled = wait_for_run_status(
+            client,
+            active_run["id"],
+            {"cancelled"},
+        )
+        paused = wait_for_session_status(client, approved["id"], {"paused"})
+
+    assert cancelled["capture"] is None
+    assert cancelled["interruption_reason"] == "operator_emergency_stop"
+    assert cancelled["progress_artifact"]["public_url"].endswith(
+        "-paused-progress.svg"
+    )
+    assert cancelled["stage_states"]["plot"]["status"] == "cancelled"
+    assert paused["pass_count"] == 1
+    assert paused["authorization"]["stop_requested"] is True
+    assert plotter.plot_count == 1
+
+
 def test_v2_attention_timeout_pauses_before_a_second_plot(tmp_path, monkeypatch):
     monkeypatch.setattr(drawing_sessions_module, "ATTENTION_GRACE_SECONDS", 0)
     plotter = CountingPlotter(plot_delay_s=0)

--- a/apps/api/tests/test_axidraw_adapter.py
+++ b/apps/api/tests/test_axidraw_adapter.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+import signal
+from threading import Event, Thread
 from types import SimpleNamespace
 
 import pytest
 
 import learn_to_draw_api.adapters.axidraw_client as axidraw_client_module
-from learn_to_draw_api.adapters.axidraw_client import PyAxiDrawClient, PyAxiDrawClientError
+from learn_to_draw_api.adapters.axidraw_client import (
+    AxiDrawPlotExecution,
+    PyAxiDrawClient,
+    PyAxiDrawClientError,
+)
+from learn_to_draw_api.adapters.axidraw_plot_worker import AxiDrawProcessPlotRunner
 from learn_to_draw_api.adapters.axidraw_plotter import AxiDrawPlotter
 from learn_to_draw_api.adapters.factory import build_plotter_adapter
 from learn_to_draw_api.config import AppConfig
@@ -37,8 +44,11 @@ class FakeDocumentedAxiDraw:
             resolution=None,
         )
         self.fw_version_string = "FW-1.2.3"
+        self.keyboard_pause = False
+        self.errors = SimpleNamespace(code=0, keyboard=True)
         self.plot_setup_inputs: list[str | None] = []
         self.plot_run_calls: list[tuple[str | None, str | None]] = []
+        self.plot_run_outputs: list[bool] = []
         self.load_config_calls: list[str] = []
         self.plot_run_result = True
         self.disconnect_called = False
@@ -51,6 +61,7 @@ class FakeDocumentedAxiDraw:
 
     def plot_run(self, output: bool = False):
         self.plot_run_calls.append((self.options.mode, self.options.manual_cmd))
+        self.plot_run_outputs.append(output)
         return self.plot_run_result
 
     def load_config(self, config_ref: str) -> None:
@@ -195,6 +206,28 @@ def test_pyaxidraw_client_uses_generated_native_res_override(fake_vendor_axidraw
     generated_path = Path(plot_instance.load_config_calls[0])
     assert generated_path.exists()
     assert "native_res_factor = 1905.0" in generated_path.read_text()
+
+
+def test_pyaxidraw_client_collects_progress_for_documented_keyboard_pause(
+    fake_vendor_axidraw_conf,
+):
+    plot_instance = FakeDocumentedAxiDraw()
+    plot_instance.plot_run_result = "<svg data-paused='true' />"
+    plot_instance.errors.code = 103
+    client = PyAxiDrawClient(module_loader=module_loader_with([plot_instance]))
+
+    execution = client.run_plot_document(
+        "<svg xmlns='http://www.w3.org/2000/svg' />",
+        interruptible=True,
+    )
+
+    assert plot_instance.keyboard_pause is True
+    assert plot_instance.errors.keyboard is False
+    assert plot_instance.plot_run_outputs == [True]
+    assert execution.interrupted is True
+    assert execution.interruption_reason == "keyboard_interrupt"
+    assert execution.progress_svg == "<svg data-paused='true' />"
+    assert execution.details["error_code"] == 103
 
 
 def test_pyaxidraw_client_prefers_explicit_config_path(tmp_path):
@@ -359,6 +392,36 @@ class FakeClient:
         )
 
 
+class BlockingPlotRunner:
+    def __init__(self) -> None:
+        self.started = Event()
+        self.release = Event()
+        self.stop_requests = 0
+
+    def run(self, svg_text: str):
+        self.started.set()
+        self.release.wait(timeout=1)
+        return AxiDrawPlotExecution(
+            port="usb-a",
+            api_surface="documented_pyaxidraw",
+            plot_api_supported=True,
+            manual_api_supported=True,
+            config_source="vendor_default",
+            calibration_source="vendor_default",
+            native_res_factor=1016.0,
+            motion_scale=1.0,
+            details={"error_code": 103},
+            interrupted=True,
+            interruption_reason="keyboard_interrupt",
+            progress_svg=svg_text,
+        )
+
+    def request_stop(self) -> bool:
+        self.stop_requests += 1
+        self.release.set()
+        return True
+
+
 def test_axidraw_plotter_reports_status_and_maps_operations():
     plotter = AxiDrawPlotter(
         client=FakeClient(plot_api_supported=True, manual_api_supported=True),
@@ -396,6 +459,58 @@ def test_axidraw_plotter_reports_status_and_maps_operations():
     assert plot_result.document_id == "asset-1"
     assert plot_result.details["port"] == "usb-a"
     assert plotter.get_status().details["pen_tuning"] == {"pen_pos_up": 62, "pen_pos_down": 24}
+
+
+def test_axidraw_plotter_requests_stop_only_from_active_runner():
+    runner = BlockingPlotRunner()
+    plotter = AxiDrawPlotter(
+        client=FakeClient(plot_api_supported=True, manual_api_supported=True),
+        port="usb-a",
+        plot_runner=runner,
+    )
+    plotter.connect()
+    result_holder = {}
+
+    worker = Thread(
+        target=lambda: result_holder.update(
+            result=plotter.plot(
+                PlotDocument(
+                    asset_id="asset-1",
+                    name="Interruptible asset",
+                    svg_text="<svg xmlns='http://www.w3.org/2000/svg' />",
+                    width=10,
+                    height=10,
+                    prepared_width_mm=10.0,
+                    prepared_height_mm=10.0,
+                )
+            )
+        )
+    )
+    worker.start()
+    assert runner.started.wait(timeout=1)
+
+    assert plotter.request_stop() is True
+    worker.join(timeout=1)
+
+    assert runner.stop_requests == 1
+    assert result_holder["result"].interrupted is True
+    assert plotter.get_status().details["last_action_status"] == "cancelled"
+
+
+def test_process_plot_runner_signals_only_its_active_worker():
+    signalled = []
+    runner = AxiDrawProcessPlotRunner(
+        settings_provider=dict,
+        signal_sender=lambda pid, sig: signalled.append((pid, sig)),
+    )
+    runner._active_process = SimpleNamespace(
+        pid=4242,
+        is_alive=lambda: True,
+    )
+
+    assert runner.request_stop() is True
+    assert runner.request_stop() is True
+    assert signalled == [(4242, signal.SIGINT)]
 
 
 def test_axidraw_plotter_applies_persisted_calibration_to_client():

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ Hardware integration stays behind backend interfaces.
 - mock adapters remain available for development and tests
 - the AxiDraw adapter path lives behind the same backend-owned interface
 - undocumented or version-sensitive AxiDraw behavior should stay isolated in the wrapper/client layer rather than leaking into services or routes
+- real Plot-context execution runs in a dedicated process so documented keyboard-pause signal handling never installs inside the API server's worker thread
 
 ## Persistence Under `artifacts/`
 
@@ -119,6 +120,14 @@ After a registered observation completes, a single backend coordinator sends the
 Authorization remains attended. The creative client posts a heartbeat; if it is absent for 30 seconds, the current physical pass and its capture may finish, but another pass cannot begin. Stop-after-pass uses the same boundary. Backend startup converts persisted active V2 sessions to a paused recovery state, so process restart never restarts hardware automatically. Resume refreshes attendance, clears the soft-stop request, and re-enters coordination only after normal readiness checks.
 
 A plot run may retake its capture after plotting completed. The run retains an ordered `capture_attempts` history, keeps `capture` as the selected current attempt for compatibility, and sends only that current attempt through registration and normalization. Retake never invokes the plotter. Earlier capture files and metadata remain immutable evidence.
+
+### Emergency plot interruption
+
+The generic plotter adapter exposes a narrow active-plot stop request. The real AxiDraw implementation launches [documented Plot context](https://axidraw.com/doc/py_api/) in a dedicated spawned process, enables `keyboard_pause`, and requests SVG output from `plot_run(True)`. Emergency stop sends SIGINT only to that child. AxiDraw finishes the current line segment and returns error code 103 plus an updated SVG when its documented pause path succeeds.
+
+The executor stores returned progress as a diagnostic `progress_artifact`, transitions the plot stage and run through `stopping` to terminal `cancelled`, and never begins capture or another drawing-session assessment. The creative session pauses with an inspection instruction. Partial-plot resume is intentionally unsupported; the progress SVG is evidence rather than an executable recovery path. Error code 102 from the physical Pause button receives the same terminal treatment.
+
+Mock plotting uses a deterministic stop event but preserves the same result contract. Compatibility-only and unavailable adapters do not grow undocumented interruption behavior. The physical AxiDraw Pause control remains the fallback if process signalling cannot be confirmed.
 
 Existing session JSON without `session_version` parses as V1. Its bounded two-to-ten-pass, request-advice, and approve-next-iteration behavior remains available through the legacy endpoints and is not migrated or proactively rewritten.
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -167,4 +167,12 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Added capture-only retry after a completed plot and preserved ordered immutable capture attempts while keeping the existing current-capture contract
 - Kept manual registration, active-run exclusion, normal PlotRuns, mock adapters, and backend-only hardware ownership as the safety boundaries
 
+## Interruptible AxiDraw Plot Worker Slice
+
+- Moved real AxiDraw Plot-context execution into a dedicated spawned process so documented keyboard-pause signal handling is isolated from API server threads
+- Added a generic active-plot stop capability, process-scoped SIGINT, AxiDraw output-SVG collection, and explicit error-code interpretation for keyboard and physical pauses
+- Added stopping and terminal cancelled run states, persisted paused-progress SVG evidence, and guaranteed that an interrupted plot cannot continue to capture or agent assessment
+- Added deterministic mock interruption plus fake-client and process-runner coverage without adding partial-plot resume or undocumented AxiDraw calls
+- Kept the physical Pause button as the hardware fallback and documented that software pause occurs only after the current line segment
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Run real AxiDraw plots in a dedicated process with the documented keyboard-pause path enabled.
- Route emergency stop to SIGINT only that active worker, preserve returned progress SVG data, and terminate the plot run as cancelled without capture or another agent pass.
- Extend generic and mock plotter contracts with deterministic interruption behavior and document the operational semantics.

Closes #50
Parent: #47

## Checks

- [x] `make api-test` — 143 passed
- [x] `make api-lint` — passed
- [x] `make web-test` — 38 passed
- [x] `make web-lint` — passed
- [x] `make web-build` — passed
- [x] `git diff --check` — passed
- [x] CI — API and web jobs passed
- [x] Safe connected-AxiDraw acceptance — firmware 2.7.0 returned keyboard-interrupt code 103 and a progress SVG after 128.156 mm of path travel
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why

## Hardware acceptance

- Used an isolated temporary artifact workspace with mock camera/advisor and the real AxiDraw adapter.
- Set pen up/down to 60/60 so the carriage moved while the pen remained physically raised.
- The run transitioned `plotting → stopping → cancelled` and retained the 529-byte progress SVG.
- The final plotter state was connected, idle, and `last_action_status=cancelled`.
- Capture and observation stayed null, the session paused with one pass, and no subsequent pass began.
- Full evidence is recorded on #50.

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, with deterministic interruption coverage

## Risk Review

- [x] Hardware semantics are explicit: emergency stop pauses after the current path segment, not as an instant power cut
- [x] Version-sensitive behavior uses the documented `keyboard_pause`, `errors.keyboard = False`, and `plot_run(output=True)` interface
- [x] Architecture and history documentation are updated
- [x] This PR is a narrow, reviewable slice
