### PR TITLE
Fix pre-approval studio paper orientation

### DIFF
--- a/apps/web/src/features/studio/SessionStudio.tsx
+++ b/apps/web/src/features/studio/SessionStudio.tsx
@@ -133,6 +133,7 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
           <StudioCanvas
             session={session}
             runs={controller.runs}
+            pageSize={controller.plotterWorkspace?.page_size_mm}
             captureReview={controller.captureReview}
             busy={
               controller.busyAction === "register" ||

--- a/apps/web/src/features/studio/StudioCanvas.tsx
+++ b/apps/web/src/features/studio/StudioCanvas.tsx
@@ -11,6 +11,7 @@ type CanvasMode = "intended" | "observed" | "overlay" | "registration";
 interface StudioCanvasProps {
   session: DrawingSession;
   runs: Record<string, PlotRun>;
+  pageSize?: { width_mm: number; height_mm: number } | null;
   captureReview: PlotRunCaptureReviewPayload | null;
   busy: boolean;
   retryingCapture: boolean;
@@ -23,7 +24,10 @@ function readFinite(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function pageAspectFor(run: PlotRun | null) {
+function pageAspectFor(
+  run: PlotRun | null,
+  pageSize?: { width_mm: number; height_mm: number } | null,
+) {
   const capture = run?.observed_result?.capture ?? run?.capture ?? null;
   const frame = capture?.normalized?.metadata.frame;
   if (frame && frame.page_width_mm > 0 && frame.page_height_mm > 0) {
@@ -35,12 +39,16 @@ function pageAspectFor(run: PlotRun | null) {
     const height = readFinite((preparation as Record<string, unknown>).page_height_mm);
     if (width && height && width > 0 && height > 0) return width / height;
   }
+  if (pageSize && pageSize.width_mm > 0 && pageSize.height_mm > 0) {
+    return pageSize.width_mm / pageSize.height_mm;
+  }
   return 210 / 297;
 }
 
 export function StudioCanvas({
   session,
   runs,
+  pageSize = null,
   captureReview,
   busy,
   retryingCapture,
@@ -92,7 +100,7 @@ export function StudioCanvas({
     }
   }, [captureReview, mode, observation, overlayAvailable]);
 
-  const aspect = pageAspectFor(currentRun ?? latestObservedRun);
+  const aspect = pageAspectFor(currentRun ?? latestObservedRun, pageSize);
   const hasIntended = intendedUrls.length > 0 || Boolean(proposalUrl);
 
   return (

--- a/apps/web/src/features/studio/useStudioSession.ts
+++ b/apps/web/src/features/studio/useStudioSession.ts
@@ -5,6 +5,7 @@ import {
   confirmPlotRunCaptureReview,
   fetchDrawingSession,
   fetchHardwareStatus,
+  fetchPlotterWorkspace,
   fetchPlotRun,
   fetchPlotRunCaptureReview,
   heartbeatDrawingSession,
@@ -14,7 +15,11 @@ import {
   stopDrawingSession,
 } from "../../lib/api";
 import type { DrawingSession } from "../../types/drawing";
-import type { HardwareStatus, NormalizationCorners } from "../../types/hardware";
+import type {
+  HardwareStatus,
+  NormalizationCorners,
+  PlotterWorkspace,
+} from "../../types/hardware";
 import type { PlotRun, PlotRunCaptureReviewPayload } from "../../types/plotting";
 
 const ACTIVE_SESSION_STATUSES = new Set([
@@ -48,6 +53,7 @@ export function useStudioSession(sessionId: string) {
   const [runs, setRuns] = useState<Record<string, PlotRun>>({});
   const [captureReview, setCaptureReview] = useState<PlotRunCaptureReviewPayload | null>(null);
   const [hardwareStatus, setHardwareStatus] = useState<HardwareStatus | null>(null);
+  const [plotterWorkspace, setPlotterWorkspace] = useState<PlotterWorkspace | null>(null);
   const [loading, setLoading] = useState(true);
   const [busyAction, setBusyAction] = useState<StudioAction>(null);
   const [error, setError] = useState<string | null>(null);
@@ -112,6 +118,13 @@ export function useStudioSession(sessionId: string) {
           statusError instanceof Error ? statusError.message : "Hardware status is unavailable.",
         );
       }
+    }
+
+    try {
+      const workspace = await fetchPlotterWorkspace();
+      if (mountedRef.current) setPlotterWorkspace(workspace);
+    } catch {
+      if (mountedRef.current) setPlotterWorkspace(null);
     }
   }
 
@@ -211,6 +224,7 @@ export function useStudioSession(sessionId: string) {
     runs,
     captureReview,
     hardwareStatus,
+    plotterWorkspace,
     hardwareError,
     loading,
     busyAction,

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -241,6 +241,18 @@ function installStudioMock(
     requests.push({ method, url, body: typeof init?.body === "string" ? init.body : undefined });
 
     if (url === "/api/hardware/status") return Response.json(defaultAxiDrawHardwareStatus);
+    if (url === "/api/plotter/workspace") {
+      return Response.json({
+        plotter_bounds_mm: { width_mm: 289.974, height_mm: 207.932 },
+        page_size_mm: { width_mm: 279.4, height_mm: 215.9 },
+        margins_mm: { left_mm: 10, top_mm: 10, right_mm: 10, bottom_mm: 10 },
+        drawable_area_mm: { width_mm: 259.4, height_mm: 195.9 },
+        updated_at: now,
+        source: "persisted",
+        is_valid: true,
+        validation_error: null,
+      });
+    }
     if (url === `/api/drawing-sessions/${currentSession.id}` && method === "GET") {
       return Response.json(currentSession);
     }
@@ -424,6 +436,21 @@ it("retakes a questionable registration frame without replotting", async () => {
       (request) => request.url === "/api/plot-runs" && request.method === "POST",
     ),
   ).toBe(false);
+});
+
+it("uses the configured landscape page orientation before a plot run exists", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  installStudioMock(buildSession("awaiting_approval"));
+  const { container } = render(<App />);
+
+  expect(
+    await screen.findByRole("heading", { name: /what we intend to draw/i }),
+  ).toBeInTheDocument();
+  await waitFor(() => {
+    const paper = container.querySelector<HTMLElement>(".studio-paper");
+    expect(paper).not.toBeNull();
+    expect(Number(paper?.style.aspectRatio)).toBeCloseTo(279.4 / 215.9);
+  });
 });
 
 it("renders a true V2 overlay and exposes manual registration when required", async () => {

--- a/docs/history.md
+++ b/docs/history.md
@@ -192,4 +192,9 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Kept runtime credentials only in backend process memory, returned redacted status only, and made clear/restart restore startup configuration
 - Left environment-based advisor configuration available for operators who prefer startup-time setup
 
+## Pre-Approval Preview Orientation Fix
+
+- Made the session studio use the backend-owned workspace page dimensions before a PlotRun exists, so landscape first-pass proposals render in a landscape paper frame
+- Kept run preparation and registered-capture dimensions authoritative after plotting, with the existing A4 fallback retained when workspace data is unavailable
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Uses the backend workspace page dimensions for the studio paper frame before a PlotRun exists.
- Keeps run preparation and registered-capture dimensions higher priority after plotting.
- Retains the existing A4 fallback when workspace data cannot be loaded.
- Adds a regression test for a US Letter landscape session awaiting first approval.

The generated SVG and backend workspace were already landscape; this fixes the portrait-only presentation fallback identified in #63. No plotting, capture, registration, artifact, or hardware behavior changes.

Closes #63

## Checks

- [ ] `make api-test` — not run; frontend-only state/rendering fix with no backend changes
- [x] `make web-test` — 48 passed
- [x] `make web-lint` — passed
- [x] `make web-build` — passed
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior — none; no hardware behavior changed
- [x] I called out version-sensitive behavior when relevant — none
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice
