### PR TITLE
Offer capture-only retake during registration

### DIFF
--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -3138,6 +3138,25 @@ button {
   background: #121110;
 }
 
+.studio-registration-recovery {
+  margin-bottom: 12px;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(255, 248, 238, 0.05);
+}
+
+.studio-registration-recovery p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+
 .studio-conversation {
   position: sticky;
   top: 18px;
@@ -3606,7 +3625,8 @@ button {
   .studio-canvas-toolbar,
   .studio-recovery,
   .studio-complete,
-  .studio-stop-dock {
+  .studio-stop-dock,
+  .studio-registration-recovery {
     align-items: stretch;
     flex-direction: column;
   }

--- a/apps/web/src/features/studio/SessionStudio.tsx
+++ b/apps/web/src/features/studio/SessionStudio.tsx
@@ -134,9 +134,14 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
             session={session}
             runs={controller.runs}
             captureReview={controller.captureReview}
-            busy={controller.busyAction === "register"}
+            busy={
+              controller.busyAction === "register" ||
+              controller.busyAction === "retry-capture"
+            }
+            retryingCapture={controller.busyAction === "retry-capture"}
             error={controller.captureReview ? controller.error : null}
             onConfirmRegistration={controller.confirmRegistration}
+            onRetryCapture={controller.retryCapture}
           />
 
           {session.status === "planning" ? (

--- a/apps/web/src/features/studio/StudioCanvas.tsx
+++ b/apps/web/src/features/studio/StudioCanvas.tsx
@@ -13,8 +13,10 @@ interface StudioCanvasProps {
   runs: Record<string, PlotRun>;
   captureReview: PlotRunCaptureReviewPayload | null;
   busy: boolean;
+  retryingCapture: boolean;
   error: string | null;
   onConfirmRegistration: (runId: string, corners: NormalizationCorners) => Promise<void>;
+  onRetryCapture: (runId: string) => Promise<void>;
 }
 
 function readFinite(value: unknown): number | null {
@@ -41,8 +43,10 @@ export function StudioCanvas({
   runs,
   captureReview,
   busy,
+  retryingCapture,
   error,
   onConfirmRegistration,
+  onRetryCapture,
 }: StudioCanvasProps) {
   const currentRun = session.current_run_id ? runs[session.current_run_id] ?? null : null;
   const latestObservedRun = useMemo(
@@ -145,6 +149,20 @@ export function StudioCanvas({
 
       {mode === "registration" && captureReview ? (
         <div className="studio-registration-wrap">
+          <div className="studio-registration-recovery">
+            <p>
+              If the page is blocked, blurred, or overexposed, take another photograph before
+              placing its corners. The drawing will not be plotted again.
+            </p>
+            <button
+              type="button"
+              className="button-secondary"
+              disabled={busy}
+              onClick={() => void onRetryCapture(captureReview.run_id)}
+            >
+              {retryingCapture ? "Retaking photo…" : "Retake photo only"}
+            </button>
+          </div>
           <CaptureReviewEditor
             capture={captureReview.capture}
             review={captureReview.review}

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -407,6 +407,25 @@ it("offers capture-only recovery and never creates a replacement plot run", asyn
   ).toBe(false);
 });
 
+it("retakes a questionable registration frame without replotting", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const pendingRun = buildRun("awaiting_capture_review", buildCapture("pending"));
+  const harness = installStudioMock(buildSession("awaiting_capture_review"), pendingRun);
+  render(<App />);
+
+  expect(await screen.findByText(/manual page registration required/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: /retake photo only/i }));
+
+  await waitFor(() => {
+    expect(harness.requests.some((request) => request.url.endsWith("/capture/retry"))).toBe(true);
+  });
+  expect(
+    harness.requests.some(
+      (request) => request.url === "/api/plot-runs" && request.method === "POST",
+    ),
+  ).toBe(false);
+});
+
 it("renders a true V2 overlay and exposes manual registration when required", async () => {
   const observedCapture = buildCapture("confirmed");
   const completedRun = buildRun("completed", observedCapture);
@@ -425,8 +444,10 @@ it("renders a true V2 overlay and exposes manual registration when required", as
       runs={{ "run-1": completedRun }}
       captureReview={null}
       busy={false}
+      retryingCapture={false}
       error={null}
       onConfirmRegistration={async () => undefined}
+      onRetryCapture={async () => undefined}
     />,
   );
 
@@ -438,18 +459,23 @@ it("renders a true V2 overlay and exposes manual registration when required", as
 
   const pendingCapture = buildCapture("pending");
   const pendingRun = buildRun("awaiting_capture_review", pendingCapture);
+  const retryCapture = vi.fn(async () => undefined);
   rerender(
     <StudioCanvas
       session={buildSession("awaiting_capture_review")}
       runs={{ "run-1": pendingRun }}
       captureReview={{ run_id: "run-1", capture: pendingCapture, review: pendingCapture.review! }}
       busy={false}
+      retryingCapture={false}
       error={null}
       onConfirmRegistration={async () => undefined}
+      onRetryCapture={retryCapture}
     />,
   );
   expect(await screen.findByText(/manual page registration required/i)).toBeInTheDocument();
   expect(screen.getByRole("button", { name: /register page/i })).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: /retake photo only/i }));
+  expect(retryCapture).toHaveBeenCalledWith("run-1");
 });
 
 it("lists session-level work in Gallery and keeps the full operator surface in Controls", async () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,7 @@ The conversation records user guidance, agent plans, interpretations, decisions,
 
 The creative screen posts heartbeats only while visible and on an active authorized session. Closing or hiding it therefore allows the current physical pass to finish but prevents another pass after the backend grace period. Stop-after-pass preserves that same safe boundary. Emergency stop is confirmation-protected and is offered only while the current run is pending or plotting; its copy states that interruption occurs after the current path segment.
 
-Paused capture failures offer a camera-only retake, which cannot create a replacement plot run. Manual registration remains in-context on the canvas. Resume is explicit and rechecks backend readiness. Advisor configuration stays server-side: the browser exposes provider availability and recovery guidance but never accepts, stores, or displays an API key.
+Paused capture failures and questionable frames awaiting manual registration offer a camera-only retake, which cannot create a replacement plot run. Manual registration remains in-context on the canvas after the replacement capture. Resume is explicit and rechecks backend readiness. Advisor configuration stays server-side: the browser exposes provider availability and recovery guidance but never accepts, stores, or displays an API key.
 
 ## Extension Points
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -181,6 +181,7 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Made cumulative intended artwork, the latest registered observation, exact V2 overlay, and in-context manual corner registration the primary visual surface
 - Added a compact typed conversation for plan revisions, queued guidance, agent interpretations, decisions, human-action requests, and consequential machine events
 - Added attended heartbeat behavior, stop-after-pass, confirmation-protected emergency stop, capture-only retake, paused recovery, and accessible live-state treatment to the creative interface
+- Exposed capture-only retake directly beside manual registration so a blocked, blurred, or overexposed frame can be replaced before its corners are confirmed, without replotting
 - Added a session gallery whose preview follows the latest or final camera observation, while retaining machine setup, capture, diagnostics, manual SVG plotting, and legacy session tools under Controls
 - Kept provider secrets entirely backend-configured and preserved the existing polling, PlotRun, capture, registration, hardware-adapter, and V1 compatibility boundaries
 


### PR DESCRIPTION
## Summary

- Adds `Retake photo only` directly beside the in-context manual registration editor.
- Explains that blocked, blurred, or overexposed frames can be replaced without plotting again.
- Reuses the existing capture-retry contract and shared busy/error state.
- Adds an awaiting-review integration test that verifies retry occurs and no PlotRun is created.

Closes #59
Parent: #47

## Checks

- [ ] `make api-test` — not run; no backend changes
- [x] `make web-test` — 46 passed
- [x] `make web-build` — TypeScript and Vite production build passed
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why
- [x] `make web-lint` — ESLint passed with zero warnings
- [x] `git diff --check` — passed

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

The UI invokes only the existing backend capture-retry endpoint. It does not create a run or access camera hardware directly.

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior
- [x] I called out version-sensitive behavior when relevant
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

No new hardware behavior is introduced. The backend remains responsible for preserving prior capture attempts and ensuring retry never replots.
