### PR TITLE
Replace operator dashboard with creative studio

### DIFF
--- a/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
@@ -196,9 +196,24 @@ class DrawingSessionService:
             for stored in self._store.list():
                 session = self._sync(stored)
                 preview_url = None
-                if session.current_proposal is not None:
+                if session.iterations:
+                    latest_run = self._plot_workflow.get_run(
+                        session.iterations[-1].run_id
+                    )
+                    capture = (
+                        latest_run.observed_result.capture
+                        if latest_run.observed_result is not None
+                        else latest_run.capture
+                    )
+                    if capture is not None:
+                        preview_url = (
+                            capture.normalized.rectified_grayscale_url
+                            if capture.normalized is not None
+                            else capture.public_url
+                        )
+                if preview_url is None and session.current_proposal is not None:
                     preview_url = session.current_proposal.asset.public_url
-                elif session.iterations:
+                elif preview_url is None and session.iterations:
                     preview_url = session.iterations[-1].asset.public_url
                 summaries.append(
                     DrawingSessionSummary(

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1037,10 +1037,12 @@ def test_drawing_session_runs_observes_proposes_and_approves_next_layer(tmp_path
         assert proposal["asset"]["id"] == approved["iterations"][1]["asset"]["id"]
         wait_for_run_completion(client, second_run_id)
         completed = client.get(f"/api/drawing-sessions/{created['id']}").json()
+        gallery_summary = client.get("/api/drawing-sessions").json()["sessions"][0]
 
     assert completed["status"] == "completed"
     assert len(completed["iterations"]) == 2
     assert completed["iterations"][0]["next_proposal"]["approved_run_id"] == second_run_id
+    assert gallery_summary["preview_url"].endswith("-rectified-grayscale.png")
 
     with create_test_client(
         tmp_path,

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,5 +1,90 @@
-import { HardwareDashboard } from "../features/hardware/HardwareDashboard";
+import { useEffect, useState, type MouseEvent, type ReactNode } from "react";
+
+import { ControlsPage } from "../features/studio/ControlsPage";
+import { CreativeHome } from "../features/studio/CreativeHome";
+import { GalleryPage } from "../features/studio/GalleryPage";
+import { SessionStudio } from "../features/studio/SessionStudio";
+
+function normalizePath(pathname: string) {
+  const normalized = pathname.replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function usePathname() {
+  const [pathname, setPathname] = useState(() => normalizePath(window.location.pathname));
+
+  useEffect(() => {
+    const handleNavigation = () => setPathname(normalizePath(window.location.pathname));
+    window.addEventListener("popstate", handleNavigation);
+    return () => window.removeEventListener("popstate", handleNavigation);
+  }, []);
+
+  function navigate(path: string) {
+    const next = normalizePath(path);
+    if (next === pathname) return;
+    window.history.pushState({}, "", next);
+    setPathname(next);
+    window.scrollTo({ top: 0 });
+  }
+
+  return { pathname, navigate };
+}
+
+function AppLink({
+  href,
+  navigate,
+  children,
+  className,
+}: {
+  href: string;
+  navigate: (path: string) => void;
+  children: ReactNode;
+  className?: string;
+}) {
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) return;
+    event.preventDefault();
+    navigate(href);
+  }
+
+  return <a href={href} className={className} onClick={handleClick}>{children}</a>;
+}
 
 export function App() {
-  return <HardwareDashboard />;
+  const { pathname, navigate } = usePathname();
+  const sessionMatch = pathname.match(/^\/sessions\/([^/]+)$/);
+
+  return (
+    <div className="creative-app-shell">
+      <header className="creative-nav">
+        <AppLink href="/" navigate={navigate} className="creative-brand">
+          <span className="creative-brand-mark" aria-hidden="true">✦</span>
+          <span>LearnToDraw</span>
+        </AppLink>
+        <nav aria-label="Main navigation">
+          <AppLink href="/" navigate={navigate} className={pathname === "/" ? "active" : undefined}>Create</AppLink>
+          <AppLink href="/gallery" navigate={navigate} className={pathname === "/gallery" ? "active" : undefined}>Gallery</AppLink>
+          <AppLink href="/controls" navigate={navigate} className={pathname === "/controls" ? "active" : undefined}>Controls</AppLink>
+        </nav>
+      </header>
+
+      {pathname === "/" ? <CreativeHome navigate={navigate} /> : null}
+      {pathname === "/gallery" ? <GalleryPage /> : null}
+      {pathname === "/controls" ? <ControlsPage /> : null}
+      {sessionMatch ? <SessionStudio sessionId={decodeURIComponent(sessionMatch[1])} /> : null}
+      {!sessionMatch && !["/", "/gallery", "/controls"].includes(pathname) ? (
+        <main className="studio-loading">
+          <h1>That page does not exist.</h1>
+          <AppLink href="/" navigate={navigate} className="button-primary">Return home</AppLink>
+        </main>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -2679,3 +2679,980 @@ button {
     gap: 4px;
   }
 }
+
+/* Agentic creative studio */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.creative-app-shell {
+  min-height: 100vh;
+}
+
+.creative-nav {
+  position: relative;
+  z-index: 20;
+  width: min(100% - 40px, 1560px);
+  margin: 0 auto;
+  padding: 22px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.creative-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #f5efe6;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 760;
+  letter-spacing: -0.02em;
+}
+
+.creative-brand-mark {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #1b1814;
+  background: var(--accent);
+}
+
+.creative-nav nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.creative-nav nav a {
+  padding: 9px 13px;
+  border-radius: 999px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.creative-nav nav a:hover,
+.creative-nav nav a:focus-visible,
+.creative-nav nav a.active {
+  color: #f5efe6;
+  background: rgba(255, 248, 238, 0.08);
+}
+
+.creative-home {
+  min-height: calc(100vh - 76px);
+  width: min(100% - 40px, 1460px);
+  margin: 0 auto;
+  padding: clamp(56px, 10vh, 120px) 0 52px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 48px;
+  align-items: start;
+}
+
+.creative-home-hero {
+  width: min(100%, 980px);
+}
+
+.creative-home-kicker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: #c8bdad;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.studio-orbit {
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+  border-radius: 50%;
+  border: 1px solid var(--accent);
+  box-shadow: inset 0 0 0 5px rgba(208, 161, 95, 0.15);
+}
+
+.creative-home h1 {
+  max-width: 900px;
+  margin: 26px 0 20px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(4rem, 9vw, 8.6rem);
+  font-weight: 400;
+  line-height: 0.88;
+  letter-spacing: -0.07em;
+  color: #f3ede3;
+}
+
+.creative-home-lede {
+  max-width: 650px;
+  margin: 0 0 32px;
+  color: var(--text-muted);
+  font-size: clamp(1rem, 2vw, 1.3rem);
+}
+
+.creative-prompt {
+  max-width: 920px;
+  border: 1px solid rgba(218, 197, 166, 0.28);
+  border-radius: 28px;
+  background: rgba(42, 39, 34, 0.9);
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}
+
+.creative-prompt textarea {
+  width: 100%;
+  min-height: 150px;
+  padding: 26px 28px 16px;
+  resize: vertical;
+  border: 0;
+  outline: 0;
+  color: #f7f1e8;
+  background: transparent;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(1.35rem, 2.4vw, 2.15rem);
+  line-height: 1.25;
+}
+
+.creative-prompt textarea::placeholder {
+  color: rgba(211, 201, 188, 0.48);
+}
+
+.creative-prompt:focus-within {
+  border-color: rgba(223, 173, 103, 0.78);
+  box-shadow: 0 0 0 4px rgba(208, 161, 95, 0.11), 0 32px 90px rgba(0, 0, 0, 0.32);
+}
+
+.creative-prompt-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 16px 16px 28px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.86rem;
+}
+
+.creative-submit {
+  min-width: 190px;
+  border-radius: 999px;
+  padding: 14px 22px;
+}
+
+.creative-home-blocker,
+.studio-attention-banner {
+  margin-top: 18px;
+  padding: 15px 17px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
+  border: 1px solid rgba(238, 154, 95, 0.3);
+  border-radius: 16px;
+  background: rgba(104, 56, 28, 0.2);
+  color: #f3d2b8;
+}
+
+.creative-home-blocker a {
+  margin-left: auto;
+  color: #ffd8aa;
+}
+
+.creative-home-links {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 24px;
+}
+
+.creative-home-links a {
+  color: #c8bdad;
+  text-underline-offset: 4px;
+}
+
+.creative-readiness {
+  min-width: 230px;
+  display: grid;
+  gap: 12px;
+  justify-items: end;
+  color: var(--text-muted);
+  font-size: 0.86rem;
+}
+
+.creative-readiness > div {
+  display: flex;
+  gap: 8px;
+}
+
+.studio-session-shell,
+.gallery-page,
+.controls-page {
+  width: min(100% - 40px, 1560px);
+  margin: 0 auto;
+  padding: 30px 0 100px;
+}
+
+.studio-session-heading,
+.gallery-heading,
+.controls-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 28px;
+  margin-bottom: 24px;
+}
+
+.studio-session-heading h1,
+.gallery-heading h1,
+.controls-heading h1 {
+  max-width: 980px;
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2.2rem, 4vw, 4.4rem);
+  font-weight: 400;
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+}
+
+.studio-session-meta {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.studio-session-meta strong {
+  color: #f1e9de;
+}
+
+.studio-session-readiness {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.studio-attention-banner {
+  margin: 0 0 18px;
+}
+
+.studio-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(310px, 390px);
+  gap: 20px;
+  align-items: start;
+}
+
+.studio-artwork-column {
+  min-width: 0;
+  display: grid;
+  gap: 18px;
+}
+
+.studio-canvas-panel,
+.studio-conversation,
+.studio-plan-card,
+.studio-recovery,
+.studio-complete,
+.gallery-empty,
+.controls-section {
+  border: 1px solid var(--border);
+  border-radius: 26px;
+  background: rgba(34, 32, 29, 0.88);
+  box-shadow: var(--shadow);
+}
+
+.studio-canvas-panel {
+  min-height: min(74vh, 880px);
+  padding: 18px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 14px;
+}
+
+.studio-canvas-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.studio-canvas-toolbar h2,
+.studio-conversation h2,
+.studio-plan-card h2,
+.studio-recovery h2,
+.studio-complete h2 {
+  margin: 0;
+  font-size: clamp(1.3rem, 2vw, 1.9rem);
+  line-height: 1.06;
+  letter-spacing: -0.035em;
+}
+
+.studio-canvas-modes {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(10, 10, 9, 0.36);
+}
+
+.studio-canvas-modes button {
+  border: 0;
+  border-radius: 999px;
+  padding: 7px 11px;
+  color: var(--text-muted);
+  background: transparent;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.studio-canvas-modes button[aria-pressed="true"] {
+  color: #211d18;
+  background: #eee7dc;
+}
+
+.studio-canvas-modes button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.studio-paper-stage {
+  min-height: 480px;
+  padding: clamp(14px, 3vw, 32px);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(213, 174, 116, 0.08), transparent 35%),
+    #121110;
+}
+
+.studio-paper {
+  position: relative;
+  height: min(64vh, 760px);
+  max-width: 100%;
+  overflow: hidden;
+  background: #f7f5ef;
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.42), inset 0 0 0 1px rgba(60, 48, 34, 0.1);
+}
+
+.studio-paper > img,
+.studio-intended-stack,
+.studio-intended-stack img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.studio-paper > img,
+.studio-intended-stack img {
+  display: block;
+  object-fit: contain;
+}
+
+.studio-intended-stack-overlay {
+  mix-blend-mode: multiply;
+}
+
+.studio-paper-empty {
+  position: absolute;
+  inset: 0;
+  padding: 24px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 9px;
+  text-align: center;
+  color: #786f64;
+}
+
+.studio-paper-empty strong {
+  color: #302b25;
+}
+
+.studio-thinking-mark {
+  width: 36px;
+  height: 36px;
+  display: inline-block;
+  border-radius: 50%;
+  border: 2px solid rgba(208, 161, 95, 0.25);
+  border-top-color: var(--accent);
+  animation: studio-spin 1.1s linear infinite;
+}
+
+@keyframes studio-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .studio-thinking-mark { animation: none; }
+}
+
+.studio-opacity-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.studio-opacity-control input {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.studio-canvas-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.studio-registration-wrap {
+  min-height: 520px;
+  padding: 12px;
+  overflow: auto;
+  border-radius: 20px;
+  background: #121110;
+}
+
+.studio-conversation {
+  position: sticky;
+  top: 18px;
+  height: min(78vh, 900px);
+  min-height: 620px;
+  padding: 18px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 14px;
+}
+
+.studio-conversation > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.studio-queued-count {
+  padding: 6px 9px;
+  border: 1px solid rgba(208, 161, 95, 0.28);
+  border-radius: 999px;
+  color: #e7c493;
+  background: rgba(208, 161, 95, 0.1);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.studio-event-log {
+  margin: 0;
+  padding: 4px 4px 4px 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  list-style: none;
+}
+
+.studio-event {
+  max-width: 94%;
+  padding: 12px 13px;
+  border-radius: 16px 16px 16px 4px;
+  background: rgba(255, 248, 238, 0.055);
+  border: 1px solid var(--border);
+}
+
+.studio-event-user {
+  align-self: flex-end;
+  border-radius: 16px 16px 4px 16px;
+  background: rgba(208, 161, 95, 0.12);
+  border-color: rgba(208, 161, 95, 0.22);
+}
+
+.studio-event-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.studio-event-meta strong {
+  color: #eee6da;
+}
+
+.studio-event p {
+  margin: 6px 0 0;
+  color: #d8d0c4;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.studio-event-end {
+  width: 1px;
+  height: 1px;
+}
+
+.studio-message-form {
+  display: grid;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.studio-message-form label {
+  color: #e9e1d5;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.studio-message-form textarea {
+  width: 100%;
+  min-height: 86px;
+  padding: 11px 12px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  outline: 0;
+  color: #f2ece2;
+  background: rgba(10, 10, 9, 0.48);
+}
+
+.studio-message-form textarea:focus {
+  border-color: rgba(208, 161, 95, 0.6);
+  box-shadow: 0 0 0 3px rgba(208, 161, 95, 0.1);
+}
+
+.studio-message-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.studio-plan-card,
+.studio-recovery,
+.studio-complete {
+  padding: 22px;
+}
+
+.studio-plan-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.42fr);
+  gap: 28px;
+}
+
+.studio-plan-card-thinking {
+  grid-template-columns: 1fr;
+}
+
+.studio-plan-card p,
+.studio-recovery p,
+.studio-complete p {
+  margin: 9px 0 0;
+  color: var(--text-muted);
+}
+
+.studio-plan-card h2:focus-visible,
+.studio-recovery h2:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 5px;
+}
+
+.studio-plan-details {
+  margin: 22px 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.studio-plan-details div {
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.studio-plan-details dt {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.studio-plan-details dd {
+  margin: 6px 0 0;
+  color: #e7dfd3;
+}
+
+.studio-approval {
+  padding: 16px;
+  display: grid;
+  align-content: center;
+  gap: 16px;
+  border-radius: 18px;
+  background: rgba(208, 161, 95, 0.08);
+  border: 1px solid rgba(208, 161, 95, 0.24);
+}
+
+.studio-approval p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.studio-recovery,
+.studio-complete {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.studio-recovery-actions,
+.studio-complete-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.studio-stop-dock {
+  position: fixed;
+  z-index: 30;
+  left: 50%;
+  bottom: 18px;
+  width: min(calc(100% - 36px), 960px);
+  transform: translateX(-50%);
+  padding: 12px 12px 12px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(224, 207, 181, 0.22);
+  border-radius: 20px;
+  background: rgba(27, 25, 22, 0.96);
+  box-shadow: 0 18px 65px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(20px);
+}
+
+.studio-stop-dock > div {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  line-height: 1.3;
+}
+
+.studio-stop-dock span {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+}
+
+.button-danger {
+  padding: 11px 16px;
+  border: 1px solid rgba(255, 151, 128, 0.42);
+  border-radius: 14px;
+  color: #ffe1d8;
+  background: rgba(154, 54, 40, 0.28);
+  font-weight: 700;
+}
+
+.button-danger:hover:not(:disabled) {
+  background: rgba(181, 62, 44, 0.42);
+}
+
+.button-danger:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.studio-confirm-modal {
+  position: fixed;
+  z-index: 120;
+  inset: 0;
+  padding: 20px;
+  display: grid;
+  place-items: center;
+  background: rgba(6, 5, 4, 0.76);
+  backdrop-filter: blur(10px);
+}
+
+.studio-confirm-card {
+  width: min(100%, 560px);
+  padding: 28px;
+  border: 1px solid rgba(239, 157, 128, 0.32);
+  border-radius: 24px;
+  background: #25211d;
+  box-shadow: 0 28px 100px rgba(0, 0, 0, 0.6);
+}
+
+.studio-confirm-card h2 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.studio-confirm-card p:not(.eyebrow) {
+  color: var(--text-muted);
+}
+
+.studio-confirm-card > div {
+  margin-top: 22px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.studio-loading {
+  min-height: 70vh;
+  padding: 60px 20px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.studio-loading h1 {
+  margin: 0;
+}
+
+.gallery-heading p,
+.controls-heading p,
+.controls-section-heading p {
+  color: var(--text-muted);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.gallery-card {
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 260px auto;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  color: inherit;
+  text-decoration: none;
+  background: rgba(34, 32, 29, 0.88);
+  transition: transform 150ms ease, border-color 150ms ease;
+}
+
+.gallery-card:hover,
+.gallery-card:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(208, 161, 95, 0.48);
+}
+
+.gallery-card-preview {
+  padding: 22px;
+  display: grid;
+  place-items: center;
+  background: #121110;
+}
+
+.gallery-card-preview img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: white;
+}
+
+.gallery-card-copy {
+  padding: 18px;
+}
+
+.gallery-card-copy h2 {
+  margin: 10px 0 8px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.45rem;
+  font-weight: 400;
+  line-height: 1.08;
+}
+
+.gallery-card-copy p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.gallery-card-status {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: #d9b986;
+  font-size: 0.73rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.gallery-empty {
+  padding: 42px;
+  text-align: center;
+}
+
+.gallery-empty h2 {
+  margin-top: 0;
+}
+
+.gallery-empty p {
+  color: var(--text-muted);
+}
+
+.controls-heading .readiness-bar {
+  justify-content: flex-end;
+}
+
+.controls-section {
+  padding: 20px;
+  margin-bottom: 22px;
+}
+
+.controls-section-heading {
+  margin-bottom: 18px;
+}
+
+.controls-section-heading h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2.1rem);
+  letter-spacing: -0.035em;
+}
+
+.controls-section-heading p:not(.eyebrow) {
+  margin: 8px 0 0;
+}
+
+.controls-section > .machine-setup-layout {
+  grid-template-columns: minmax(0, 1.1fr) minmax(340px, 0.7fr);
+}
+
+@media (max-width: 1100px) {
+  .creative-home,
+  .studio-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .creative-readiness {
+    order: -1;
+    justify-items: start;
+  }
+
+  .studio-conversation {
+    position: static;
+    height: 620px;
+  }
+
+  .studio-plan-card,
+  .controls-section > .machine-setup-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .creative-nav,
+  .creative-home,
+  .studio-session-shell,
+  .gallery-page,
+  .controls-page {
+    width: min(100% - 24px, 1560px);
+  }
+
+  .creative-nav {
+    align-items: flex-start;
+  }
+
+  .creative-brand span:last-child {
+    display: none;
+  }
+
+  .creative-home {
+    padding-top: 42px;
+    gap: 24px;
+  }
+
+  .creative-home h1 {
+    font-size: clamp(3.4rem, 18vw, 5.8rem);
+  }
+
+  .creative-prompt-footer,
+  .studio-session-heading,
+  .gallery-heading,
+  .controls-heading,
+  .studio-canvas-toolbar,
+  .studio-recovery,
+  .studio-complete,
+  .studio-stop-dock {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .creative-prompt-footer {
+    padding: 14px;
+  }
+
+  .studio-session-readiness,
+  .studio-canvas-modes,
+  .studio-recovery-actions,
+  .studio-complete-actions,
+  .controls-heading .readiness-bar {
+    justify-content: flex-start;
+  }
+
+  .studio-paper-stage {
+    min-height: 360px;
+    padding: 10px;
+  }
+
+  .studio-paper {
+    width: 100%;
+    height: auto;
+    max-height: 64vh;
+  }
+
+  .studio-plan-details {
+    grid-template-columns: 1fr;
+  }
+
+  .studio-conversation {
+    min-height: 560px;
+    height: 70vh;
+  }
+
+  .studio-stop-dock {
+    width: calc(100% - 24px);
+    padding: 14px;
+  }
+
+  .studio-stop-dock > div {
+    margin-bottom: 4px;
+  }
+
+  .studio-confirm-card > div {
+    display: grid;
+  }
+}

--- a/apps/web/src/features/plot-workflow/DrawingSessionPanel.tsx
+++ b/apps/web/src/features/plot-workflow/DrawingSessionPanel.tsx
@@ -10,10 +10,14 @@ interface DrawingSessionPanelProps {
 }
 
 const STATUS_LABELS = {
+  planning: "Planning",
+  awaiting_approval: "Ready for approval",
   running: "Plotting or capturing",
   awaiting_capture_review: "Registration needs review",
   observed: "Observation ready",
   proposal_ready: "Next layer ready",
+  paused: "Paused",
+  stopping: "Stopping safely",
   completed: "Iteration limit reached",
   failed: "Session stopped",
 };
@@ -110,7 +114,8 @@ export function DrawingSessionPanel({
             <div>
               <span className="summary-label">Progress</span>
               <strong>
-                Pass {currentIteration.number} of {session.iteration_limit}
+                Pass {currentIteration.number}
+                {session.iteration_limit ? ` of ${session.iteration_limit}` : ""}
               </strong>
             </div>
             <div>

--- a/apps/web/src/features/plot-workflow/PlotWorkflowPanel.tsx
+++ b/apps/web/src/features/plot-workflow/PlotWorkflowPanel.tsx
@@ -132,6 +132,12 @@ function getStatusLabel(status: PlotRun["status"]) {
   if (status === "plotting") {
     return "Plotting";
   }
+  if (status === "stopping") {
+    return "Stopping";
+  }
+  if (status === "cancelled") {
+    return "Cancelled";
+  }
   return "Preparing";
 }
 

--- a/apps/web/src/features/plot-workflow/plotWorkflowFormatters.ts
+++ b/apps/web/src/features/plot-workflow/plotWorkflowFormatters.ts
@@ -40,6 +40,9 @@ export function getStageLabel(run: PlotRun | null) {
   if (run.status === "plotting") {
     return "Plotting";
   }
+  if (run.status === "stopping") {
+    return "Stopping";
+  }
   if (run.status === "capturing") {
     return "Capturing";
   }
@@ -52,6 +55,9 @@ export function getStageLabel(run: PlotRun | null) {
   if (run.status === "failed") {
     return "Failed";
   }
+  if (run.status === "cancelled") {
+    return "Cancelled";
+  }
   return "Preparing";
 }
 
@@ -63,12 +69,13 @@ export function getRunStatusTone(status: PlotRun["status"] | "idle") {
   if (
     status === "pending" ||
     status === "plotting" ||
+    status === "stopping" ||
     status === "capturing" ||
     status === "awaiting_capture_review"
   ) {
     return "warn";
   }
-  if (status === "failed") {
+  if (status === "failed" || status === "cancelled") {
     return "warn";
   }
   return "ok";
@@ -151,7 +158,7 @@ export function getStepSummaryItems(run: PlotRun | null): RunStepSummaryItem[] {
     label:
       plotState.status === "completed"
         ? "Plotted ✓"
-        : plotState.status === "failed"
+        : plotState.status === "failed" || plotState.status === "cancelled"
           ? "Plot !"
           : plotState.status === "in_progress"
             ? "Plotting…"
@@ -159,7 +166,7 @@ export function getStepSummaryItems(run: PlotRun | null): RunStepSummaryItem[] {
     tone:
       plotState.status === "completed"
         ? "ok"
-        : plotState.status === "failed"
+        : plotState.status === "failed" || plotState.status === "cancelled"
           ? "error"
           : plotState.status === "in_progress"
             ? "warn"
@@ -241,6 +248,9 @@ export function getStepSummaryNote(run: PlotRun | null) {
   }
   if (run.status === "completed" && run.capture_mode === "skip") {
     return "Capture skipped for this run.";
+  }
+  if (run.status === "cancelled") {
+    return run.stage_states.plot?.message ?? "The plot was cancelled before capture.";
   }
   const failedStage = Object.values(run.stage_states).find((stage) => stage.status === "failed");
   if (failedStage?.message) {

--- a/apps/web/src/features/plot-workflow/usePlotWorkflow.ts
+++ b/apps/web/src/features/plot-workflow/usePlotWorkflow.ts
@@ -21,7 +21,13 @@ type PlotAction = "upload" | "pattern" | "start" | "review" | null;
 type NoticeTone = "info" | "success" | "error";
 type SelectionSource = "manual" | "run-derived" | null;
 
-const ACTIVE_RUN_STATUSES = new Set(["pending", "plotting", "capturing", "awaiting_capture_review"]);
+const ACTIVE_RUN_STATUSES = new Set([
+  "pending",
+  "plotting",
+  "stopping",
+  "capturing",
+  "awaiting_capture_review",
+]);
 export const PLOT_WORKFLOW_ACTIVE_POLL_INTERVAL_MS = 1200;
 export const PLOT_WORKFLOW_IDLE_POLL_INTERVAL_MS = 3500;
 

--- a/apps/web/src/features/studio/ControlsPage.tsx
+++ b/apps/web/src/features/studio/ControlsPage.tsx
@@ -1,0 +1,90 @@
+import { StatusPill } from "../../components/StatusPill";
+import { HardwareStartupState } from "../hardware/HardwareStartupState";
+import { MachineSetupPanel } from "../hardware/MachineSetupPanel";
+import { useHardwareDashboard } from "../hardware/useHardwareDashboard";
+import { PlotWorkflowPanel } from "../plot-workflow/PlotWorkflowPanel";
+import { usePlotWorkflow } from "../plot-workflow/usePlotWorkflow";
+
+export function ControlsPage() {
+  const hardware = useHardwareDashboard();
+  const workflow = usePlotWorkflow();
+
+  if (hardware.loading && !hardware.hardwareStatus) {
+    return <HardwareStartupState title="Opening Controls." message="Checking local hardware." />;
+  }
+
+  if (!hardware.hardwareStatus) {
+    return (
+      <HardwareStartupState
+        title="Local backend unavailable."
+        message="Start the LearnToDraw API locally and retry."
+        error={hardware.error}
+      >
+        <button type="button" className="button-secondary" onClick={() => void hardware.refresh()}>
+          Retry
+        </button>
+      </HardwareStartupState>
+    );
+  }
+
+  return (
+    <main className="controls-page">
+      <header className="controls-heading">
+        <div>
+          <p className="eyebrow">Controls</p>
+          <h1>Machine setup and manual work</h1>
+          <p>Operational tools stay here, separate from the creative session.</p>
+        </div>
+        <div className="readiness-bar">
+          <StatusPill label="Plotter" value={hardware.hardwareStatus.plotter.available ? "ready" : "attention"} tone={hardware.hardwareStatus.plotter.available ? "ok" : "warn"} />
+          <StatusPill label="Camera" value={hardware.hardwareStatus.camera.available ? "ready" : "attention"} tone={hardware.hardwareStatus.camera.available ? "ok" : "warn"} />
+          <button type="button" className="button-secondary" onClick={() => void hardware.refresh()}>
+            {hardware.refreshing ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+      </header>
+
+      {hardware.error ? <div className="banner" role="alert">{hardware.error}</div> : null}
+
+      <section className="controls-section">
+        <div className="controls-section-heading">
+          <p className="eyebrow">Setup and diagnostics</p>
+          <h2>Paper, plotter, and camera</h2>
+        </div>
+        <MachineSetupPanel
+          hardwareStatus={hardware.hardwareStatus}
+          plotterCalibration={hardware.plotterCalibration}
+          plotterDevice={hardware.plotterDevice}
+          plotterWorkspace={hardware.plotterWorkspace}
+          latestCapture={hardware.latestCapture}
+          refreshing={hardware.refreshing}
+          actionName={hardware.actionName}
+          actionFeedback={hardware.actionFeedback}
+          walkHome={hardware.walkHome}
+          runPlotterTestAction={hardware.runPlotterTestAction}
+          runDiagnosticPattern={hardware.runDiagnosticPattern}
+          setPlotterCalibration={hardware.setPlotterCalibration}
+          setPlotterSafeBounds={hardware.setPlotterSafeBounds}
+          setPlotterWorkspace={hardware.setPlotterWorkspace}
+          setPlotterPenHeights={hardware.setPlotterPenHeights}
+          capture={hardware.capture}
+          setCameraDevice={hardware.setCameraDevice}
+        />
+      </section>
+
+      <section className="controls-section controls-manual-workflow">
+        <div className="controls-section-heading">
+          <p className="eyebrow">Manual plotting</p>
+          <h2>Upload, plot, capture, and inspect an SVG</h2>
+          <p>This retains the original explicit operator workflow, including manual registration.</p>
+        </div>
+        <PlotWorkflowPanel
+          controller={workflow}
+          hardwareStatus={hardware.hardwareStatus}
+          plotterWorkspace={hardware.plotterWorkspace}
+          latestCapture={hardware.latestCapture}
+        />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/features/studio/CreativeHome.tsx
+++ b/apps/web/src/features/studio/CreativeHome.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+import { StatusPill } from "../../components/StatusPill";
+import {
+  createDrawingSession,
+  fetchHardwareStatus,
+  fetchLatestDrawingSession,
+} from "../../lib/api";
+import type { DrawingSession } from "../../types/drawing";
+import type { HardwareStatus } from "../../types/hardware";
+
+const RESUMABLE_STATUSES = new Set([
+  "planning",
+  "awaiting_approval",
+  "running",
+  "awaiting_capture_review",
+  "paused",
+  "stopping",
+]);
+
+export function CreativeHome({ navigate }: { navigate: (path: string) => void }) {
+  const [intent, setIntent] = useState("");
+  const [hardware, setHardware] = useState<HardwareStatus | null>(null);
+  const [recentSession, setRecentSession] = useState<DrawingSession | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    Promise.all([fetchHardwareStatus(), fetchLatestDrawingSession()])
+      .then(([status, latest]) => {
+        if (!mountedRef.current) return;
+        setHardware(status);
+        setRecentSession(latest.session);
+        setError(null);
+        if (latest.session && RESUMABLE_STATUSES.has(latest.session.status)) {
+          navigate(`/sessions/${latest.session.id}`);
+        }
+      })
+      .catch((loadError) => {
+        if (!mountedRef.current) return;
+        setError(
+          loadError instanceof Error ? loadError.message : "The local studio is unavailable.",
+        );
+      })
+      .finally(() => {
+        if (mountedRef.current) setLoading(false);
+      });
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const nextIntent = intent.trim();
+    if (nextIntent.length < 3 || creating) return;
+    try {
+      setCreating(true);
+      setError(null);
+      const session = await createDrawingSession(nextIntent);
+      navigate(`/sessions/${session.id}`);
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : "Unable to start a drawing.");
+    } finally {
+      if (mountedRef.current) setCreating(false);
+    }
+  }
+
+  const plotterReady = hardware?.plotter.available === true;
+  const cameraReady = hardware?.camera.available === true;
+  const ready = plotterReady && cameraReady;
+
+  return (
+    <main className="creative-home">
+      <section className="creative-home-hero">
+        <div className="creative-home-kicker">
+          <span className="studio-orbit" aria-hidden="true" />
+          <span>A drawing studio that looks, responds, and keeps going</span>
+        </div>
+        <h1>What should we draw?</h1>
+        <p className="creative-home-lede">
+          Begin with an idea. The studio will propose a composition and show its first marks before
+          the plotter moves.
+        </p>
+
+        <form className="creative-prompt" onSubmit={submit}>
+          <label htmlFor="creative-intent" className="sr-only">Drawing idea</label>
+          <textarea
+            id="creative-intent"
+            value={intent}
+            rows={4}
+            autoFocus
+            maxLength={1000}
+            placeholder="A pelican riding a bicycle through a field of loose, joyful flowers…"
+            onChange={(event) => setIntent(event.target.value)}
+          />
+          <div className="creative-prompt-footer">
+            <span>The first step is only a plan and preview.</span>
+            <button
+              type="submit"
+              className="button-primary creative-submit"
+              disabled={
+                intent.trim().length < 3 || loading || creating || Boolean(error && !hardware)
+              }
+            >
+              {creating ? "Creating the plan…" : "Create a drawing"}
+            </button>
+          </div>
+        </form>
+
+        {error ? (
+          <div className="creative-home-blocker" role="alert">
+            <strong>{hardware ? "The studio needs attention." : "Local backend unavailable."}</strong>
+            <span>{error}</span>
+            <a href="/controls">Open Controls</a>
+          </div>
+        ) : null}
+
+        {!loading && hardware && !ready ? (
+          <div className="creative-home-blocker" role="status">
+            <strong>Hardware setup will be needed before approval.</strong>
+            <span>
+              {!plotterReady && !cameraReady
+                ? "The plotter and camera need attention."
+                : !plotterReady
+                  ? "The plotter needs attention."
+                  : "The camera needs attention."}
+            </span>
+            <a href="/controls">Open Controls</a>
+          </div>
+        ) : null}
+
+        <div className="creative-home-links">
+          {recentSession ? (
+            <a href={`/sessions/${recentSession.id}`}>Open recent drawing</a>
+          ) : null}
+          <a href="/gallery">Browse gallery</a>
+          <a href="/controls">Manual plotting and Controls</a>
+        </div>
+      </section>
+
+      <aside className="creative-readiness" aria-label="Studio readiness">
+        <span>{loading ? "Checking the studio…" : ready ? "Ready to create" : "Setup needed"}</span>
+        <div>
+          <StatusPill label="Plotter" value={plotterReady ? "ready" : "attention"} tone={plotterReady ? "ok" : "warn"} />
+          <StatusPill label="Camera" value={cameraReady ? "ready" : "attention"} tone={cameraReady ? "ok" : "warn"} />
+        </div>
+      </aside>
+    </main>
+  );
+}

--- a/apps/web/src/features/studio/GalleryPage.tsx
+++ b/apps/web/src/features/studio/GalleryPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+
+import { fetchDrawingSessions } from "../../lib/api";
+import type { DrawingSessionSummary } from "../../types/drawing";
+
+function formatDate(timestamp: string) {
+  return new Date(timestamp).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function GalleryPage() {
+  const [sessions, setSessions] = useState<DrawingSessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchDrawingSessions()
+      .then((response) => {
+        if (!active) return;
+        setSessions(response.sessions);
+        setError(null);
+      })
+      .catch((loadError) => {
+        if (!active) return;
+        setError(loadError instanceof Error ? loadError.message : "Unable to load the gallery.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <main className="gallery-page">
+      <header className="gallery-heading">
+        <div>
+          <p className="eyebrow">Gallery</p>
+          <h1>Drawings made through observation</h1>
+          <p>Return to an active session or revisit how a completed drawing developed.</p>
+        </div>
+        <a className="button-primary" href="/">Create a drawing</a>
+      </header>
+
+      {loading ? <p role="status">Loading sessions…</p> : null}
+      {error ? <div className="banner" role="alert">{error}</div> : null}
+      {!loading && !error && sessions.length === 0 ? (
+        <section className="gallery-empty">
+          <h2>The gallery is waiting for its first drawing.</h2>
+          <p>Start with an idea; planning happens before any machine movement.</p>
+          <a className="button-primary" href="/">Create a drawing</a>
+        </section>
+      ) : null}
+
+      <div className="gallery-grid">
+        {sessions.map((session) => (
+          <a key={session.id} className="gallery-card" href={`/sessions/${session.id}`}>
+            <div className="gallery-card-preview">
+              {session.preview_url ? (
+                <img src={session.preview_url} alt="" />
+              ) : (
+                <span aria-hidden="true" className="studio-orbit" />
+              )}
+            </div>
+            <div className="gallery-card-copy">
+              <div className="gallery-card-status">
+                <span>{session.status.replace(/_/g, " ")}</span>
+                {session.session_version === 1 ? <span>Legacy</span> : null}
+              </div>
+              <h2>{session.intent}</h2>
+              <p>
+                {session.pass_count === 1 ? "1 pass" : `${session.pass_count} passes`} · {formatDate(session.updated_at)}
+              </p>
+            </div>
+          </a>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/features/studio/SessionStudio.tsx
+++ b/apps/web/src/features/studio/SessionStudio.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useRef, useState } from "react";
+
+import { StatusPill } from "../../components/StatusPill";
+import type { DrawingSessionStatus } from "../../types/drawing";
+import { StudioCanvas } from "./StudioCanvas";
+import { StudioConversation } from "./StudioConversation";
+import { useStudioSession } from "./useStudioSession";
+
+const STATUS_LABELS: Record<DrawingSessionStatus, string> = {
+  planning: "Planning",
+  awaiting_approval: "Ready for approval",
+  running: "Drawing in progress",
+  awaiting_capture_review: "Registration needed",
+  observed: "Observation ready",
+  proposal_ready: "Proposal ready",
+  paused: "Paused for attention",
+  stopping: "Stopping safely",
+  completed: "Drawing complete",
+  failed: "Session failed",
+};
+
+function activeSession(status: DrawingSessionStatus) {
+  return ["running", "awaiting_capture_review", "stopping"].includes(status);
+}
+
+export function SessionStudio({ sessionId }: { sessionId: string }) {
+  const controller = useStudioSession(sessionId);
+  const [showEmergencyConfirm, setShowEmergencyConfirm] = useState(false);
+  const emergencyCancelRef = useRef<HTMLButtonElement | null>(null);
+  const planHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const recoveryHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const session = controller.session;
+  const currentRun = session?.current_run_id
+    ? controller.runs[session.current_run_id] ?? null
+    : null;
+  const completionEvents = session?.events.filter(
+    (event) => event.type === "session_completed",
+  ) ?? [];
+  const completionMessage = completionEvents[completionEvents.length - 1]?.message;
+
+  useEffect(() => {
+    if (showEmergencyConfirm) emergencyCancelRef.current?.focus();
+  }, [showEmergencyConfirm]);
+
+  useEffect(() => {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement) {
+      return;
+    }
+    if (session?.status === "awaiting_approval") planHeadingRef.current?.focus();
+    if (session?.status === "paused") recoveryHeadingRef.current?.focus();
+  }, [session?.status]);
+
+  if (controller.loading && !session) {
+    return (
+      <main className="studio-loading" aria-live="polite">
+        <span className="studio-thinking-mark" aria-hidden="true" />
+        <h1>Opening the studio…</h1>
+      </main>
+    );
+  }
+
+  if (!session) {
+    return (
+      <main className="studio-loading">
+        <h1>This drawing could not be opened.</h1>
+        <p>{controller.error ?? "The session may no longer be available."}</p>
+        <a className="button-secondary" href="/gallery">Return to gallery</a>
+      </main>
+    );
+  }
+
+  const plotterReady = controller.hardwareStatus?.plotter.available === true;
+  const cameraReady = controller.hardwareStatus?.camera.available === true;
+  const canRetryCapture = Boolean(
+    currentRun &&
+      currentRun.capture_mode === "auto" &&
+      currentRun.stage_states.plot?.status === "completed" &&
+      ["completed", "failed", "awaiting_capture_review"].includes(currentRun.status),
+  );
+  const canEmergencyStop = Boolean(
+    currentRun && ["pending", "plotting"].includes(currentRun.status),
+  );
+
+  return (
+    <main className="studio-session-shell">
+      <header className="studio-session-heading">
+        <div>
+          <p className="eyebrow">Drawing session</p>
+          <h1>{session.intent}</h1>
+          <div className="studio-session-meta">
+            <strong>{STATUS_LABELS[session.status]}</strong>
+            <span aria-hidden="true">·</span>
+            <span>{session.pass_count === 1 ? "1 pass" : `${session.pass_count} passes`}</span>
+            {session.session_version === 1 ? <span>Legacy session</span> : null}
+          </div>
+        </div>
+        <div className="studio-session-readiness" aria-label="Machine readiness">
+          <StatusPill
+            label="Studio"
+            value={controller.hardwareStatus ? "online" : "offline"}
+            tone={controller.hardwareStatus ? "ok" : "warn"}
+          />
+          <StatusPill label="Plotter" value={plotterReady ? "ready" : "attention"} tone={plotterReady ? "ok" : "warn"} />
+          <StatusPill label="Camera" value={cameraReady ? "ready" : "attention"} tone={cameraReady ? "ok" : "warn"} />
+        </div>
+      </header>
+
+      <div className="sr-only" role="status" aria-live="polite">
+        {STATUS_LABELS[session.status]}. Pass {session.pass_count}.
+      </div>
+
+      {controller.hardwareError ? (
+        <div className="studio-attention-banner" role="status">
+          <strong>Local studio connection needs attention.</strong>
+          <span>{controller.hardwareError} The current physical pass will finish safely.</span>
+        </div>
+      ) : null}
+
+      {session.advisor.available === false ? (
+        <div className="studio-attention-banner" role="status">
+          <strong>Creative advisor unavailable.</strong>
+          <span>{session.advisor.message}</span>
+        </div>
+      ) : null}
+
+      {controller.error && session.status !== "awaiting_capture_review" ? (
+        <div className="banner" role="alert">{controller.error}</div>
+      ) : null}
+
+      <div className="studio-workspace">
+        <div className="studio-artwork-column">
+          <StudioCanvas
+            session={session}
+            runs={controller.runs}
+            captureReview={controller.captureReview}
+            busy={controller.busyAction === "register"}
+            error={controller.captureReview ? controller.error : null}
+            onConfirmRegistration={controller.confirmRegistration}
+          />
+
+          {session.status === "planning" ? (
+            <section className="studio-plan-card studio-plan-card-thinking" aria-live="polite">
+              <p className="eyebrow">Planning</p>
+              <h2>Finding the first useful marks</h2>
+              <p>No hardware will move until a safe SVG preview is ready and you approve it.</p>
+            </section>
+          ) : null}
+
+          {session.status === "awaiting_approval" && session.plan ? (
+            <section className="studio-plan-card">
+              <div className="studio-plan-copy">
+                <div>
+                  <p className="eyebrow">Drawing plan</p>
+                  <h2 ref={planHeadingRef} tabIndex={-1}>{session.plan.summary}</h2>
+                </div>
+                <dl className="studio-plan-details">
+                  <div>
+                    <dt>Use of the paper</dt>
+                    <dd>{session.plan.paper_strategy}</dd>
+                  </div>
+                  <div>
+                    <dt>Finished when</dt>
+                    <dd>{session.plan.completion_intent}</dd>
+                  </div>
+                </dl>
+              </div>
+              <div className="studio-approval">
+                <p>
+                  Approving authorizes an attended sequence of plot, photograph, and agent-decision
+                  cycles. It may add more than one permanent layer without asking again.
+                </p>
+                <button
+                  type="button"
+                  className="button-primary"
+                  disabled={controller.busyAction !== null || !plotterReady || !cameraReady}
+                  onClick={() => void controller.approve()}
+                >
+                  {controller.busyAction === "approve" ? "Authorizing…" : "Approve and begin"}
+                </button>
+              </div>
+            </section>
+          ) : null}
+
+          {session.status === "paused" ? (
+            <section className="studio-recovery" aria-labelledby="recovery-title">
+              <div>
+                <p className="eyebrow">Needs attention</p>
+                <h2 id="recovery-title" ref={recoveryHeadingRef} tabIndex={-1}>
+                  The drawing is safely paused.
+                </h2>
+                <p>{session.requested_human_action ?? session.error ?? "Inspect the latest observation before continuing."}</p>
+              </div>
+              <div className="studio-recovery-actions">
+                {canRetryCapture && currentRun ? (
+                  <button
+                    type="button"
+                    className="button-secondary"
+                    disabled={controller.busyAction !== null}
+                    onClick={() => void controller.retryCapture(currentRun.id)}
+                  >
+                    {controller.busyAction === "retry-capture" ? "Retaking…" : "Retake photo only"}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="button-primary"
+                  disabled={controller.busyAction !== null || !plotterReady || !cameraReady}
+                  onClick={() => void controller.resume()}
+                >
+                  {controller.busyAction === "resume" ? "Rechecking…" : "Resume session"}
+                </button>
+              </div>
+            </section>
+          ) : null}
+
+          {session.status === "completed" ? (
+            <section className="studio-complete">
+              <p className="eyebrow">Complete</p>
+              <h2>The studio decided the drawing has arrived.</h2>
+              <p>{completionMessage}</p>
+              <div className="studio-complete-actions">
+                <a className="button-secondary" href="/gallery">View gallery</a>
+                <a className="button-primary" href="/">Create another drawing</a>
+              </div>
+            </section>
+          ) : null}
+
+          {session.status === "failed" ? (
+            <section className="studio-recovery" aria-labelledby="failed-title">
+              <div>
+                <p className="eyebrow">Session stopped</p>
+                <h2 id="failed-title">This drawing needs a fresh start.</h2>
+                <p>{session.error ?? "The session could not continue safely."}</p>
+              </div>
+              <a className="button-primary" href="/">Create another drawing</a>
+            </section>
+          ) : null}
+        </div>
+
+        <StudioConversation
+          session={session}
+          busyAction={controller.busyAction}
+          onSend={controller.sendMessage}
+        />
+      </div>
+
+      {session.session_version === 2 && session.authorization.approved_at && activeSession(session.status) ? (
+        <div className="studio-stop-dock" aria-label="Session controls">
+          <div>
+            <strong>{session.status === "stopping" ? "Finishing the current safe boundary…" : "The studio is authorized to continue."}</strong>
+            <span>Guidance waits for the next decision; stop requests never interrupt persistence.</span>
+          </div>
+          <button
+            type="button"
+            className="button-secondary"
+            disabled={controller.busyAction !== null || session.status === "stopping"}
+            onClick={() => void controller.stopAfterPass()}
+          >
+            {controller.busyAction === "stop-after-pass" ? "Stopping…" : "Stop after this pass"}
+          </button>
+          <button
+            type="button"
+            className="button-danger"
+            disabled={
+              controller.busyAction !== null ||
+              session.status === "stopping" ||
+              !canEmergencyStop
+            }
+            onClick={() => setShowEmergencyConfirm(true)}
+          >
+            Emergency stop
+          </button>
+        </div>
+      ) : null}
+
+      {showEmergencyConfirm ? (
+        <div className="studio-confirm-modal" role="alertdialog" aria-modal="true" aria-labelledby="emergency-title" aria-describedby="emergency-description">
+          <div className="studio-confirm-card">
+            <p className="eyebrow">Emergency intervention</p>
+            <h2 id="emergency-title">Pause the active plot?</h2>
+            <p id="emergency-description">
+              The AxiDraw pauses after its current path segment—not as an instant power cut. No
+              capture or later agent pass will begin, and resuming a partially plotted SVG is not
+              supported.
+            </p>
+            <div>
+              <button ref={emergencyCancelRef} type="button" className="button-secondary" onClick={() => setShowEmergencyConfirm(false)}>
+                Keep drawing
+              </button>
+              <button
+                type="button"
+                className="button-danger"
+                onClick={() => {
+                  setShowEmergencyConfirm(false);
+                  void controller.emergencyStop();
+                }}
+              >
+                Pause after current segment
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/src/features/studio/StudioCanvas.tsx
+++ b/apps/web/src/features/studio/StudioCanvas.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { CaptureReviewEditor } from "../plot-workflow/CaptureReviewEditor";
+import { isV2PageAlignedCapture } from "../plot-workflow/RunArtifactCompare";
+import type { DrawingSession } from "../../types/drawing";
+import type { NormalizationCorners } from "../../types/hardware";
+import type { PlotRun, PlotRunCaptureReviewPayload } from "../../types/plotting";
+
+type CanvasMode = "intended" | "observed" | "overlay" | "registration";
+
+interface StudioCanvasProps {
+  session: DrawingSession;
+  runs: Record<string, PlotRun>;
+  captureReview: PlotRunCaptureReviewPayload | null;
+  busy: boolean;
+  error: string | null;
+  onConfirmRegistration: (runId: string, corners: NormalizationCorners) => Promise<void>;
+}
+
+function readFinite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function pageAspectFor(run: PlotRun | null) {
+  const capture = run?.observed_result?.capture ?? run?.capture ?? null;
+  const frame = capture?.normalized?.metadata.frame;
+  if (frame && frame.page_width_mm > 0 && frame.page_height_mm > 0) {
+    return frame.page_width_mm / frame.page_height_mm;
+  }
+  const preparation = run?.plotter_run_details.preparation;
+  if (preparation && typeof preparation === "object") {
+    const width = readFinite((preparation as Record<string, unknown>).page_width_mm);
+    const height = readFinite((preparation as Record<string, unknown>).page_height_mm);
+    if (width && height && width > 0 && height > 0) return width / height;
+  }
+  return 210 / 297;
+}
+
+export function StudioCanvas({
+  session,
+  runs,
+  captureReview,
+  busy,
+  error,
+  onConfirmRegistration,
+}: StudioCanvasProps) {
+  const currentRun = session.current_run_id ? runs[session.current_run_id] ?? null : null;
+  const latestObservedRun = useMemo(
+    () =>
+      [...session.iterations]
+        .reverse()
+        .map((iteration) => runs[iteration.run_id])
+        .find((run) => Boolean(run?.observed_result?.capture ?? run?.capture)) ?? null,
+    [runs, session.iterations],
+  );
+  const observation =
+    latestObservedRun?.observed_result?.capture ?? latestObservedRun?.capture ?? null;
+  const observedUrl =
+    observation?.normalized?.rectified_grayscale_url ?? observation?.public_url ?? null;
+  const intendedUrls = session.iterations
+    .map((iteration) => runs[iteration.run_id]?.prepared_artifact?.public_url)
+    .filter((url): url is string => Boolean(url));
+  const proposalUrl =
+    intendedUrls.length === 0 ? session.current_proposal?.asset.public_url ?? null : null;
+  const overlayAvailable = Boolean(
+    observedUrl && intendedUrls.length > 0 && isV2PageAlignedCapture(observation),
+  );
+  const [mode, setMode] = useState<CanvasMode>(
+    session.status === "awaiting_capture_review" ? "registration" : "intended",
+  );
+  const [intendedOpacity, setIntendedOpacity] = useState(55);
+
+  useEffect(() => {
+    if (session.status === "awaiting_capture_review" && captureReview) {
+      setMode("registration");
+    } else if (observation) {
+      setMode("observed");
+    } else {
+      setMode("intended");
+    }
+  }, [captureReview?.capture.id, observation?.id, session.status]);
+
+  useEffect(() => {
+    if (captureReview) return;
+    if (mode === "overlay" && !overlayAvailable) setMode("observed");
+    if (mode === "registration") {
+      setMode(observation ? "observed" : "intended");
+    }
+  }, [captureReview, mode, observation, overlayAvailable]);
+
+  const aspect = pageAspectFor(currentRun ?? latestObservedRun);
+  const hasIntended = intendedUrls.length > 0 || Boolean(proposalUrl);
+
+  return (
+    <section className="studio-canvas-panel" aria-label="Drawing canvas">
+      <header className="studio-canvas-toolbar">
+        <div>
+          <p className="eyebrow">Paper</p>
+          <h2>
+            {mode === "observed"
+              ? "What the camera sees"
+              : mode === "overlay"
+                ? "Intended versus observed"
+                : mode === "registration"
+                  ? "Register this observation"
+                  : "What we intend to draw"}
+          </h2>
+        </div>
+        <div className="studio-canvas-modes" aria-label="Canvas view">
+          <button
+            type="button"
+            aria-pressed={mode === "intended"}
+            disabled={!hasIntended}
+            onClick={() => setMode("intended")}
+          >
+            Intended
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "observed"}
+            disabled={!observedUrl}
+            onClick={() => setMode("observed")}
+          >
+            Observed
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "overlay"}
+            disabled={!overlayAvailable}
+            onClick={() => setMode("overlay")}
+          >
+            Overlay
+          </button>
+          {captureReview ? (
+            <button
+              type="button"
+              aria-pressed={mode === "registration"}
+              onClick={() => setMode("registration")}
+            >
+              Register
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {mode === "registration" && captureReview ? (
+        <div className="studio-registration-wrap">
+          <CaptureReviewEditor
+            capture={captureReview.capture}
+            review={captureReview.review}
+            busy={busy}
+            error={error}
+            onConfirm={(corners) => onConfirmRegistration(captureReview.run_id, corners)}
+          />
+        </div>
+      ) : (
+        <div className="studio-paper-stage">
+          <div className="studio-paper" style={{ aspectRatio: `${aspect}` }}>
+            {mode === "observed" && observedUrl ? (
+              <img src={observedUrl} alt="Latest registered drawing observation" />
+            ) : null}
+
+            {mode === "overlay" && observedUrl ? (
+              <>
+                <img src={observedUrl} alt="Latest registered drawing observation" />
+                <div
+                  className="studio-intended-stack studio-intended-stack-overlay"
+                  style={{ opacity: intendedOpacity / 100 }}
+                >
+                  {intendedUrls.map((url, index) => (
+                    <img key={url} src={url} alt={`Intended drawing pass ${index + 1}`} />
+                  ))}
+                </div>
+              </>
+            ) : null}
+
+            {mode === "intended" ? (
+              <div className="studio-intended-stack">
+                {proposalUrl ? (
+                  <img src={proposalUrl} alt="Proposed first drawing pass" />
+                ) : null}
+                {intendedUrls.map((url, index) => (
+                  <img key={url} src={url} alt={`Intended drawing pass ${index + 1}`} />
+                ))}
+              </div>
+            ) : null}
+
+            {!hasIntended && !observedUrl ? (
+              <div className="studio-paper-empty" role="status">
+                <span className="studio-thinking-mark" aria-hidden="true" />
+                <strong>The drawing plan is taking shape.</strong>
+                <span>The first marks will appear here before anything moves.</span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      )}
+
+      {mode === "overlay" ? (
+        <label className="studio-opacity-control">
+          Intended opacity
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={intendedOpacity}
+            onChange={(event) => setIntendedOpacity(Number(event.target.value))}
+          />
+          <span>{intendedOpacity}%</span>
+        </label>
+      ) : null}
+
+      {observation && !isV2PageAlignedCapture(observation) ? (
+        <p className="studio-canvas-note">Legacy registration · overlay unavailable</p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/studio/StudioConversation.tsx
+++ b/apps/web/src/features/studio/StudioConversation.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+import type { DrawingSession, DrawingSessionEvent } from "../../types/drawing";
+import type { StudioAction } from "./useStudioSession";
+
+interface StudioConversationProps {
+  session: DrawingSession;
+  busyAction: StudioAction;
+  onSend: (message: string) => Promise<void>;
+}
+
+function eventSpeaker(event: DrawingSessionEvent) {
+  return event.type === "user_guidance" ? "You" : "Studio";
+}
+
+function eventBody(event: DrawingSessionEvent) {
+  const assessment = event.details.assessment;
+  if (event.type === "agent_decision" && typeof assessment === "string") {
+    return `${assessment} ${event.message}`;
+  }
+  return event.message;
+}
+
+function formatEventTime(timestamp: string) {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function StudioConversation({
+  session,
+  busyAction,
+  onSend,
+}: StudioConversationProps) {
+  const [draft, setDraft] = useState("");
+  const endRef = useRef<HTMLLIElement | null>(null);
+  const canSend =
+    draft.trim().length > 0 &&
+    !["completed", "failed", "stopping"].includes(session.status) &&
+    busyAction !== "message";
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [session.events.length]);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!canSend) return;
+    const message = draft.trim();
+    setDraft("");
+    await onSend(message);
+  }
+
+  return (
+    <aside className="studio-conversation" aria-label="Drawing conversation">
+      <header>
+        <div>
+          <p className="eyebrow">Conversation</p>
+          <h2>Shape the next decision</h2>
+        </div>
+        {session.queued_guidance.length > 0 ? (
+          <span className="studio-queued-count">
+            {session.queued_guidance.length} queued
+          </span>
+        ) : null}
+      </header>
+
+      <ol className="studio-event-log" aria-live="polite" aria-relevant="additions text">
+        {session.events.map((event) => (
+          <li
+            key={event.id}
+            className={
+              event.type === "user_guidance"
+                ? "studio-event studio-event-user"
+                : "studio-event studio-event-agent"
+            }
+          >
+            <div className="studio-event-meta">
+              <strong>{eventSpeaker(event)}</strong>
+              <time dateTime={event.created_at}>{formatEventTime(event.created_at)}</time>
+            </div>
+            <p>{eventBody(event)}</p>
+          </li>
+        ))}
+        <li ref={endRef} className="studio-event-end" aria-hidden="true" />
+      </ol>
+
+      <form className="studio-message-form" onSubmit={submit}>
+        <label htmlFor="studio-guidance">
+          {session.authorization.approved_at
+            ? "Guidance for the next observation"
+            : "Revise the plan"}
+        </label>
+        <textarea
+          id="studio-guidance"
+          value={draft}
+          rows={3}
+          maxLength={2000}
+          disabled={["completed", "failed", "stopping"].includes(session.status)}
+          placeholder={
+            session.authorization.approved_at
+              ? "For example: make the rhythm less regular"
+              : "For example: leave more open space on the right"
+          }
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+              event.preventDefault();
+              event.currentTarget.form?.requestSubmit();
+            }
+          }}
+        />
+        <div className="studio-message-actions">
+          <span>⌘ Enter to send</span>
+          <button type="submit" className="button-secondary" disabled={!canSend}>
+            {busyAction === "message"
+              ? "Sending…"
+              : session.authorization.approved_at
+                ? "Queue guidance"
+                : "Revise plan"}
+          </button>
+        </div>
+      </form>
+    </aside>
+  );
+}

--- a/apps/web/src/features/studio/useStudioSession.ts
+++ b/apps/web/src/features/studio/useStudioSession.ts
@@ -1,0 +1,232 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  approveDrawingSession,
+  confirmPlotRunCaptureReview,
+  fetchDrawingSession,
+  fetchHardwareStatus,
+  fetchPlotRun,
+  fetchPlotRunCaptureReview,
+  heartbeatDrawingSession,
+  resumeDrawingSession,
+  retryPlotRunCapture,
+  sendDrawingSessionMessage,
+  stopDrawingSession,
+} from "../../lib/api";
+import type { DrawingSession } from "../../types/drawing";
+import type { HardwareStatus, NormalizationCorners } from "../../types/hardware";
+import type { PlotRun, PlotRunCaptureReviewPayload } from "../../types/plotting";
+
+const ACTIVE_SESSION_STATUSES = new Set([
+  "planning",
+  "running",
+  "awaiting_capture_review",
+  "stopping",
+]);
+const HEARTBEAT_SESSION_STATUSES = new Set([
+  "running",
+  "awaiting_capture_review",
+  "stopping",
+]);
+
+export const STUDIO_ACTIVE_POLL_MS = 1000;
+export const STUDIO_IDLE_POLL_MS = 3500;
+export const STUDIO_HEARTBEAT_MS = 10000;
+
+export type StudioAction =
+  | "message"
+  | "approve"
+  | "stop-after-pass"
+  | "emergency-stop"
+  | "resume"
+  | "retry-capture"
+  | "register"
+  | null;
+
+export function useStudioSession(sessionId: string) {
+  const [session, setSession] = useState<DrawingSession | null>(null);
+  const [runs, setRuns] = useState<Record<string, PlotRun>>({});
+  const [captureReview, setCaptureReview] = useState<PlotRunCaptureReviewPayload | null>(null);
+  const [hardwareStatus, setHardwareStatus] = useState<HardwareStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busyAction, setBusyAction] = useState<StudioAction>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hardwareError, setHardwareError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const refreshRunningRef = useRef(false);
+
+  async function refresh({ silent = false }: { silent?: boolean } = {}) {
+    if (refreshRunningRef.current) {
+      return;
+    }
+    refreshRunningRef.current = true;
+    try {
+      const nextSession = await fetchDrawingSession(sessionId);
+      const runIds = Array.from(
+        new Set([
+          ...nextSession.iterations.map((iteration) => iteration.run_id),
+          ...(nextSession.current_run_id ? [nextSession.current_run_id] : []),
+        ]),
+      );
+      const runEntries = await Promise.all(
+        runIds.map(async (runId) => [runId, await fetchPlotRun(runId)] as const),
+      );
+      const nextRuns = Object.fromEntries(runEntries);
+      const currentRun = nextSession.current_run_id
+        ? nextRuns[nextSession.current_run_id] ?? null
+        : null;
+      const nextReview =
+        currentRun?.status === "awaiting_capture_review"
+          ? await fetchPlotRunCaptureReview(currentRun.id)
+          : null;
+
+      if (mountedRef.current) {
+        setSession(nextSession);
+        setRuns(nextRuns);
+        setCaptureReview(nextReview);
+        setError(null);
+      }
+    } catch (refreshError) {
+      if (mountedRef.current && !silent) {
+        setError(
+          refreshError instanceof Error ? refreshError.message : "Unable to load this drawing.",
+        );
+      }
+    } finally {
+      refreshRunningRef.current = false;
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+
+    try {
+      const status = await fetchHardwareStatus();
+      if (mountedRef.current) {
+        setHardwareStatus(status);
+        setHardwareError(null);
+      }
+    } catch (statusError) {
+      if (mountedRef.current) {
+        setHardwareStatus(null);
+        setHardwareError(
+          statusError instanceof Error ? statusError.message : "Hardware status is unavailable.",
+        );
+      }
+    }
+  }
+
+  async function runAction(
+    action: Exclude<StudioAction, null>,
+    callback: () => Promise<DrawingSession | PlotRun | { run: PlotRun }>,
+  ) {
+    try {
+      setBusyAction(action);
+      setError(null);
+      const result = await callback();
+      if (!mountedRef.current) return;
+      if ("session_version" in result) {
+        setSession(result);
+      } else if ("run" in result) {
+        setRuns((current) => ({ ...current, [result.run.id]: result.run }));
+      } else {
+        setRuns((current) => ({ ...current, [result.id]: result }));
+      }
+      await refresh({ silent: true });
+    } catch (actionError) {
+      if (mountedRef.current) {
+        setError(
+          actionError instanceof Error ? actionError.message : "The studio action failed.",
+        );
+      }
+    } finally {
+      if (mountedRef.current) {
+        setBusyAction(null);
+      }
+    }
+  }
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setLoading(true);
+    void refresh();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [sessionId]);
+
+  useEffect(() => {
+    const pollMs =
+      session && ACTIVE_SESSION_STATUSES.has(session.status)
+        ? STUDIO_ACTIVE_POLL_MS
+        : STUDIO_IDLE_POLL_MS;
+    const poller = window.setInterval(() => void refresh({ silent: true }), pollMs);
+    return () => window.clearInterval(poller);
+  }, [session?.id, session?.status]);
+
+  useEffect(() => {
+    const shouldHeartbeat = Boolean(
+      session?.session_version === 2 &&
+        session.authorization.approved_at &&
+        HEARTBEAT_SESSION_STATUSES.has(session.status),
+    );
+    if (!shouldHeartbeat || !session) {
+      return undefined;
+    }
+
+    const sendHeartbeat = async () => {
+      if (document.visibilityState === "hidden") return;
+      try {
+        const updated = await heartbeatDrawingSession(session.id);
+        if (mountedRef.current) {
+          setSession(updated);
+          setHardwareError(null);
+        }
+      } catch (heartbeatError) {
+        if (mountedRef.current) {
+          setHardwareError(
+            heartbeatError instanceof Error
+              ? `Attendance signal lost: ${heartbeatError.message}`
+              : "Attendance signal lost.",
+          );
+        }
+      }
+    };
+
+    void sendHeartbeat();
+    const heartbeat = window.setInterval(() => void sendHeartbeat(), STUDIO_HEARTBEAT_MS);
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") void sendHeartbeat();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("focus", handleVisibility);
+    return () => {
+      window.clearInterval(heartbeat);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("focus", handleVisibility);
+    };
+  }, [session?.id, session?.status, session?.authorization.approved_at]);
+
+  return {
+    session,
+    runs,
+    captureReview,
+    hardwareStatus,
+    hardwareError,
+    loading,
+    busyAction,
+    error,
+    refresh,
+    sendMessage: (text: string) =>
+      runAction("message", () => sendDrawingSessionMessage(sessionId, text)),
+    approve: () => runAction("approve", () => approveDrawingSession(sessionId)),
+    stopAfterPass: () =>
+      runAction("stop-after-pass", () => stopDrawingSession(sessionId, "after_pass")),
+    emergencyStop: () =>
+      runAction("emergency-stop", () => stopDrawingSession(sessionId, "emergency")),
+    resume: () => runAction("resume", () => resumeDrawingSession(sessionId)),
+    retryCapture: (runId: string) =>
+      runAction("retry-capture", () => retryPlotRunCapture(runId)),
+    confirmRegistration: (runId: string, corners: NormalizationCorners) =>
+      runAction("register", () => confirmPlotRunCaptureReview(runId, corners)),
+  };
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -19,7 +19,11 @@ import type {
   PlotRunListResponse,
 } from "../types/plotting";
 import type { HelperStatus } from "../types/helper";
-import type { DrawingSession, LatestDrawingSessionResponse } from "../types/drawing";
+import type {
+  DrawingSession,
+  DrawingSessionListResponse,
+  LatestDrawingSessionResponse,
+} from "../types/drawing";
 
 const REQUEST_TIMEOUT_MS = 2000;
 const HELPER_OPEN_URL = "learntodraw-helper://open";
@@ -319,6 +323,12 @@ export function confirmPlotRunCaptureReview(
   );
 }
 
+export function retryPlotRunCapture(runId: string) {
+  return requestJson<PlotRun>(`/api/plot-runs/${runId}/capture/retry`, {
+    method: "POST",
+  });
+}
+
 export function fetchLatestDrawingSession() {
   return requestJson<LatestDrawingSessionResponse>("/api/drawing-sessions/latest");
 }
@@ -329,18 +339,61 @@ export function fetchDrawingSession(sessionId: string) {
 
 export function createDrawingSession(
   intent: string,
-  initialAssetId: string,
-  iterationLimit: number,
+  initialAssetId?: string,
+  iterationLimit?: number,
 ) {
+  const body: Record<string, unknown> = { intent, mode: "additive" };
+  if (initialAssetId) {
+    body.initial_asset_id = initialAssetId;
+  }
+  if (iterationLimit !== undefined) {
+    body.iteration_limit = iterationLimit;
+  }
   return requestJson<DrawingSession>("/api/drawing-sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      intent,
-      initial_asset_id: initialAssetId,
-      iteration_limit: iterationLimit,
-      mode: "additive",
-    }),
+    body: JSON.stringify(body),
+  });
+}
+
+export function fetchDrawingSessions() {
+  return requestJson<DrawingSessionListResponse>("/api/drawing-sessions");
+}
+
+export function sendDrawingSessionMessage(sessionId: string, text: string) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  });
+}
+
+export function approveDrawingSession(sessionId: string) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/approve`, {
+    method: "POST",
+  });
+}
+
+export function heartbeatDrawingSession(sessionId: string) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/heartbeat`, {
+    method: "POST",
+  });
+}
+
+export function stopDrawingSession(
+  sessionId: string,
+  mode: "after_pass" | "emergency",
+) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/stop`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode }),
+  });
+}
+
+export function resumeDrawingSession(sessionId: string) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/resume`, {
+    method: "POST",
   });
 }
 

--- a/apps/web/src/types/drawing.ts
+++ b/apps/web/src/types/drawing.ts
@@ -1,10 +1,14 @@
 import type { PlotAsset } from "./plotting";
 
 export type DrawingSessionStatus =
+  | "planning"
+  | "awaiting_approval"
   | "running"
   | "awaiting_capture_review"
   | "observed"
   | "proposal_ready"
+  | "paused"
+  | "stopping"
   | "completed"
   | "failed";
 
@@ -35,15 +39,82 @@ export interface DrawingIteration {
 
 export interface DrawingSession {
   id: string;
+  session_version: 1 | 2;
   intent: string;
   mode: "additive";
-  iteration_limit: number;
+  iteration_limit: number | null;
   status: DrawingSessionStatus;
   created_at: string;
   updated_at: string;
   iterations: DrawingIteration[];
   advisor: DrawingAdvisorStatus;
   error: string | null;
+  plan: {
+    summary: string;
+    paper_strategy: string;
+    completion_intent: string;
+  } | null;
+  current_proposal: {
+    asset: PlotAsset;
+    created_at: string;
+    advisor_driver: string;
+    advisor_model: string | null;
+  } | null;
+  current_run_id: string | null;
+  assessing_run_id: string | null;
+  pass_count: number;
+  planning_generation: number;
+  authorization: {
+    approved_at: string | null;
+    stop_requested: boolean;
+    last_heartbeat_at: string | null;
+  };
+  queued_guidance: string[];
+  requested_human_action: string | null;
+  events: DrawingSessionEvent[];
+  approved_at: string | null;
+  paused_at: string | null;
+  completed_at: string | null;
+}
+
+export type DrawingSessionEventType =
+  | "session_created"
+  | "user_guidance"
+  | "plan_ready"
+  | "plan_failed"
+  | "session_approved"
+  | "plot_started"
+  | "observation_ready"
+  | "agent_decision"
+  | "session_paused"
+  | "session_resumed"
+  | "stop_requested"
+  | "session_completed"
+  | "session_failed";
+
+export interface DrawingSessionEvent {
+  id: string;
+  type: DrawingSessionEventType;
+  created_at: string;
+  message: string;
+  asset_id: string | null;
+  run_id: string | null;
+  details: Record<string, unknown>;
+}
+
+export interface DrawingSessionSummary {
+  id: string;
+  session_version: 1 | 2;
+  intent: string;
+  status: DrawingSessionStatus;
+  pass_count: number;
+  created_at: string;
+  updated_at: string;
+  preview_url: string | null;
+}
+
+export interface DrawingSessionListResponse {
+  sessions: DrawingSessionSummary[];
 }
 
 export interface LatestDrawingSessionResponse {

--- a/apps/web/src/types/plotting.ts
+++ b/apps/web/src/types/plotting.ts
@@ -12,7 +12,7 @@ export interface PlotAsset {
 }
 
 export interface PlotStageState {
-  status: "pending" | "in_progress" | "completed" | "failed";
+  status: "pending" | "in_progress" | "completed" | "failed" | "cancelled";
   started_at: string | null;
   completed_at: string | null;
   message: string | null;
@@ -23,8 +23,10 @@ export interface PlotRun {
   status:
     | "pending"
     | "plotting"
+    | "stopping"
     | "capturing"
     | "awaiting_capture_review"
+    | "cancelled"
     | "completed"
     | "failed";
   purpose: "normal" | "diagnostic";
@@ -38,12 +40,19 @@ export interface PlotRun {
     mime_type: string;
   } | null;
   capture: CaptureMetadata | null;
+  capture_attempts: CaptureMetadata[];
   observed_result?: {
     capture: CaptureMetadata;
     camera_driver: string;
     captured_at: string;
     duration_ms: number;
   } | null;
+  progress_artifact: {
+    file_path: string;
+    public_url: string;
+    mime_type: string;
+  } | null;
+  interruption_reason: string | null;
   error: string | null;
   stage_states: Record<"prepare" | "plot" | "capture" | "capture_review", PlotStageState>;
   plotter_run_details: Record<string, unknown>;
@@ -73,5 +82,5 @@ export interface PlotRunListResponse {
 export interface PlotRunCaptureReviewPayload {
   run_id: string;
   capture: CaptureMetadata;
-  review: CaptureMetadata["review"];
+  review: NonNullable<CaptureMetadata["review"]>;
 }

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -1,0 +1,504 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import { App } from "../src/app/App";
+import { StudioCanvas } from "../src/features/studio/StudioCanvas";
+import type {
+  DrawingSession,
+  DrawingSessionEvent,
+  DrawingSessionStatus,
+} from "../src/types/drawing";
+import type { CaptureMetadata } from "../src/types/hardware";
+import type { PlotAsset, PlotRun } from "../src/types/plotting";
+import {
+  createHardwareDashboardHarness,
+  defaultAxiDrawHardwareStatus,
+  installHardwareDashboardFetchMock,
+} from "./hardwareDashboardTestUtils";
+
+const now = "2026-09-04T20:00:00Z";
+
+const asset: PlotAsset = {
+  id: "asset-1",
+  kind: "generated_svg",
+  pattern_id: null,
+  name: "Whimsical flowers — first pass",
+  timestamp: now,
+  file_path: "/tmp/asset-1.svg",
+  public_url: "/plot-assets/asset-1.svg",
+  mime_type: "image/svg+xml",
+};
+
+function event(
+  type: DrawingSessionEvent["type"],
+  message: string,
+  details: Record<string, unknown> = {},
+): DrawingSessionEvent {
+  return {
+    id: `${type}-${message}`,
+    type,
+    created_at: now,
+    message,
+    asset_id: null,
+    run_id: type === "session_created" ? null : "run-1",
+    details,
+  };
+}
+
+function buildSession(
+  status: DrawingSessionStatus,
+  overrides: Partial<DrawingSession> = {},
+): DrawingSession {
+  const approved = !["planning", "awaiting_approval"].includes(status);
+  const hasRun = approved;
+  return {
+    id: "session-1",
+    session_version: 2,
+    intent: "A whimsical field of flowers",
+    mode: "additive",
+    iteration_limit: null,
+    status,
+    created_at: now,
+    updated_at: now,
+    iterations: hasRun
+      ? [{ number: 1, asset, run_id: "run-1", created_at: now, next_proposal: null }]
+      : [],
+    advisor: {
+      driver: "mock",
+      available: true,
+      model: "mock-advisor-v1",
+      message: null,
+    },
+    error: status === "paused" ? "The camera observation needs attention." : null,
+    plan:
+      status === "planning"
+        ? null
+        : {
+            summary: "Build an airy cluster from varied stems and a loose center.",
+            paper_strategy: "Keep the composition centered with generous breathing room.",
+            completion_intent: "Stop when the field feels lively without filling every gap.",
+          },
+    current_proposal:
+      status === "planning"
+        ? null
+        : {
+            asset,
+            created_at: now,
+            advisor_driver: "mock",
+            advisor_model: "mock-advisor-v1",
+          },
+    current_run_id: hasRun ? "run-1" : null,
+    assessing_run_id: null,
+    pass_count: hasRun ? 1 : 0,
+    planning_generation: 1,
+    authorization: {
+      approved_at: approved ? now : null,
+      stop_requested: status === "stopping",
+      last_heartbeat_at: approved ? now : null,
+    },
+    queued_guidance: [],
+    requested_human_action: null,
+    events: [
+      event("session_created", "Creative session created. Planning the first pass."),
+      ...(status === "planning"
+        ? []
+        : [event("plan_ready", "The drawing plan and first-pass preview are ready.")]),
+      ...(approved ? [event("session_approved", "Open-ended drawing approved.")] : []),
+    ],
+    approved_at: approved ? now : null,
+    paused_at: status === "paused" ? now : null,
+    completed_at: status === "completed" ? now : null,
+    ...overrides,
+  };
+}
+
+function buildCapture(reviewStatus: "pending" | "confirmed" = "confirmed"): CaptureMetadata {
+  const corners = {
+    top_left: [100, 100] as [number, number],
+    top_right: [1500, 100] as [number, number],
+    bottom_right: [1500, 1100] as [number, number],
+    bottom_left: [100, 1100] as [number, number],
+  };
+  return {
+    id: "capture-1",
+    timestamp: now,
+    file_path: "/tmp/capture-1.jpg",
+    public_url: "/captures/capture-1.jpg",
+    width: 1600,
+    height: 1200,
+    mime_type: "image/jpeg",
+    review: {
+      registration_version: 2,
+      review_mode: "manual_corners",
+      review_required: reviewStatus === "pending",
+      review_status: reviewStatus,
+      proposed_corners: corners,
+      confirmed_corners: reviewStatus === "confirmed" ? corners : null,
+      confirmation_source: reviewStatus === "confirmed" ? "manual" : null,
+    },
+    normalized:
+      reviewStatus === "confirmed"
+        ? {
+            rectified_color_url: "/captures/capture-1-color.png",
+            rectified_grayscale_url: "/captures/capture-1-gray.png",
+            debug_overlay_url: "/captures/capture-1-debug.png",
+            metadata: {
+              method: "manual_corners_v2",
+              confidence: null,
+              corners,
+              transform: {
+                matrix: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                inverse_matrix: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                source_space: "raw_capture_px",
+                destination_space: "page_px",
+                pixels_per_mm_x: 8,
+                pixels_per_mm_y: 8,
+              },
+              output: { width: 2048, height: 1583, aspect_ratio: 1.294 },
+              target_frame_source: "prepared_svg",
+              frame: {
+                kind: "page_aligned",
+                version: 2,
+                page_width_mm: 279.4,
+                page_height_mm: 215.9,
+                origin: "top-left",
+              },
+            },
+          }
+        : null,
+  };
+}
+
+function buildRun(
+  status: PlotRun["status"] = "plotting",
+  capture: CaptureMetadata | null = null,
+): PlotRun {
+  const plotComplete = !["pending", "plotting", "stopping"].includes(status);
+  return {
+    id: "run-1",
+    status,
+    purpose: "normal",
+    capture_mode: "auto",
+    created_at: now,
+    updated_at: now,
+    asset,
+    prepared_artifact: {
+      file_path: "/tmp/run-1-prepared.svg",
+      public_url: "/plot-run-artifacts/run-1-prepared.svg",
+      mime_type: "image/svg+xml",
+    },
+    capture,
+    capture_attempts: [],
+    observed_result:
+      capture?.review?.review_status === "confirmed"
+        ? { capture, camera_driver: "mock-camera", captured_at: now, duration_ms: 200 }
+        : null,
+    progress_artifact: null,
+    interruption_reason: null,
+    error: status === "failed" ? "Capture failed." : null,
+    stage_states: {
+      prepare: { status: "completed", started_at: now, completed_at: now, message: "Prepared." },
+      plot: {
+        status: plotComplete ? "completed" : "in_progress",
+        started_at: now,
+        completed_at: plotComplete ? now : null,
+        message: plotComplete ? "Plotted." : "Plotting.",
+      },
+      capture: {
+        status: capture ? "completed" : status === "failed" ? "failed" : "pending",
+        started_at: capture || status === "failed" ? now : null,
+        completed_at: capture || status === "failed" ? now : null,
+        message: status === "failed" ? "Capture failed." : null,
+      },
+      capture_review: {
+        status:
+          status === "awaiting_capture_review"
+            ? "in_progress"
+            : capture?.review?.review_status === "confirmed"
+              ? "completed"
+              : "pending",
+        started_at: capture ? now : null,
+        completed_at: capture?.review?.review_status === "confirmed" ? now : null,
+        message: null,
+      },
+    },
+    plotter_run_details: {
+      preparation: { page_width_mm: 279.4, page_height_mm: 215.9 },
+    },
+    camera_run_details: {},
+  };
+}
+
+function installStudioMock(
+  initialSession: DrawingSession,
+  run: PlotRun | null = null,
+) {
+  let currentSession = initialSession;
+  let currentRun = run;
+  const requests: Array<{ method: string; url: string; body?: string }> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    requests.push({ method, url, body: typeof init?.body === "string" ? init.body : undefined });
+
+    if (url === "/api/hardware/status") return Response.json(defaultAxiDrawHardwareStatus);
+    if (url === `/api/drawing-sessions/${currentSession.id}` && method === "GET") {
+      return Response.json(currentSession);
+    }
+    if (url === `/api/plot-runs/${currentRun?.id}` && method === "GET" && currentRun) {
+      return Response.json(currentRun);
+    }
+    if (url.endsWith("/capture-review") && method === "GET" && currentRun?.capture?.review) {
+      return Response.json({
+        run_id: currentRun.id,
+        capture: currentRun.capture,
+        review: currentRun.capture.review,
+      });
+    }
+    if (url.endsWith("/heartbeat") && method === "POST") return Response.json(currentSession);
+    if (url.endsWith("/messages") && method === "POST") {
+      const text = JSON.parse(String(init?.body)).text as string;
+      currentSession = {
+        ...currentSession,
+        status: currentSession.authorization.approved_at ? currentSession.status : "planning",
+        plan: currentSession.authorization.approved_at ? currentSession.plan : null,
+        current_proposal: currentSession.authorization.approved_at
+          ? currentSession.current_proposal
+          : null,
+        queued_guidance: [...currentSession.queued_guidance, text],
+        events: [...currentSession.events, event("user_guidance", text)],
+      };
+      return Response.json(currentSession);
+    }
+    if (url.endsWith("/approve") && method === "POST") {
+      currentSession = buildSession("running");
+      currentRun = buildRun("plotting");
+      return Response.json(currentSession);
+    }
+    if (url.endsWith("/stop") && method === "POST") {
+      currentSession = {
+        ...currentSession,
+        status: "stopping",
+        authorization: { ...currentSession.authorization, stop_requested: true },
+      };
+      return Response.json(currentSession);
+    }
+    if (url.endsWith("/capture/retry") && method === "POST" && currentRun) {
+      currentRun = { ...currentRun, status: "capturing", error: null };
+      return Response.json(currentRun);
+    }
+    if (url.endsWith("/resume") && method === "POST") {
+      currentSession = { ...currentSession, status: "running", error: null, paused_at: null };
+      return Response.json(currentSession);
+    }
+    throw new Error(`Unexpected request: ${method} ${url}`);
+  });
+  return { requests, getSession: () => currentSession };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, "", "/");
+  Object.defineProperty(window, "scrollTo", { value: vi.fn(), writable: true });
+});
+
+it("starts with creative intent and creates a prompt-only planning session", async () => {
+  const currentSession = buildSession("planning");
+  const requests: Array<{ method: string; url: string; body?: string }> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    requests.push({ method, url, body: typeof init?.body === "string" ? init.body : undefined });
+    if (url === "/api/hardware/status") return Response.json(defaultAxiDrawHardwareStatus);
+    if (url === "/api/drawing-sessions/latest") return Response.json({ session: null });
+    if (url === "/api/drawing-sessions" && method === "POST") return Response.json(currentSession);
+    if (url === `/api/drawing-sessions/${currentSession.id}`) return Response.json(currentSession);
+    throw new Error(`Unexpected request: ${method} ${url}`);
+  });
+
+  render(<App />);
+  expect(await screen.findByRole("heading", { name: /what should we draw/i })).toBeInTheDocument();
+  fireEvent.change(screen.getByLabelText(/drawing idea/i), {
+    target: { value: "A field of unruly flowers" },
+  });
+  const createButton = screen.getByRole("button", { name: /create a drawing/i });
+  await waitFor(() => expect(createButton).toBeEnabled());
+  fireEvent.click(createButton);
+
+  expect(await screen.findByRole("heading", { name: /finding the first useful marks/i })).toBeInTheDocument();
+  const createRequest = requests.find(
+    (request) => request.url === "/api/drawing-sessions" && request.method === "POST",
+  );
+  expect(JSON.parse(createRequest?.body ?? "{}")).toEqual({
+    intent: "A field of unruly flowers",
+    mode: "additive",
+  });
+  expect(requests.some((request) => request.url === "/api/plot-runs")).toBe(false);
+});
+
+it("shows the plan, explains open-ended approval, and lets a message replace the proposal", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const harness = installStudioMock(buildSession("awaiting_approval"));
+  render(<App />);
+
+  const planHeading = await screen.findByRole("heading", { name: /build an airy cluster/i });
+  await waitFor(() => expect(planHeading).toHaveFocus());
+  expect(screen.getByRole("img", { name: /proposed first drawing pass/i })).toBeInTheDocument();
+  expect(screen.getByText(/authorizes an attended sequence/i)).toBeInTheDocument();
+  expect(screen.getByText(/more than one permanent layer/i)).toBeInTheDocument();
+
+  fireEvent.change(screen.getByLabelText(/revise the plan/i), {
+    target: { value: "Leave more room on the right" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /revise plan/i }));
+
+  expect(await screen.findByRole("heading", { name: /finding the first useful marks/i })).toBeInTheDocument();
+  expect(screen.queryByRole("img", { name: /proposed first drawing pass/i })).not.toBeInTheDocument();
+  expect(
+    harness.requests.some(
+      (request) => request.url.endsWith("/messages") && request.body?.includes("room on the right"),
+    ),
+  ).toBe(true);
+});
+
+it("queues active guidance, sends heartbeats, and confirmation-protects emergency stop", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const harness = installStudioMock(buildSession("running"), buildRun("plotting"));
+  render(<App />);
+
+  expect(await screen.findByText(/the studio is authorized to continue/i)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(harness.requests.some((request) => request.url.endsWith("/heartbeat"))).toBe(true);
+  });
+
+  fireEvent.change(screen.getByLabelText(/guidance for the next observation/i), {
+    target: { value: "Make the flowers less regular" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /queue guidance/i }));
+  expect(await screen.findByText("1 queued")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /^emergency stop$/i }));
+  const dialog = screen.getByRole("alertdialog", { name: /pause the active plot/i });
+  expect(within(dialog).getByText(/after its current path segment/i)).toBeInTheDocument();
+  fireEvent.click(within(dialog).getByRole("button", { name: /pause after current segment/i }));
+
+  await waitFor(() => {
+    const stopRequest = harness.requests.find((request) => request.url.endsWith("/stop"));
+    expect(JSON.parse(stopRequest?.body ?? "{}")).toEqual({ mode: "emergency" });
+  });
+});
+
+it("offers capture-only recovery and never creates a replacement plot run", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const failedRun = buildRun("failed");
+  const harness = installStudioMock(buildSession("paused"), failedRun);
+  render(<App />);
+
+  const recoveryHeading = await screen.findByRole("heading", { name: /safely paused/i });
+  await waitFor(() => expect(recoveryHeading).toHaveFocus());
+  fireEvent.click(screen.getByRole("button", { name: /retake photo only/i }));
+
+  await waitFor(() => {
+    expect(harness.requests.some((request) => request.url.endsWith("/capture/retry"))).toBe(true);
+  });
+  expect(
+    harness.requests.some(
+      (request) => request.url === "/api/plot-runs" && request.method === "POST",
+    ),
+  ).toBe(false);
+});
+
+it("renders a true V2 overlay and exposes manual registration when required", async () => {
+  const observedCapture = buildCapture("confirmed");
+  const completedRun = buildRun("completed", observedCapture);
+  const completedSession = buildSession("completed", {
+    events: [
+      event("agent_decision", "The composition has enough life.", {
+        assessment: "The varied stems now read as a field.",
+        decision: "complete",
+      }),
+      event("session_completed", "The drawing feels complete."),
+    ],
+  });
+  const { rerender } = render(
+    <StudioCanvas
+      session={completedSession}
+      runs={{ "run-1": completedRun }}
+      captureReview={null}
+      busy={false}
+      error={null}
+      onConfirmRegistration={async () => undefined}
+    />,
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /^overlay$/i }));
+  expect(screen.getByRole("heading", { name: /intended versus observed/i })).toBeInTheDocument();
+  const slider = screen.getByRole("slider", { name: /intended opacity/i });
+  fireEvent.change(slider, { target: { value: "72" } });
+  expect(slider).toHaveValue("72");
+
+  const pendingCapture = buildCapture("pending");
+  const pendingRun = buildRun("awaiting_capture_review", pendingCapture);
+  rerender(
+    <StudioCanvas
+      session={buildSession("awaiting_capture_review")}
+      runs={{ "run-1": pendingRun }}
+      captureReview={{ run_id: "run-1", capture: pendingCapture, review: pendingCapture.review! }}
+      busy={false}
+      error={null}
+      onConfirmRegistration={async () => undefined}
+    />,
+  );
+  expect(await screen.findByText(/manual page registration required/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /register page/i })).toBeInTheDocument();
+});
+
+it("lists session-level work in Gallery and keeps the full operator surface in Controls", async () => {
+  window.history.replaceState({}, "", "/gallery");
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    Response.json({
+      sessions: [
+        {
+          id: "session-1",
+          session_version: 2,
+          intent: "A whimsical field of flowers",
+          status: "completed",
+          pass_count: 3,
+          created_at: now,
+          updated_at: now,
+          preview_url: "/captures/final-gray.png",
+        },
+      ],
+    }),
+  );
+  const { unmount } = render(<App />);
+  expect(await screen.findByRole("heading", { name: /drawings made through observation/i })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: /whimsical field of flowers/i })).toBeInTheDocument();
+  expect(screen.getByText(/3 passes/i)).toBeInTheDocument();
+  unmount();
+
+  window.history.replaceState({}, "", "/controls");
+  const controlsHarness = createHardwareDashboardHarness();
+  installHardwareDashboardFetchMock(controlsHarness);
+  render(<App />);
+  expect(await screen.findByRole("heading", { name: /machine setup and manual work/i })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: /upload, plot, capture, and inspect an svg/i })).toBeInTheDocument();
+  expect(screen.getByLabelText(/upload svg/i)).toHaveAttribute("type", "file");
+});
+
+it("surfaces provider-disabled recovery without exposing a browser key field", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const paused = buildSession("paused", {
+    advisor: {
+      driver: "disabled",
+      available: false,
+      model: null,
+      message: "Drawing advisor is disabled on the local backend.",
+    },
+  });
+  installStudioMock(paused, buildRun("failed"));
+  render(<App />);
+
+  expect(await screen.findByText(/creative advisor unavailable/i)).toBeInTheDocument();
+  expect(screen.getByText(/disabled on the local backend/i)).toBeInTheDocument();
+  expect(screen.queryByLabelText(/api key/i)).not.toBeInTheDocument();
+});

--- a/apps/web/tests/dashboard.test.tsx
+++ b/apps/web/tests/dashboard.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
-import { App } from "../src/app/App";
+import { HardwareDashboard as App } from "../src/features/hardware/HardwareDashboard";
 import type { CaptureReview } from "../src/types/hardware";
 import type { PlotRun } from "../src/types/plotting";
 import {
@@ -99,6 +99,7 @@ function buildRun({
           normalized,
         }
       : null,
+    capture_attempts: [],
     observed_result: observedCaptureId
       ? {
           capture: {
@@ -117,6 +118,8 @@ function buildRun({
           duration_ms: 900,
         }
       : null,
+    progress_artifact: null,
+    interruption_reason: null,
     error: null,
     stage_states: {
       prepare: {

--- a/apps/web/tests/drawingSessionPanel.test.tsx
+++ b/apps/web/tests/drawingSessionPanel.test.tsx
@@ -38,6 +38,7 @@ function buildSession(status: DrawingSession["status"]): DrawingSession {
     : null;
   return {
     id: "session-1",
+    session_version: 1,
     intent: "A lively field of flowers",
     mode: "additive",
     iteration_limit: 3,
@@ -60,6 +61,23 @@ function buildSession(status: DrawingSession["status"]): DrawingSession {
       message: null,
     },
     error: null,
+    plan: null,
+    current_proposal: null,
+    current_run_id: "run-1",
+    assessing_run_id: null,
+    pass_count: 1,
+    planning_generation: 0,
+    authorization: {
+      approved_at: null,
+      stop_requested: false,
+      last_heartbeat_at: null,
+    },
+    queued_guidance: [],
+    requested_human_action: null,
+    events: [],
+    approved_at: null,
+    paused_at: null,
+    completed_at: null,
   };
 }
 

--- a/apps/web/tests/hardwareDashboardFocused.test.tsx
+++ b/apps/web/tests/hardwareDashboardFocused.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
-import { App } from "../src/app/App";
+import { HardwareDashboard as App } from "../src/features/hardware/HardwareDashboard";
 import { CameraPanel } from "../src/features/hardware/CameraPanel";
 import * as api from "../src/lib/api";
 import {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,13 +31,15 @@ The current backend structure centers on:
 
 ## Frontend Responsibilities
 
-The frontend is a lightweight local dashboard.
+The frontend is a lightweight local creative studio. Its primary surface describes and follows a drawing; operational tools remain secondary.
 
-- polls backend endpoints for hardware status, captures, plot runs, and plotter state
-- triggers safe backend-owned actions such as capture, return-to-origin, test actions, and plot workflow operations
-- organizes the local operator experience into workflow, machine-setup, and run-history surfaces
-- presents read-only hardware detail plus a small number of bounded controls
-- previews planned-vs-captured output and current workspace information without becoming a second hardware API
+- `/` starts from “What should we draw?” or redirects to the current active session
+- `/sessions/:id` presents the plan, cumulative intended artwork, latest registered observation, exact overlay, conversation, recovery actions, and persistent stop controls
+- `/gallery` lists session-level work using the latest or final observation as its preview
+- `/controls` retains paper setup, hardware readiness, test capture, fixed diagnostics, manual SVG plotting, and manual registration
+- polls backend endpoints for session, run, capture-review, and hardware state; the creative screen also posts its attendance heartbeat
+- sends conversational revisions before approval and queues guidance during physical work, but never invokes hardware outside backend-owned session and plot-run operations
+- presents major creative and machine events without turning routine polling and low-level stage transitions into conversation noise
 
 ## CameraBridge Real-Camera Path
 
@@ -86,6 +88,7 @@ The app currently supports a single backend-owned plotting workflow with a few n
 - `device settings`: stable machine information and operational safe bounds are backend-owned and surfaced read-only except for narrow safe overrides
 - `calibration`: persisted plotter calibration remains backend-owned and separate from transient runtime overrides
 - `drawing sessions`: V2 begins from creative intent, requires explicit authorization for an attended open-ended session, then serially observes and decides whether to continue, complete, or pause; V1 bounded sessions remain readable
+- `creative studio`: the prompt-first home and session canvas are the default product surface; machine setup, diagnostics, capture tools, and manual plotting live under Controls, while Gallery exposes session-level history
 
 ## Manual Capture Registration V2
 
@@ -130,6 +133,18 @@ The executor stores returned progress as a diagnostic `progress_artifact`, trans
 Mock plotting uses a deterministic stop event but preserves the same result contract. Compatibility-only and unavailable adapters do not grow undocumented interruption behavior. The physical AxiDraw Pause control remains the fallback if process signalling cannot be confirmed.
 
 Existing session JSON without `session_version` parses as V1. Its bounded two-to-ten-pass, request-advice, and approve-next-iteration behavior remains available through the legacy endpoints and is not migrated or proactively rewritten.
+
+## Creative Studio Interaction Contract
+
+Planning never implies motion. The home may create a planning session while plotter or camera readiness is incomplete; approval and every later pass still pass through backend hardware-readiness and safety checks. Pre-approval guidance replaces the proposal. Approval copy explicitly describes the attended, open-ended plot/capture/assessment authorization.
+
+The active canvas treats the physical page as the common coordinate frame. Intended mode stacks every prepared incremental SVG, observed mode shows the latest registered photograph, and overlay mode stacks those two views without cropping only when capture metadata proves a V2 page-aligned frame. Pending manual registration embeds the existing corner editor in the canvas and preserves validation errors and the draft.
+
+The conversation records user guidance, agent plans, interpretations, decisions, requests for human action, and consequential machine events. Guidance submitted while work is active is visibly queued and consumed by the backend at the next assessment. A live region announces state changes, focus moves to recovery or approval headings when those states appear, and all status labels include text rather than relying on color.
+
+The creative screen posts heartbeats only while visible and on an active authorized session. Closing or hiding it therefore allows the current physical pass to finish but prevents another pass after the backend grace period. Stop-after-pass preserves that same safe boundary. Emergency stop is confirmation-protected and is offered only while the current run is pending or plotting; its copy states that interruption occurs after the current path segment.
+
+Paused capture failures offer a camera-only retake, which cannot create a replacement plot run. Manual registration remains in-context on the canvas. Resume is explicit and rechecks backend readiness. Advisor configuration stays server-side: the browser exposes provider availability and recovery guidance but never accepts, stores, or displays an API key.
 
 ## Extension Points
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -175,4 +175,13 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Added deterministic mock interruption plus fake-client and process-runner coverage without adding partial-plot resume or undocumented AxiDraw calls
 - Kept the physical Pause button as the hardware fallback and documented that software pause occurs only after the current line segment
 
+## Agentic Creative Studio Interface Slice
+
+- Replaced the operator dashboard as the default route with a prompt-first creative home and session-centered studio
+- Made cumulative intended artwork, the latest registered observation, exact V2 overlay, and in-context manual corner registration the primary visual surface
+- Added a compact typed conversation for plan revisions, queued guidance, agent interpretations, decisions, human-action requests, and consequential machine events
+- Added attended heartbeat behavior, stop-after-pass, confirmation-protected emergency stop, capture-only retake, paused recovery, and accessible live-state treatment to the creative interface
+- Added a session gallery whose preview follows the latest or final camera observation, while retaining machine setup, capture, diagnostics, manual SVG plotting, and legacy session tools under Controls
+- Kept provider secrets entirely backend-configured and preserved the existing polling, PlotRun, capture, registration, hardware-adapter, and V1 compatibility boundaries
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Replaces the operator dashboard at `/` with a prompt-first creative home and session-centered studio.
- Adds a cumulative intended/observed/overlay/registration canvas, compact typed conversation, queued guidance, attended heartbeat, safe stop and recovery actions, Gallery, and secondary Controls.
- Uses the V2 session/coordinator/interruptible-worker contracts from the preceding slices while preserving the existing manual workflow and V1 reads.
- Makes Gallery prefer the latest/final observation instead of an ideal SVG when one exists.
- Implements the pre-edit plan recorded on #51.

Closes #51
Parent: #47

## Checks

- [x] `make api-test` — 143 passed
- [x] `make web-test` — 45 passed
- [x] `make web-build` — TypeScript and Vite production build passed
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why
- [x] `make api-lint` — Ruff passed
- [x] `make web-lint` — ESLint passed with zero warnings
- [x] `git diff --check` — passed
- Visual browser inspection was unavailable because this Codex task had no enabled browser surface. Responsive layout and interaction states are covered by source review and rendered component tests.

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

The frontend calls only backend session, PlotRun, capture-review, and hardware APIs. The visual QA server used isolated temporary artifact directories with mock plotter, camera, and advisor adapters; it did not address the connected hardware.

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior
- [x] I called out version-sensitive behavior when relevant
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

The interface assumes the preceding backend slices remain authoritative for readiness, authorization, 30-second heartbeat grace, SVG safety, capture-only retry, and process-scoped AxiDraw interruption. Emergency-stop copy intentionally promises only a pause after the current path segment. No undocumented hardware behavior or browser-side hardware access is introduced.
