### PR TITLE
Add runtime OpenAI advisor setup to Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,17 @@ CameraBridge is not assumed to be running just because it is installed. Start `C
 
 Agentic drawing sessions begin with a plan and safe first-pass preview before motion. One explicit approval authorizes an attended sequence of additive plot, capture, and assessment cycles; stop, heartbeat, registration, and recovery boundaries remain backend-enforced. The visual drawing advisor is disabled by default. To enable the OpenAI Responses API adapter, set:
 
+For a temporary local setup, open **Controls → Creative advisor**. The key is submitted to the loopback backend, held only in process memory, cleared from the form after submission, and discarded when the API stops. It is never stored in browser storage or LearnToDraw artifacts.
+
+For startup-time server configuration instead, set:
+
 ```bash
 export LEARN_TO_DRAW_DRAWING_ADVISOR=openai
 export OPENAI_API_KEY=YOUR_API_KEY
 export LEARN_TO_DRAW_OPENAI_MODEL=YOUR_IMAGE_CAPABLE_MODEL
 ```
 
-The configured model must accept image input and structured JSON output. The adapter sends the registered grayscale observation and drawing intent, then accepts only interpretation text and a bounded SVG layer. API credentials are read from the environment and are never persisted in artifacts. For local contract testing without an external request, use `LEARN_TO_DRAW_DRAWING_ADVISOR=mock`.
+The configured model must accept image input and structured JSON output. The adapter sends the registered grayscale observation and drawing intent, then accepts only interpretation text and a bounded SVG layer. Runtime and environment credentials remain server-side and are never persisted in artifacts. For local contract testing without an external request, use `LEARN_TO_DRAW_DRAWING_ADVISOR=mock`.
 
 The implementation uses the official [Responses API](https://platform.openai.com/docs/api-reference/responses/create) contract. Model availability and billing depend on the OpenAI API project associated with the supplied key.
 

--- a/apps/api/src/learn_to_draw_api/api.py
+++ b/apps/api/src/learn_to_draw_api/api.py
@@ -24,7 +24,10 @@ from learn_to_draw_api.services.camera_device_settings import (
     CameraDeviceSettingsStore,
 )
 from learn_to_draw_api.services.hardware import HardwareService
-from learn_to_draw_api.services.drawing_advisor import build_drawing_advisor
+from learn_to_draw_api.services.drawing_advisor import (
+    RuntimeDrawingAdvisor,
+    build_drawing_advisor,
+)
 from learn_to_draw_api.services.drawing_sessions import (
     DrawingSessionService,
     DrawingSessionStore,
@@ -120,11 +123,12 @@ def create_app(
         device_settings_service=device_settings_service,
         workspace_service=workspace_service,
     )
+    drawing_advisor = RuntimeDrawingAdvisor(build_drawing_advisor(app_config))
     drawing_session_service = DrawingSessionService(
         store=DrawingSessionStore(app_config.drawing_sessions_dir),
         plot_workflow_service=plot_workflow_service,
         workspace_service=workspace_service,
-        advisor=build_drawing_advisor(app_config),
+        advisor=drawing_advisor,
     )
 
     @asynccontextmanager
@@ -140,6 +144,7 @@ def create_app(
     app.state.hardware_service = hardware_service
     app.state.plot_workflow_service = plot_workflow_service
     app.state.drawing_session_service = drawing_session_service
+    app.state.drawing_advisor = drawing_advisor
     app.state.plotter_calibration_service = calibration_service
     app.state.plotter_device_settings_service = device_settings_service
     app.state.camera_device_settings_service = camera_settings_service
@@ -156,6 +161,7 @@ def create_app(
             hardware_service,
             plot_workflow_service,
             drawing_session_service,
+            drawing_advisor,
         )
     )
     app.mount(

--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 
 class HardwareError(Exception):
@@ -381,6 +381,18 @@ class DrawingAdvisorStatus(BaseModel):
     available: bool
     model: Optional[str] = None
     message: Optional[str] = None
+
+
+class DrawingAdvisorConfigurationRequest(BaseModel):
+    api_key: SecretStr
+    model: str = Field(min_length=1, max_length=200)
+
+
+class DrawingAdvisorRuntimeStatus(BaseModel):
+    advisor: DrawingAdvisorStatus
+    source: Literal["startup", "runtime"]
+    persistence: Literal["process_memory"] = "process_memory"
+    clears_on_restart: bool = True
 
 
 class DrawingIterationProposal(BaseModel):

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -6,6 +6,8 @@ from learn_to_draw_api.models import (
     CameraCaptureResponse,
     CameraCommandResponse,
     CameraDeviceSelectionRequest,
+    DrawingAdvisorConfigurationRequest,
+    DrawingAdvisorRuntimeStatus,
     DrawingSession,
     DrawingSessionCreateRequest,
     DrawingSessionListResponse,
@@ -38,6 +40,7 @@ from learn_to_draw_api.models import (
     PlotterWorkspaceResponse,
 )
 from learn_to_draw_api.services.hardware import HardwareService
+from learn_to_draw_api.services.drawing_advisor import RuntimeDrawingAdvisor
 from learn_to_draw_api.services.drawing_sessions import DrawingSessionService
 from learn_to_draw_api.services.plot_workflow import PlotWorkflowService
 
@@ -46,12 +49,39 @@ def build_api_router(
     hardware_service: HardwareService,
     plot_workflow_service: PlotWorkflowService,
     drawing_session_service: DrawingSessionService,
+    drawing_advisor: RuntimeDrawingAdvisor,
 ) -> APIRouter:
     router = APIRouter()
 
     @router.get("/api/health", response_model=HealthResponse)
     def get_health() -> HealthResponse:
         return HealthResponse()
+
+    @router.get(
+        "/api/drawing-advisor/configuration",
+        response_model=DrawingAdvisorRuntimeStatus,
+    )
+    def get_drawing_advisor_configuration() -> DrawingAdvisorRuntimeStatus:
+        return drawing_advisor.runtime_status
+
+    @router.post(
+        "/api/drawing-advisor/configuration",
+        response_model=DrawingAdvisorRuntimeStatus,
+    )
+    def post_drawing_advisor_configuration(
+        request: DrawingAdvisorConfigurationRequest,
+    ) -> DrawingAdvisorRuntimeStatus:
+        return drawing_advisor.configure_openai(
+            api_key=request.api_key.get_secret_value(),
+            model=request.model,
+        )
+
+    @router.delete(
+        "/api/drawing-advisor/configuration",
+        response_model=DrawingAdvisorRuntimeStatus,
+    )
+    def delete_drawing_advisor_configuration() -> DrawingAdvisorRuntimeStatus:
+        return drawing_advisor.clear_runtime_configuration()
 
     @router.get("/api/hardware/status", response_model=HardwareStatus)
     def get_hardware_status() -> HardwareStatus:

--- a/apps/api/src/learn_to_draw_api/services/drawing_advisor.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_advisor.py
@@ -4,12 +4,18 @@ from abc import ABC, abstractmethod
 import base64
 from dataclasses import dataclass
 import json
+from threading import RLock
 from typing import Literal, Optional
 
 import httpx
 
 from learn_to_draw_api.config import AppConfig
-from learn_to_draw_api.models import DrawingAdvisorStatus, ServiceUnavailableError
+from learn_to_draw_api.models import (
+    DrawingAdvisorRuntimeStatus,
+    DrawingAdvisorStatus,
+    InvalidArtifactError,
+    ServiceUnavailableError,
+)
 
 
 @dataclass(frozen=True)
@@ -82,6 +88,65 @@ class DrawingAdvisor(ABC):
         prior_interpretations: list[str],
     ) -> DrawingAdviceDraft:
         raise NotImplementedError
+
+
+class RuntimeDrawingAdvisor(DrawingAdvisor):
+    """Thread-safe advisor delegate with an optional process-memory override."""
+
+    def __init__(self, startup_advisor: DrawingAdvisor) -> None:
+        self._startup_advisor = startup_advisor
+        self._active_advisor = startup_advisor
+        self._source: Literal["startup", "runtime"] = "startup"
+        self._lock = RLock()
+
+    @property
+    def status(self) -> DrawingAdvisorStatus:
+        return self._snapshot().status
+
+    @property
+    def runtime_status(self) -> DrawingAdvisorRuntimeStatus:
+        with self._lock:
+            advisor = self._active_advisor
+            source = self._source
+        return DrawingAdvisorRuntimeStatus(advisor=advisor.status, source=source)
+
+    def configure_openai(self, *, api_key: str, model: str) -> DrawingAdvisorRuntimeStatus:
+        normalized_key = api_key.strip()
+        normalized_model = model.strip()
+        if not normalized_key:
+            raise InvalidArtifactError("Enter an OpenAI API key.")
+        if len(normalized_key) > 4096:
+            raise InvalidArtifactError("The OpenAI API key is too long.")
+        if not normalized_model:
+            raise InvalidArtifactError("Enter an OpenAI model.")
+
+        candidate = OpenAIDrawingAdvisor(
+            api_key=normalized_key,
+            model=normalized_model,
+        )
+        with self._lock:
+            self._active_advisor = candidate
+            self._source = "runtime"
+        return self.runtime_status
+
+    def clear_runtime_configuration(self) -> DrawingAdvisorRuntimeStatus:
+        with self._lock:
+            self._active_advisor = self._startup_advisor
+            self._source = "startup"
+        return self.runtime_status
+
+    def plan_initial(self, **kwargs) -> InitialDrawingPlanDraft:
+        return self._snapshot().plan_initial(**kwargs)
+
+    def assess_iteration(self, **kwargs) -> DrawingAssessmentDraft:
+        return self._snapshot().assess_iteration(**kwargs)
+
+    def propose_next_layer(self, **kwargs) -> DrawingAdviceDraft:
+        return self._snapshot().propose_next_layer(**kwargs)
+
+    def _snapshot(self) -> DrawingAdvisor:
+        with self._lock:
+            return self._active_advisor
 
 
 class DisabledDrawingAdvisor(DrawingAdvisor):

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 import cv2
 from fastapi.testclient import TestClient
+import httpx
 import numpy as np
 
 from learn_to_draw_api.adapters.axidraw_models import resolve_axidraw_model_info
@@ -133,6 +134,94 @@ def test_health_and_status_endpoints(tmp_path):
     payload = status.json()
     assert payload["plotter"]["driver"] == "mock-plotter"
     assert payload["camera"]["driver"] == "mock-camera"
+
+
+def test_runtime_openai_advisor_configuration_is_redacted_and_used(tmp_path, monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "output_text": json.dumps(
+                    {
+                        "summary": "Build a loose cluster of varied flowers.",
+                        "paper_strategy": "Use the center and preserve breathing room.",
+                        "completion_intent": "Stop when the field feels lively.",
+                        "svg": (
+                            '<svg xmlns="http://www.w3.org/2000/svg" '
+                            'width="170mm" height="257mm" viewBox="0 0 170 257">'
+                            '<circle cx="85" cy="128" r="10"/></svg>'
+                        ),
+                    }
+                )
+            }
+
+    monkeypatch.setattr(httpx, "post", lambda *_args, **_kwargs: Response())
+    api_key = "sk-test-runtime-secret"
+
+    with create_test_client(tmp_path) as client:
+        startup = client.get("/api/drawing-advisor/configuration")
+        configured = client.post(
+            "/api/drawing-advisor/configuration",
+            json={"api_key": api_key, "model": "vision-model"},
+        )
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "A loose field of flowers"},
+        ).json()
+        planned = wait_for_session_status(
+            client,
+            created["id"],
+            {"awaiting_approval", "failed"},
+        )
+        cleared = client.delete("/api/drawing-advisor/configuration")
+
+    assert startup.json() == {
+        "advisor": {
+            "driver": "disabled",
+            "available": False,
+            "model": None,
+            "message": (
+                "Drawing advisor is disabled. Set LEARN_TO_DRAW_DRAWING_ADVISOR=openai, "
+                "OPENAI_API_KEY, and LEARN_TO_DRAW_OPENAI_MODEL to enable it."
+            ),
+        },
+        "source": "startup",
+        "persistence": "process_memory",
+        "clears_on_restart": True,
+    }
+    assert configured.status_code == 200
+    assert configured.json()["advisor"] == {
+        "driver": "openai",
+        "available": True,
+        "model": "vision-model",
+        "message": None,
+    }
+    assert configured.json()["source"] == "runtime"
+    assert api_key not in configured.text
+    assert planned["status"] == "awaiting_approval"
+    assert planned["advisor"]["driver"] == "openai"
+    assert planned["current_proposal"]["advisor_model"] == "vision-model"
+    assert cleared.json()["advisor"]["driver"] == "disabled"
+    assert cleared.json()["source"] == "startup"
+
+
+def test_invalid_runtime_advisor_configuration_preserves_active_advisor(tmp_path):
+    with create_test_client(
+        tmp_path,
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        invalid = client.post(
+            "/api/drawing-advisor/configuration",
+            json={"api_key": "   ", "model": "vision-model"},
+        )
+        current = client.get("/api/drawing-advisor/configuration")
+
+    assert invalid.status_code == 400
+    assert invalid.json() == {"detail": "Enter an OpenAI API key."}
+    assert current.json()["advisor"]["driver"] == "mock"
+    assert current.json()["source"] == "startup"
 
 
 class CompatOnlyPlotter:

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -3552,6 +3552,73 @@ button {
   margin-bottom: 22px;
 }
 
+.advisor-setup {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  gap: 28px;
+  padding: 24px;
+  margin-bottom: 22px;
+  border: 1px solid rgba(208, 161, 95, 0.34);
+  border-radius: 26px;
+  background: linear-gradient(135deg, rgba(55, 46, 35, 0.94), rgba(28, 27, 25, 0.94));
+  box-shadow: var(--shadow);
+}
+
+.advisor-setup-copy h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2.1rem);
+  letter-spacing: -0.035em;
+}
+
+.advisor-setup-copy > p:not(.eyebrow) {
+  max-width: 62ch;
+  color: var(--text-muted);
+}
+
+.advisor-status {
+  display: grid;
+  gap: 5px;
+  padding: 13px 15px;
+  border-radius: 15px;
+  background: rgba(255, 248, 238, 0.06);
+  color: var(--text-muted);
+}
+
+.advisor-status strong {
+  color: var(--text);
+}
+
+.advisor-setup-form {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.advisor-setup-form .field-group input {
+  border-color: rgba(255, 248, 238, 0.16);
+  background: rgba(10, 10, 9, 0.54);
+  color: var(--text);
+}
+
+.advisor-setup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.advisor-setup-feedback,
+.advisor-setup-error {
+  margin: 0;
+}
+
+.advisor-setup-feedback {
+  color: #b9d9bf;
+}
+
+.advisor-setup-error {
+  color: #ffb7a7;
+}
+
 .controls-section-heading {
   margin-bottom: 18px;
 }
@@ -3587,6 +3654,7 @@ button {
   }
 
   .studio-plan-card,
+  .advisor-setup,
   .controls-section > .machine-setup-layout {
     grid-template-columns: 1fr;
   }

--- a/apps/web/src/features/studio/AdvisorSetupPanel.tsx
+++ b/apps/web/src/features/studio/AdvisorSetupPanel.tsx
@@ -1,0 +1,138 @@
+import { FormEvent, useEffect, useState } from "react";
+
+import {
+  clearDrawingAdvisorConfiguration,
+  configureDrawingAdvisor,
+  fetchDrawingAdvisorConfiguration,
+} from "../../lib/api";
+import type { DrawingAdvisorRuntimeStatus } from "../../types/drawing";
+
+const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
+
+export function AdvisorSetupPanel() {
+  const [status, setStatus] = useState<DrawingAdvisorRuntimeStatus | null>(null);
+  const [apiKey, setApiKey] = useState("");
+  const [model, setModel] = useState(DEFAULT_OPENAI_MODEL);
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchDrawingAdvisorConfiguration()
+      .then((nextStatus) => {
+        if (controller.signal.aborted) return;
+        setStatus(nextStatus);
+        if (nextStatus.advisor.model) setModel(nextStatus.advisor.model);
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(caught instanceof Error ? caught.message : "Unable to load advisor setup.");
+        }
+      });
+    return () => controller.abort();
+  }, []);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy(true);
+    setError(null);
+    setFeedback(null);
+    try {
+      const nextStatus = await configureDrawingAdvisor(apiKey, model);
+      setStatus(nextStatus);
+      setApiKey("");
+      setFeedback(
+        "OpenAI advisor loaded in backend memory. The first drawing plan will verify the key and model with OpenAI.",
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to configure the advisor.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clearConfiguration() {
+    setBusy(true);
+    setError(null);
+    setFeedback(null);
+    try {
+      const nextStatus = await clearDrawingAdvisorConfiguration();
+      setStatus(nextStatus);
+      setApiKey("");
+      setModel(nextStatus.advisor.model ?? DEFAULT_OPENAI_MODEL);
+      setFeedback("Runtime OpenAI configuration cleared.");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to clear the advisor setup.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const isRuntimeOpenAI = status?.source === "runtime";
+  const statusLabel = status === null
+    ? "Checking advisor…"
+    : status.advisor.available
+      ? `${status.advisor.driver === "openai" ? "OpenAI" : "Creative"} advisor ready`
+      : "Creative advisor unavailable";
+
+  return (
+    <section className="advisor-setup" aria-labelledby="advisor-setup-title">
+      <div className="advisor-setup-copy">
+        <p className="eyebrow">Creative advisor</p>
+        <h2 id="advisor-setup-title">Generate and assess drawings with OpenAI</h2>
+        <p>
+          Your key is sent only to this localhost backend and held in process memory. It is never
+          saved to browser storage or LearnToDraw artifacts, and it disappears when the API stops.
+        </p>
+        <div className="advisor-status" aria-live="polite">
+          <strong>{statusLabel}</strong>
+          {status?.advisor.model ? <span>Model: {status.advisor.model}</span> : null}
+          {status?.advisor.message && !status.advisor.available
+            ? <span>{status.advisor.message}</span>
+            : null}
+        </div>
+      </div>
+
+      <form className="advisor-setup-form" onSubmit={(event) => void submit(event)}>
+        <label className="field-group">
+          <span>OpenAI API key</span>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+            autoComplete="new-password"
+            spellCheck={false}
+            required
+            disabled={busy}
+            placeholder={isRuntimeOpenAI ? "Enter a replacement key" : "sk-…"}
+          />
+        </label>
+        <label className="field-group">
+          <span>Model</span>
+          <input
+            type="text"
+            value={model}
+            onChange={(event) => setModel(event.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            required
+            disabled={busy}
+          />
+        </label>
+        <div className="advisor-setup-actions">
+          <button type="submit" disabled={busy || apiKey.trim().length === 0 || model.trim().length === 0}>
+            {busy ? "Saving…" : isRuntimeOpenAI ? "Replace runtime key" : "Enable OpenAI advisor"}
+          </button>
+          {isRuntimeOpenAI ? (
+            <button type="button" className="button-secondary" disabled={busy} onClick={() => void clearConfiguration()}>
+              Clear runtime key
+            </button>
+          ) : null}
+        </div>
+        {feedback ? <p className="advisor-setup-feedback" role="status">{feedback}</p> : null}
+        {error ? <p className="advisor-setup-error" role="alert">{error}</p> : null}
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/features/studio/AdvisorSetupPanel.tsx
+++ b/apps/web/src/features/studio/AdvisorSetupPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../lib/api";
 import type { DrawingAdvisorRuntimeStatus } from "../../types/drawing";
 
-const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
+const DEFAULT_OPENAI_MODEL = "gpt-5.6-terra";
 
 export function AdvisorSetupPanel() {
   const [status, setStatus] = useState<DrawingAdvisorRuntimeStatus | null>(null);

--- a/apps/web/src/features/studio/ControlsPage.tsx
+++ b/apps/web/src/features/studio/ControlsPage.tsx
@@ -4,6 +4,7 @@ import { MachineSetupPanel } from "../hardware/MachineSetupPanel";
 import { useHardwareDashboard } from "../hardware/useHardwareDashboard";
 import { PlotWorkflowPanel } from "../plot-workflow/PlotWorkflowPanel";
 import { usePlotWorkflow } from "../plot-workflow/usePlotWorkflow";
+import { AdvisorSetupPanel } from "./AdvisorSetupPanel";
 
 export function ControlsPage() {
   const hardware = useHardwareDashboard();
@@ -45,6 +46,8 @@ export function ControlsPage() {
       </header>
 
       {hardware.error ? <div className="banner" role="alert">{hardware.error}</div> : null}
+
+      <AdvisorSetupPanel />
 
       <section className="controls-section">
         <div className="controls-section-heading">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,6 +20,7 @@ import type {
 } from "../types/plotting";
 import type { HelperStatus } from "../types/helper";
 import type {
+  DrawingAdvisorRuntimeStatus,
   DrawingSession,
   DrawingSessionListResponse,
   LatestDrawingSessionResponse,
@@ -134,6 +135,24 @@ async function requestJson<T>(
 
 export function fetchHardwareStatus() {
   return requestJson<HardwareStatus>("/api/hardware/status");
+}
+
+export function fetchDrawingAdvisorConfiguration() {
+  return requestJson<DrawingAdvisorRuntimeStatus>("/api/drawing-advisor/configuration");
+}
+
+export function configureDrawingAdvisor(apiKey: string, model: string) {
+  return requestJson<DrawingAdvisorRuntimeStatus>("/api/drawing-advisor/configuration", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ api_key: apiKey, model }),
+  });
+}
+
+export function clearDrawingAdvisorConfiguration() {
+  return requestJson<DrawingAdvisorRuntimeStatus>("/api/drawing-advisor/configuration", {
+    method: "DELETE",
+  });
 }
 
 export function fetchLatestCapture() {

--- a/apps/web/src/types/drawing.ts
+++ b/apps/web/src/types/drawing.ts
@@ -19,6 +19,13 @@ export interface DrawingAdvisorStatus {
   message: string | null;
 }
 
+export interface DrawingAdvisorRuntimeStatus {
+  advisor: DrawingAdvisorStatus;
+  source: "startup" | "runtime";
+  persistence: "process_memory";
+  clears_on_restart: boolean;
+}
+
 export interface DrawingIterationProposal {
   interpretation: string;
   asset: PlotAsset;

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -511,6 +511,46 @@ it("lists session-level work in Gallery and keeps the full operator surface in C
   expect(screen.getByLabelText(/upload svg/i)).toHaveAttribute("type", "file");
 });
 
+it("configures the OpenAI advisor in backend memory and clears the key field", async () => {
+  window.history.replaceState({}, "", "/controls");
+  const controlsHarness = createHardwareDashboardHarness({
+    advisorConfiguration: {
+      advisor: {
+        driver: "disabled",
+        available: false,
+        model: null,
+        message: "Drawing advisor is disabled on the local backend.",
+      },
+      source: "startup",
+      persistence: "process_memory",
+      clears_on_restart: true,
+    },
+  });
+  installHardwareDashboardFetchMock(controlsHarness);
+  render(<App />);
+
+  const apiKey = "sk-test-browser-secret";
+  const keyInput = await screen.findByLabelText(/openai api key/i);
+  const modelInput = screen.getByLabelText(/^model$/i);
+  fireEvent.change(keyInput, { target: { value: apiKey } });
+  fireEvent.change(modelInput, { target: { value: "gpt-5.4-mini" } });
+  fireEvent.click(screen.getByRole("button", { name: /enable openai advisor/i }));
+
+  await waitFor(() => {
+    expect(controlsHarness.advisorConfigurationRequests).toEqual([
+      { api_key: apiKey, model: "gpt-5.4-mini" },
+    ]);
+  });
+  expect(keyInput).toHaveValue("");
+  expect(screen.getByText(/loaded in backend memory/i)).toBeInTheDocument();
+  expect(screen.queryByDisplayValue(apiKey)).not.toBeInTheDocument();
+  expect(window.localStorage.getItem("OPENAI_API_KEY")).toBeNull();
+
+  fireEvent.click(screen.getByRole("button", { name: /clear runtime key/i }));
+  await waitFor(() => expect(controlsHarness.advisorConfigurationClears).toBe(1));
+  expect(screen.getByText(/runtime openai configuration cleared/i)).toBeInTheDocument();
+});
+
 it("surfaces provider-disabled recovery without exposing a browser key field", async () => {
   window.history.replaceState({}, "", "/sessions/session-1");
   const paused = buildSession("paused", {

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -533,12 +533,12 @@ it("configures the OpenAI advisor in backend memory and clears the key field", a
   const keyInput = await screen.findByLabelText(/openai api key/i);
   const modelInput = screen.getByLabelText(/^model$/i);
   fireEvent.change(keyInput, { target: { value: apiKey } });
-  fireEvent.change(modelInput, { target: { value: "gpt-5.4-mini" } });
+  fireEvent.change(modelInput, { target: { value: "gpt-5.6-terra" } });
   fireEvent.click(screen.getByRole("button", { name: /enable openai advisor/i }));
 
   await waitFor(() => {
     expect(controlsHarness.advisorConfigurationRequests).toEqual([
-      { api_key: apiKey, model: "gpt-5.4-mini" },
+      { api_key: apiKey, model: "gpt-5.6-terra" },
     ]);
   });
   expect(keyInput).toHaveValue("");

--- a/apps/web/tests/hardwareDashboardTestUtils.ts
+++ b/apps/web/tests/hardwareDashboardTestUtils.ts
@@ -14,6 +14,7 @@ import type {
   PlotterWorkspace,
 } from "../src/types/hardware";
 import type { HelperStatus } from "../src/types/helper";
+import type { DrawingAdvisorRuntimeStatus } from "../src/types/drawing";
 import type { PlotRun, PlotRunSummary } from "../src/types/plotting";
 
 export const defaultHardwareStatus: HardwareStatus = {
@@ -218,6 +219,9 @@ export interface HardwareDashboardHarness {
     action: "confirm";
     corners: NormalizationCorners;
   }>;
+  advisorConfiguration: DrawingAdvisorRuntimeStatus;
+  advisorConfigurationRequests: Array<{ api_key: string; model: string }>;
+  advisorConfigurationClears: number;
 }
 
 function jsonResponse(body: unknown) {
@@ -280,6 +284,19 @@ export function createHardwareDashboardHarness(
     safeBoundsRequests: [],
     workspaceRequests: [],
     captureReviewActions: [],
+    advisorConfiguration: {
+      advisor: {
+        driver: "mock",
+        available: true,
+        model: "mock-advisor-v1",
+        message: null,
+      },
+      source: "startup",
+      persistence: "process_memory",
+      clears_on_restart: true,
+    },
+    advisorConfigurationRequests: [],
+    advisorConfigurationClears: 0,
     ...overrides,
   };
 }
@@ -396,6 +413,41 @@ export function installHardwareDashboardFetchMock(
 
       if (url === "/api/hardware/status") {
         return jsonResponse(harness.currentHardwareStatus);
+      }
+
+      if (url === "/api/drawing-advisor/configuration") {
+        if (method === "POST") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as {
+            api_key: string;
+            model: string;
+          };
+          harness.advisorConfigurationRequests.push(body);
+          harness.advisorConfiguration = {
+            advisor: {
+              driver: "openai",
+              available: true,
+              model: body.model,
+              message: null,
+            },
+            source: "runtime",
+            persistence: "process_memory",
+            clears_on_restart: true,
+          };
+        } else if (method === "DELETE") {
+          harness.advisorConfigurationClears += 1;
+          harness.advisorConfiguration = {
+            advisor: {
+              driver: "disabled",
+              available: false,
+              model: null,
+              message: "Drawing advisor is disabled on the local backend.",
+            },
+            source: "startup",
+            persistence: "process_memory",
+            clears_on_restart: true,
+          };
+        }
+        return jsonResponse(harness.advisorConfiguration);
       }
 
       if (url === "/api/captures/latest") {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,7 +144,9 @@ The conversation records user guidance, agent plans, interpretations, decisions,
 
 The creative screen posts heartbeats only while visible and on an active authorized session. Closing or hiding it therefore allows the current physical pass to finish but prevents another pass after the backend grace period. Stop-after-pass preserves that same safe boundary. Emergency stop is confirmation-protected and is offered only while the current run is pending or plotting; its copy states that interruption occurs after the current path segment.
 
-Paused capture failures and questionable frames awaiting manual registration offer a camera-only retake, which cannot create a replacement plot run. Manual registration remains in-context on the canvas after the replacement capture. Resume is explicit and rechecks backend readiness. Advisor configuration stays server-side: the browser exposes provider availability and recovery guidance but never accepts, stores, or displays an API key.
+Paused capture failures and questionable frames awaiting manual registration offer a camera-only retake, which cannot create a replacement plot run. Manual registration remains in-context on the canvas after the replacement capture. Resume is explicit and rechecks backend readiness.
+
+Advisor credentials remain a backend-owned secret. Controls may submit an API key to the loopback-only configuration endpoint, but the frontend clears the password field after success and never writes the key to browser storage, artifacts, URLs, or responses. A thread-safe advisor delegate swaps the active provider atomically for planning and assessment work already owned by the drawing-session service. Runtime configuration exists only in backend process memory and clear/restart restores the startup environment configuration.
 
 ## Extension Points
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -185,4 +185,11 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Added a session gallery whose preview follows the latest or final camera observation, while retaining machine setup, capture, diagnostics, manual SVG plotting, and legacy session tools under Controls
 - Kept provider secrets entirely backend-configured and preserved the existing polling, PlotRun, capture, registration, hardware-adapter, and V1 compatibility boundaries
 
+## Runtime Drawing Advisor Setup Slice
+
+- Added a Controls form that submits an OpenAI key and model to the localhost backend without using browser storage or persisted artifacts
+- Added a thread-safe runtime advisor delegate so existing drawing-session orchestration uses the configured provider without restarting the API
+- Kept runtime credentials only in backend process memory, returned redacted status only, and made clear/restart restore startup configuration
+- Left environment-based advisor configuration available for operators who prefer startup-time setup
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Adds a Controls panel for submitting an OpenAI API key and image-capable model to the localhost backend.
- Adds a thread-safe runtime advisor delegate so existing drawing-session orchestration sees the new provider without an API restart.
- Keeps the secret out of responses, browser storage, artifacts, URLs, and git; runtime configuration clears on API restart or explicit removal.
- Updates the architecture, history, and setup documentation for the runtime-only credential boundary.

The slice keeps hardware behavior unchanged and gives the prompt-first studio a UI-native setup path. It implements the expanded plan recorded on #61.

Closes #61
Related to #47

## Checks

- [x] `make api-test` — 145 passed
- [x] `make api-lint` — passed
- [x] `make web-test` — 47 passed
- [x] `make web-lint` — passed
- [x] `make web-build` — passed
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why — none skipped

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior — no hardware behavior changed
- [x] I called out version-sensitive behavior when relevant — `gpt-5.6-terra` is the current UI default and remains editable
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

The API must remain loopback-bound: the credential is posted over localhost HTTP, retained only in backend process memory, and never persisted. Configuration does not call OpenAI immediately; the first drawing plan verifies key validity and model access, and provider failures use the existing recoverable session state.

## Live verification

- Configured `gpt-5.6-terra` through Controls; the status response was redacted and reported process-memory runtime configuration.
- Created a prompt-only pelican-on-a-bicycle session against the real OpenAI Responses API.
- Planning completed as `awaiting_approval` with a validated generated SVG and no PlotRun, approval, or hardware motion.
- GitHub CI: API and web jobs passed.
