### PR TITLE
Show live creative session progress

### DIFF
--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -2949,6 +2949,141 @@ button {
   gap: 8px;
 }
 
+.studio-progress {
+  --progress-tone: var(--accent);
+  margin-bottom: 18px;
+  padding: clamp(18px, 2.4vw, 26px);
+  display: grid;
+  grid-template-columns: minmax(260px, 0.72fr) minmax(480px, 1fr);
+  align-items: end;
+  gap: 28px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--progress-tone) 34%, var(--border));
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--progress-tone) 12%, transparent), transparent 44%),
+    rgba(34, 32, 29, 0.88);
+  box-shadow: var(--shadow);
+}
+
+.studio-progress[data-tone="attention"] {
+  --progress-tone: #e9b767;
+}
+
+.studio-progress[data-tone="complete"] {
+  --progress-tone: #8ac69a;
+}
+
+.studio-progress[data-tone="failed"] {
+  --progress-tone: #ee8c78;
+}
+
+.studio-progress-copy h2 {
+  margin: 7px 0 0;
+  font-size: clamp(1.4rem, 2.4vw, 2.15rem);
+  line-height: 1.04;
+  letter-spacing: -0.035em;
+}
+
+.studio-progress-copy p {
+  max-width: 64ch;
+  margin: 9px 0 0;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.studio-progress-now {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: color-mix(in srgb, var(--progress-tone) 78%, white);
+  font-size: 0.73rem;
+  font-weight: 800;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.studio-progress-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--progress-tone);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--progress-tone) 12%, transparent);
+}
+
+.studio-progress[data-tone="active"] .studio-progress-pulse {
+  animation: studio-progress-breathe 1.8s ease-in-out infinite;
+}
+
+@keyframes studio-progress-breathe {
+  50% { box-shadow: 0 0 0 9px color-mix(in srgb, var(--progress-tone) 3%, transparent); }
+}
+
+.studio-progress-steps {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  list-style: none;
+}
+
+.studio-progress-step {
+  position: relative;
+  min-width: 0;
+  display: grid;
+  gap: 9px;
+  color: #777168;
+  font-size: clamp(0.65rem, 1vw, 0.76rem);
+  font-weight: 750;
+  letter-spacing: 0.025em;
+}
+
+.studio-progress-step:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  top: 5px;
+  left: 12px;
+  width: calc(100% - 12px);
+  height: 1px;
+  background: var(--border);
+}
+
+.studio-progress-step-mark {
+  position: relative;
+  z-index: 1;
+  width: 11px;
+  height: 11px;
+  border: 2px solid #59554e;
+  border-radius: 50%;
+  background: #22201d;
+}
+
+.studio-progress-step[data-state="complete"] {
+  color: #b9b0a4;
+}
+
+.studio-progress-step[data-state="complete"]::after {
+  background: color-mix(in srgb, var(--progress-tone) 45%, var(--border));
+}
+
+.studio-progress-step[data-state="complete"] .studio-progress-step-mark {
+  border-color: color-mix(in srgb, var(--progress-tone) 65%, #f5eee4);
+  background: color-mix(in srgb, var(--progress-tone) 68%, #201e1b);
+}
+
+.studio-progress-step[data-state="active"],
+.studio-progress-step[data-state="attention"] {
+  color: #f3eadf;
+}
+
+.studio-progress-step[data-state="active"] .studio-progress-step-mark,
+.studio-progress-step[data-state="attention"] .studio-progress-step-mark {
+  border-color: #f8e2bd;
+  background: var(--progress-tone);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--progress-tone) 12%, transparent);
+}
+
 .studio-attention-banner {
   margin: 0 0 18px;
 }
@@ -3107,7 +3242,8 @@ button {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .studio-thinking-mark { animation: none; }
+  .studio-thinking-mark,
+  .studio-progress-pulse { animation: none; }
 }
 
 .studio-opacity-control {
@@ -3643,6 +3779,11 @@ button {
     grid-template-columns: 1fr;
   }
 
+  .studio-progress {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
   .creative-readiness {
     order: -1;
     justify-items: start;
@@ -3709,6 +3850,19 @@ button {
   .studio-complete-actions,
   .controls-heading .readiness-bar {
     justify-content: flex-start;
+  }
+
+  .studio-progress {
+    padding: 18px;
+    gap: 22px;
+  }
+
+  .studio-progress-steps {
+    overflow-x: auto;
+  }
+
+  .studio-progress-step {
+    min-width: 82px;
   }
 
   .studio-paper-stage {

--- a/apps/web/src/features/studio/SessionStudio.tsx
+++ b/apps/web/src/features/studio/SessionStudio.tsx
@@ -4,6 +4,7 @@ import { StatusPill } from "../../components/StatusPill";
 import type { DrawingSessionStatus } from "../../types/drawing";
 import { StudioCanvas } from "./StudioCanvas";
 import { StudioConversation } from "./StudioConversation";
+import { StudioProgressPanel } from "./StudioProgressPanel";
 import { useStudioSession } from "./useStudioSession";
 
 const STATUS_LABELS: Record<DrawingSessionStatus, string> = {
@@ -106,9 +107,7 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
         </div>
       </header>
 
-      <div className="sr-only" role="status" aria-live="polite">
-        {STATUS_LABELS[session.status]}. Pass {session.pass_count}.
-      </div>
+      <StudioProgressPanel session={session} run={currentRun} />
 
       {controller.hardwareError ? (
         <div className="studio-attention-banner" role="status">

--- a/apps/web/src/features/studio/StudioProgressPanel.tsx
+++ b/apps/web/src/features/studio/StudioProgressPanel.tsx
@@ -1,0 +1,56 @@
+import type { DrawingSession } from "../../types/drawing";
+import type { PlotRun } from "../../types/plotting";
+import { deriveStudioProgress } from "./studioProgress";
+
+export function StudioProgressPanel({
+  session,
+  run,
+}: {
+  session: DrawingSession;
+  run: PlotRun | null;
+}) {
+  const progress = deriveStudioProgress(session, run);
+
+  return (
+    <section
+      className="studio-progress"
+      data-tone={progress.tone}
+      aria-labelledby="studio-progress-title"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div className="studio-progress-copy">
+        <div className="studio-progress-now">
+          <span className="studio-progress-pulse" aria-hidden="true" />
+          <span>Right now</span>
+          <span aria-hidden="true">·</span>
+          <span>{progress.passLabel}</span>
+        </div>
+        <h2 id="studio-progress-title">{progress.title}</h2>
+        <p>{progress.detail}</p>
+      </div>
+      <ol className="studio-progress-steps" aria-label="Drawing cycle">
+        {progress.steps.map((step) => (
+          <li
+            key={step.id}
+            className="studio-progress-step"
+            data-state={step.state}
+            aria-current={step.state === "active" || step.state === "attention" ? "step" : undefined}
+          >
+            <span className="studio-progress-step-mark" aria-hidden="true" />
+            <span>{step.label}</span>
+            <span className="sr-only">
+              {step.state === "complete"
+                ? " complete"
+                : step.state === "attention"
+                  ? " needs attention"
+                  : step.state === "active"
+                    ? " in progress"
+                    : " pending"}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/src/features/studio/studioProgress.ts
+++ b/apps/web/src/features/studio/studioProgress.ts
@@ -1,0 +1,232 @@
+import type { DrawingSession } from "../../types/drawing";
+import type { PlotRun } from "../../types/plotting";
+
+export type StudioProgressStepId =
+  | "plan"
+  | "draw"
+  | "photograph"
+  | "register"
+  | "reflect";
+
+export type StudioProgressStepState = "pending" | "active" | "complete" | "attention";
+
+export interface StudioProgressStep {
+  id: StudioProgressStepId;
+  label: string;
+  state: StudioProgressStepState;
+}
+
+export interface StudioProgressModel {
+  title: string;
+  detail: string;
+  passLabel: string;
+  tone: "active" | "attention" | "complete" | "failed";
+  steps: StudioProgressStep[];
+}
+
+const STEP_LABELS: Array<{ id: StudioProgressStepId; label: string }> = [
+  { id: "plan", label: "Plan" },
+  { id: "draw", label: "Draw" },
+  { id: "photograph", label: "Photograph" },
+  { id: "register", label: "Register" },
+  { id: "reflect", label: "Reflect" },
+];
+
+function passNumber(session: DrawingSession): number {
+  const currentIteration = session.current_run_id
+    ? session.iterations.find((iteration) => iteration.run_id === session.current_run_id)
+    : null;
+  return currentIteration?.number ?? Math.max(1, session.pass_count);
+}
+
+function inferRunStep(run: PlotRun | null): StudioProgressStepId {
+  if (!run) return "draw";
+  if (run.status === "awaiting_capture_review") return "register";
+  if (run.status === "capturing" || run.stage_states.capture.status === "in_progress") {
+    return "photograph";
+  }
+  if (
+    run.status === "pending" ||
+    run.status === "plotting" ||
+    run.status === "stopping" ||
+    run.stage_states.prepare.status === "in_progress" ||
+    run.stage_states.plot.status === "in_progress"
+  ) {
+    return "draw";
+  }
+  return "reflect";
+}
+
+function stepsFor(
+  activeStep: StudioProgressStepId,
+  state: "active" | "attention" = "active",
+  allComplete = false,
+): StudioProgressStep[] {
+  const activeIndex = STEP_LABELS.findIndex((step) => step.id === activeStep);
+  return STEP_LABELS.map((step, index) => ({
+    ...step,
+    state: allComplete
+      ? "complete"
+      : index < activeIndex
+        ? "complete"
+        : index === activeIndex
+          ? state
+          : "pending",
+  }));
+}
+
+function activeRunModel(session: DrawingSession, run: PlotRun | null): StudioProgressModel {
+  const number = passNumber(session);
+  if (session.assessing_run_id) {
+    return {
+      title: `Looking at pass ${number}`,
+      detail:
+        "The advisor is studying the registered photograph and deciding whether another layer would improve the drawing.",
+      passLabel: `Pass ${number}`,
+      tone: "active",
+      steps: stepsFor("reflect"),
+    };
+  }
+  if (!run) {
+    return {
+      title: `Preparing pass ${number}`,
+      detail: "The studio is creating the next safe physical action. The plotter has not started this pass yet.",
+      passLabel: `Pass ${number}`,
+      tone: "active",
+      steps: stepsFor("draw"),
+    };
+  }
+  if (run.status === "capturing" || run.stage_states.capture.status === "in_progress") {
+    return {
+      title: `Photographing pass ${number}`,
+      detail: "The marks are down. The camera is recording the sheet so the advisor can see what actually happened.",
+      passLabel: `Pass ${number}`,
+      tone: "active",
+      steps: stepsFor("photograph"),
+    };
+  }
+  if (run.status === "pending" || run.stage_states.prepare.status === "in_progress") {
+    return {
+      title: `Preparing pass ${number}`,
+      detail: "The drawing layer is being checked and prepared before the plotter begins moving.",
+      passLabel: `Pass ${number}`,
+      tone: "active",
+      steps: stepsFor("draw"),
+    };
+  }
+  if (run.status === "plotting" || run.stage_states.plot.status === "in_progress") {
+    return {
+      title: `Drawing pass ${number}`,
+      detail: "The plotter is adding this layer to the sheet. Guidance sent now will shape the next decision.",
+      passLabel: `Pass ${number}`,
+      tone: "active",
+      steps: stepsFor("draw"),
+    };
+  }
+  return {
+    title: `Preparing to review pass ${number}`,
+    detail: "The observation is ready. The studio is handing it to the advisor for the next creative decision.",
+    passLabel: `Pass ${number}`,
+    tone: "active",
+    steps: stepsFor("reflect"),
+  };
+}
+
+export function deriveStudioProgress(
+  session: DrawingSession,
+  run: PlotRun | null,
+): StudioProgressModel {
+  const number = passNumber(session);
+  const passLabel = `Pass ${number}`;
+
+  if (session.status === "planning") {
+    return {
+      title: "Planning the first pass",
+      detail: "The advisor is turning your idea into a safe drawing plan and preview. Nothing will move yet.",
+      passLabel,
+      tone: "active",
+      steps: stepsFor("plan"),
+    };
+  }
+  if (session.status === "awaiting_approval") {
+    return {
+      title: "Preview ready for approval",
+      detail: "Review the plan and first-pass artwork. The plotter remains still until you approve.",
+      passLabel,
+      tone: "attention",
+      steps: stepsFor("plan", "attention"),
+    };
+  }
+  if (session.status === "awaiting_capture_review") {
+    return {
+      title: `Page registration needed for pass ${number}`,
+      detail: "Place the four corner markers on the physical sheet, or retake the photo, before the advisor continues.",
+      passLabel,
+      tone: "attention",
+      steps: stepsFor("register", "attention"),
+    };
+  }
+  if (session.status === "stopping") {
+    const emergencyStopInProgress = run?.status === "stopping";
+    return {
+      title: emergencyStopInProgress
+        ? "Stopping safely"
+        : `Finishing pass ${number}, then stopping`,
+      detail: emergencyStopInProgress
+        ? "The plotter will pause after its current path segment. No photograph or later pass will begin."
+        : "The current pass and its observation will finish, but the studio will not begin another layer.",
+      passLabel,
+      tone: "attention",
+      steps: stepsFor(inferRunStep(run), "attention"),
+    };
+  }
+  if (session.status === "paused") {
+    return {
+      title: "Session paused",
+      detail:
+        session.requested_human_action ??
+        session.error ??
+        "The studio is waiting for attention and will not make another physical move.",
+      passLabel,
+      tone: "attention",
+      steps: stepsFor(inferRunStep(run), "attention"),
+    };
+  }
+  if (session.status === "completed") {
+    return {
+      title: "Drawing complete",
+      detail: "The studio has finished this drawing and will not add another layer.",
+      passLabel: session.pass_count === 1 ? "1 pass complete" : `${session.pass_count} passes complete`,
+      tone: "complete",
+      steps: stepsFor("reflect", "active", true),
+    };
+  }
+  if (session.status === "failed") {
+    return {
+      title: "Session stopped",
+      detail: session.error ?? "The drawing could not continue safely.",
+      passLabel,
+      tone: "failed",
+      steps: stepsFor(inferRunStep(run), "attention"),
+    };
+  }
+  if (session.status === "observed") {
+    return {
+      title: `Pass ${number} is ready to review`,
+      detail: "The registered observation is ready for a human-directed next step in this legacy session.",
+      passLabel,
+      tone: "attention",
+      steps: stepsFor("reflect", "attention"),
+    };
+  }
+  if (session.status === "proposal_ready") {
+    return {
+      title: "Next pass ready for approval",
+      detail: "Review the proposed layer before continuing this legacy session.",
+      passLabel: `Pass ${number + 1}`,
+      tone: "attention",
+      steps: stepsFor("plan", "attention"),
+    };
+  }
+  return activeRunModel(session, run);
+}

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 
 import { App } from "../src/app/App";
 import { StudioCanvas } from "../src/features/studio/StudioCanvas";
+import { StudioProgressPanel } from "../src/features/studio/StudioProgressPanel";
 import type {
   DrawingSession,
   DrawingSessionEvent,
@@ -397,6 +398,77 @@ it("queues active guidance, sends heartbeats, and confirmation-protects emergenc
     const stopRequest = harness.requests.find((request) => request.url.endsWith("/stop"));
     expect(JSON.parse(stopRequest?.body ?? "{}")).toEqual({ mode: "emergency" });
   });
+});
+
+it("explains each creative run stage in human terms", () => {
+  const { rerender } = render(
+    <StudioProgressPanel session={buildSession("planning")} run={null} />,
+  );
+  expect(screen.getByRole("heading", { name: /planning the first pass/i })).toBeInTheDocument();
+  expect(screen.getByText(/nothing will move yet/i)).toBeInTheDocument();
+  expect(screen.getByText("Plan").closest("li")).toHaveAttribute("aria-current", "step");
+
+  rerender(<StudioProgressPanel session={buildSession("awaiting_approval")} run={null} />);
+  expect(screen.getByRole("heading", { name: /preview ready for approval/i })).toBeInTheDocument();
+
+  const preparingRun = buildRun("pending");
+  preparingRun.stage_states.prepare = {
+    status: "in_progress",
+    started_at: now,
+    completed_at: null,
+    message: "Preparing.",
+  };
+  rerender(<StudioProgressPanel session={buildSession("running")} run={preparingRun} />);
+  expect(screen.getByRole("heading", { name: /preparing pass 1/i })).toBeInTheDocument();
+
+  rerender(
+    <StudioProgressPanel session={buildSession("running")} run={buildRun("plotting")} />,
+  );
+  expect(screen.getByRole("heading", { name: /drawing pass 1/i })).toBeInTheDocument();
+  expect(screen.getByText("Draw").closest("li")).toHaveAttribute("aria-current", "step");
+
+  const capturingRun = buildRun("capturing");
+  capturingRun.stage_states.capture = {
+    status: "in_progress",
+    started_at: now,
+    completed_at: null,
+    message: "Capturing.",
+  };
+  rerender(<StudioProgressPanel session={buildSession("running")} run={capturingRun} />);
+  expect(screen.getByRole("heading", { name: /photographing pass 1/i })).toBeInTheDocument();
+
+  rerender(
+    <StudioProgressPanel
+      session={buildSession("awaiting_capture_review")}
+      run={buildRun("awaiting_capture_review", buildCapture("pending"))}
+    />,
+  );
+  expect(screen.getByRole("heading", { name: /page registration needed for pass 1/i })).toBeInTheDocument();
+  expect(screen.getByText("Register").closest("li")).toHaveAttribute("aria-current", "step");
+
+  rerender(
+    <StudioProgressPanel
+      session={buildSession("running", { assessing_run_id: "run-1" })}
+      run={buildRun("completed", buildCapture())}
+    />,
+  );
+  expect(screen.getByRole("heading", { name: /looking at pass 1/i })).toBeInTheDocument();
+  expect(screen.getByText("Reflect").closest("li")).toHaveAttribute("aria-current", "step");
+
+  rerender(
+    <StudioProgressPanel session={buildSession("stopping")} run={buildRun("stopping")} />,
+  );
+  expect(screen.getByRole("heading", { name: /stopping safely/i })).toBeInTheDocument();
+
+  rerender(<StudioProgressPanel session={buildSession("paused")} run={buildRun("failed")} />);
+  expect(screen.getByRole("heading", { name: /session paused/i })).toBeInTheDocument();
+
+  rerender(<StudioProgressPanel session={buildSession("failed")} run={buildRun("failed")} />);
+  expect(screen.getByRole("heading", { name: /session stopped/i })).toBeInTheDocument();
+
+  rerender(<StudioProgressPanel session={buildSession("completed")} run={buildRun("completed")} />);
+  expect(screen.getByRole("heading", { name: /drawing complete/i })).toBeInTheDocument();
+  expect(screen.getByText(/1 pass complete/i)).toBeInTheDocument();
 });
 
 it("offers capture-only recovery and never creates a replacement plot run", async () => {

--- a/docs/history.md
+++ b/docs/history.md
@@ -197,4 +197,11 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Made the session studio use the backend-owned workspace page dimensions before a PlotRun exists, so landscape first-pass proposals render in a landscape paper frame
 - Kept run preparation and registered-capture dimensions authoritative after plotting, with the existing A4 fallback retained when workspace data is unavailable
 
+## Creative Session Progress Slice
+
+- Added a persistent, user-facing progress panel that translates session, plot-run, and stage states into planning, drawing, photographing, registration, reflection, stopping, paused, complete, and failed language
+- Added current-pass context and a compact five-step drawing-cycle indicator without inventing time estimates, percentages, or new backend states
+- Consolidated live status announcements into the progress panel and added responsive, reduced-motion, and non-color-only state treatment
+- Left polling, orchestration, advisor behavior, registration, capture, and hardware control unchanged
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- What changed? Added a persistent creative-session progress panel with a plain-language current stage, pass context, and Plan → Draw → Photograph → Register → Reflect cycle.
- Why does it exist? Session state previously appeared only as a broad header label, leaving users unsure whether the system was preparing, moving the plotter, capturing, waiting for corners, or asking the advisor what to do next.
- What was the slice plan or plan summary? Derive presentation-only progress from the existing session, PlotRun, and stage-state contracts; cover every terminal and recovery state; preserve orchestration and hardware behavior.

Closes #65

## Checks

- [ ] `make api-test` — not run; this slice changes frontend presentation only and does not alter backend contracts or behavior
- [x] `make web-test` — 7 files, 49 tests passed
- [x] `make web-build` — TypeScript and Vite production build passed
- [x] `make web-lint` — passed with zero warnings
- [x] GitHub Actions — `api` passed in 34s; `web` passed in 25s
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed — unchanged

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior — none; the panel only interprets existing persisted state
- [x] I called out version-sensitive behavior when relevant — V1 `observed` and `proposal_ready` states retain explicit human-directed copy
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

## Notes

- Progress is intentionally qualitative. It does not invent percentages, elapsed-time estimates, or additional backend states.
- No hardware motion was required or performed for this slice.
