### PR TITLE
Add creative session lifecycle and paper preflight

### DIFF
--- a/apps/api/src/learn_to_draw_api/models.py
+++ b/apps/api/src/learn_to_draw_api/models.py
@@ -373,6 +373,7 @@ DrawingSessionStatus = Literal[
     "stopping",
     "completed",
     "failed",
+    "abandoned",
 ]
 
 
@@ -418,6 +419,7 @@ DrawingSessionEventType = Literal[
     "user_guidance",
     "plan_ready",
     "plan_failed",
+    "paper_confirmed",
     "session_approved",
     "plot_started",
     "observation_ready",
@@ -425,8 +427,10 @@ DrawingSessionEventType = Literal[
     "session_paused",
     "session_resumed",
     "stop_requested",
+    "finish_requested",
     "session_completed",
     "session_failed",
+    "session_abandoned",
 ]
 
 
@@ -456,7 +460,16 @@ class DrawingSessionProposal(BaseModel):
 class DrawingSessionAuthorization(BaseModel):
     approved_at: Optional[datetime] = None
     stop_requested: bool = False
+    finish_requested: bool = False
     last_heartbeat_at: Optional[datetime] = None
+
+
+class DrawingSessionPaperPreflight(BaseModel):
+    confirmed_at: datetime
+    page_width_mm: float = Field(gt=0)
+    page_height_mm: float = Field(gt=0)
+    drawable_width_mm: float = Field(gt=0)
+    drawable_height_mm: float = Field(gt=0)
 
 
 class DrawingSession(BaseModel):
@@ -480,12 +493,14 @@ class DrawingSession(BaseModel):
     authorization: DrawingSessionAuthorization = Field(
         default_factory=DrawingSessionAuthorization
     )
+    paper_preflight: Optional[DrawingSessionPaperPreflight] = None
     queued_guidance: list[str] = Field(default_factory=list)
     requested_human_action: Optional[str] = None
     events: list[DrawingSessionEvent] = Field(default_factory=list)
     approved_at: Optional[datetime] = None
     paused_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
+    abandoned_at: Optional[datetime] = None
 
 
 class DrawingSessionCreateRequest(BaseModel):
@@ -497,6 +512,10 @@ class DrawingSessionCreateRequest(BaseModel):
 
 class DrawingSessionMessageRequest(BaseModel):
     text: str = Field(min_length=1, max_length=2000)
+
+
+class DrawingSessionApprovalRequest(BaseModel):
+    paper_ready: bool = False
 
 
 class DrawingSessionStopRequest(BaseModel):

--- a/apps/api/src/learn_to_draw_api/routes.py
+++ b/apps/api/src/learn_to_draw_api/routes.py
@@ -9,6 +9,7 @@ from learn_to_draw_api.models import (
     DrawingAdvisorConfigurationRequest,
     DrawingAdvisorRuntimeStatus,
     DrawingSession,
+    DrawingSessionApprovalRequest,
     DrawingSessionCreateRequest,
     DrawingSessionListResponse,
     DrawingSessionMessageRequest,
@@ -236,8 +237,25 @@ def build_api_router(
         "/api/drawing-sessions/{session_id}/approve",
         response_model=DrawingSession,
     )
-    def post_drawing_session_approve(session_id: str) -> DrawingSession:
-        return drawing_session_service.approve(session_id)
+    def post_drawing_session_approve(
+        session_id: str,
+        request: DrawingSessionApprovalRequest,
+    ) -> DrawingSession:
+        return drawing_session_service.approve(session_id, request)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/finish",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_finish(session_id: str) -> DrawingSession:
+        return drawing_session_service.finish(session_id)
+
+    @router.post(
+        "/api/drawing-sessions/{session_id}/abandon",
+        response_model=DrawingSession,
+    )
+    def post_drawing_session_abandon(session_id: str) -> DrawingSession:
+        return drawing_session_service.abandon(session_id)
 
     @router.post(
         "/api/drawing-sessions/{session_id}/heartbeat",

--- a/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
+++ b/apps/api/src/learn_to_draw_api/services/drawing_sessions.py
@@ -13,10 +13,12 @@ from learn_to_draw_api.models import (
     AppNotFoundError,
     DrawingIteration,
     DrawingIterationProposal,
+    DrawingSessionApprovalRequest,
     DrawingSessionAuthorization,
     DrawingSessionEvent,
     DrawingSessionListResponse,
     DrawingSessionMessageRequest,
+    DrawingSessionPaperPreflight,
     DrawingSessionPlan,
     DrawingSessionProposal,
     DrawingSessionStopRequest,
@@ -245,7 +247,7 @@ class DrawingSessionService:
             session = self._sync(self._store.get(session_id))
             if session.session_version != 2:
                 raise AppConflictError("Messages are available only for V2 drawing sessions.")
-            if session.status in {"completed", "failed", "stopping"}:
+            if session.status in {"completed", "failed", "abandoned", "stopping"}:
                 raise AppConflictError("This drawing session is not accepting guidance.")
             session.queued_guidance.append(message)
             session.events.append(self._event("user_guidance", message))
@@ -263,7 +265,11 @@ class DrawingSessionService:
                 self._store.save(session)
             return session
 
-    def approve(self, session_id: str) -> DrawingSession:
+    def approve(
+        self,
+        session_id: str,
+        request: DrawingSessionApprovalRequest,
+    ) -> DrawingSession:
         with self._lock:
             session = self._sync(self._store.get(session_id))
             if session.session_version != 2:
@@ -272,13 +278,26 @@ class DrawingSessionService:
                 raise AppConflictError("This drawing session has no first pass ready to approve.")
             if session.authorization.approved_at is not None:
                 raise AppConflictError("This drawing session has already been approved.")
+            if not request.paper_ready:
+                raise InvalidArtifactError(
+                    "Confirm that a blank sheet and pen are ready before drawing."
+                )
             self._assert_no_other_active_session(session.id)
+            workspace = self._workspace_service.current_validated()
             asset = self._plot_workflow.get_asset(session.current_proposal.asset.id)
             run = self._plot_workflow.create_run(asset.id)
             now = datetime.now(timezone.utc)
             session.authorization.approved_at = now
             session.authorization.stop_requested = False
+            session.authorization.finish_requested = False
             session.authorization.last_heartbeat_at = now
+            session.paper_preflight = DrawingSessionPaperPreflight(
+                confirmed_at=now,
+                page_width_mm=workspace.page_size_mm.width_mm,
+                page_height_mm=workspace.page_size_mm.height_mm,
+                drawable_width_mm=workspace.drawable_area_mm.width_mm,
+                drawable_height_mm=workspace.drawable_area_mm.height_mm,
+            )
             session.approved_at = now
             session.current_run_id = run.id
             session.pass_count = 1
@@ -292,6 +311,14 @@ class DrawingSessionService:
             )
             session.events.extend(
                 [
+                    self._event(
+                        "paper_confirmed",
+                        "Blank paper orientation and pen readiness confirmed.",
+                        details={
+                            "page_width_mm": workspace.page_size_mm.width_mm,
+                            "page_height_mm": workspace.page_size_mm.height_mm,
+                        },
+                    ),
                     self._event(
                         "session_approved",
                         "Open-ended attended drawing session approved.",
@@ -309,12 +336,79 @@ class DrawingSessionService:
             session.error = None
             return self._store.save(session)
 
+    def finish(self, session_id: str) -> DrawingSession:
+        with self._lock:
+            session = self._sync(self._store.get(session_id))
+            if session.session_version != 2:
+                raise AppConflictError("Finish control is available only for V2 drawing sessions.")
+            if session.status == "completed":
+                return session
+            if session.status in {"failed", "abandoned"}:
+                raise AppConflictError("This drawing session has already ended.")
+            if session.pass_count == 0 or session.current_run_id is None:
+                raise AppConflictError("Abandon an unused drawing instead of finishing it.")
+            if session.status not in ACTIVE_SESSION_STATUSES | {"paused"}:
+                raise AppConflictError("This drawing session cannot be finished from its current state.")
+
+            if not session.authorization.finish_requested:
+                session.authorization.finish_requested = True
+                session.authorization.stop_requested = False
+                session.events.append(
+                    self._event(
+                        "finish_requested",
+                        "Finish requested. No additional pass will begin.",
+                        run_id=session.current_run_id,
+                    )
+                )
+            run = self._plot_workflow.get_run(session.current_run_id)
+            if session.status == "paused" or (
+                run.status in {"completed", "failed", "cancelled"}
+                and session.assessing_run_id is None
+            ):
+                self._complete_by_user(session, run_id=run.id)
+            elif run.status == "awaiting_capture_review":
+                session.status = "awaiting_capture_review"
+            else:
+                session.status = "stopping"
+            session.updated_at = datetime.now(timezone.utc)
+            return self._store.save(session)
+
+    def abandon(self, session_id: str) -> DrawingSession:
+        with self._lock:
+            session = self._sync(self._store.get(session_id))
+            if session.session_version != 2:
+                raise AppConflictError("Abandon control is available only for V2 drawing sessions.")
+            if session.status == "abandoned":
+                return session
+            if session.status in ACTIVE_SESSION_STATUSES:
+                raise AppConflictError(
+                    "Finish or pause the current physical pass before abandoning this session."
+                )
+            if session.status in {"completed", "failed"}:
+                raise AppConflictError("An ended drawing cannot be abandoned.")
+
+            now = datetime.now(timezone.utc)
+            session.status = "abandoned"
+            session.abandoned_at = now
+            session.updated_at = now
+            session.error = None
+            session.requested_human_action = None
+            session.queued_guidance = []
+            session.events.append(
+                self._event(
+                    "session_abandoned",
+                    "This session was left unfinished.",
+                    run_id=session.current_run_id,
+                )
+            )
+            return self._store.save(session)
+
     def heartbeat(self, session_id: str) -> DrawingSession:
         with self._lock:
             session = self._store.get(session_id)
             if session.session_version != 2:
                 raise AppConflictError("Heartbeat is available only for V2 drawing sessions.")
-            if session.status in {"completed", "failed"}:
+            if session.status in {"completed", "failed", "abandoned"}:
                 return session
             now = datetime.now(timezone.utc)
             session.authorization.last_heartbeat_at = now
@@ -334,6 +428,7 @@ class DrawingSessionService:
                 return session
             now = datetime.now(timezone.utc)
             session.authorization.stop_requested = True
+            session.authorization.finish_requested = False
             session.updated_at = now
             session.events.append(
                 self._event(
@@ -380,6 +475,7 @@ class DrawingSessionService:
             self._assert_no_other_active_session(session.id)
             now = datetime.now(timezone.utc)
             session.authorization.stop_requested = False
+            session.authorization.finish_requested = False
             session.authorization.last_heartbeat_at = now
             session.paused_at = None
             session.error = None
@@ -541,7 +637,12 @@ class DrawingSessionService:
             session.status = "awaiting_capture_review"
         elif run.status in ACTIVE_PLOT_RUN_STATUSES:
             session.status = (
-                "stopping" if session.authorization.stop_requested else "running"
+                "stopping"
+                if (
+                    session.authorization.stop_requested
+                    or session.authorization.finish_requested
+                )
+                else "running"
             )
         elif run.status == "failed":
             if session.status != "paused":
@@ -562,7 +663,12 @@ class DrawingSessionService:
             and session.status == "awaiting_capture_review"
         ):
             session.status = (
-                "stopping" if session.authorization.stop_requested else "running"
+                "stopping"
+                if (
+                    session.authorization.stop_requested
+                    or session.authorization.finish_requested
+                )
+                else "running"
             )
         session.advisor = self._advisor.status
         if session.status != previous_status:
@@ -613,7 +719,12 @@ class DrawingSessionService:
                 return
             if run.status in ACTIVE_PLOT_RUN_STATUSES:
                 next_status = (
-                    "stopping" if session.authorization.stop_requested else "running"
+                    "stopping"
+                    if (
+                        session.authorization.stop_requested
+                        or session.authorization.finish_requested
+                    )
+                    else "running"
                 )
                 if session.status != next_status:
                     session.status = next_status
@@ -637,6 +748,10 @@ class DrawingSessionService:
                 self._store.save(session)
                 return
             if run.status != "completed":
+                return
+            if session.authorization.finish_requested:
+                self._complete_by_user(session, run_id=run.id)
+                self._store.save(session)
                 return
             if session.authorization.stop_requested:
                 self._pause_session(
@@ -754,6 +869,15 @@ class DrawingSessionService:
         safe_svg: Optional[str],
         consumed_guidance: list[str],
     ) -> None:
+        with self._lock:
+            session = self._store.get(session_id)
+            if session.assessing_run_id != run_id or session.current_run_id != run_id:
+                return
+            if session.authorization.finish_requested:
+                session.assessing_run_id = None
+                self._complete_by_user(session, run_id=run_id)
+                self._store.save(session)
+                return
         asset = None
         if assessment.decision == "continue" and safe_svg is not None:
             with self._lock:
@@ -767,6 +891,11 @@ class DrawingSessionService:
         with self._lock:
             session = self._store.get(session_id)
             if session.assessing_run_id != run_id or session.current_run_id != run_id:
+                return
+            if session.authorization.finish_requested:
+                session.assessing_run_id = None
+                self._complete_by_user(session, run_id=run_id)
+                self._store.save(session)
                 return
             now = datetime.now(timezone.utc)
             session.assessing_run_id = None
@@ -867,6 +996,10 @@ class DrawingSessionService:
             if session.assessing_run_id != run_id:
                 return
             session.assessing_run_id = None
+            if session.authorization.finish_requested:
+                self._complete_by_user(session, run_id=run_id)
+                self._store.save(session)
+                return
             session.queued_guidance = consumed_guidance + session.queued_guidance
             self._pause_session(session, message, run_id=run_id)
             self._store.save(session)
@@ -932,6 +1065,36 @@ class DrawingSessionService:
                 self._event("session_paused", message, run_id=run_id)
             )
 
+    def _complete_by_user(
+        self,
+        session: DrawingSession,
+        *,
+        run_id: Optional[str],
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        session.status = "completed"
+        session.completed_at = now
+        session.paused_at = None
+        session.error = None
+        session.requested_human_action = None
+        session.assessing_run_id = None
+        session.authorization.stop_requested = False
+        session.authorization.finish_requested = False
+        if not (
+            session.events
+            and session.events[-1].type == "session_completed"
+            and session.events[-1].details.get("source") == "user"
+        ):
+            session.events.append(
+                self._event(
+                    "session_completed",
+                    f"Finished by you after pass {session.pass_count}.",
+                    run_id=run_id,
+                    details={"source": "user"},
+                )
+            )
+        session.updated_at = now
+
     def _dispatch_plan(self, session_id: str, generation: int) -> None:
         Thread(
             target=self._plan_session,
@@ -961,14 +1124,14 @@ class DrawingSessionService:
                 drawable_width_mm=plot_area.draw_width_mm,
                 drawable_height_mm=plot_area.draw_height_mm,
             )
-            asset = self._plot_workflow.create_generated_asset(
-                name=f"{intent[:48]} — first pass",
-                svg_text=safe_svg,
-            )
             with self._lock:
                 session = self._store.get(session_id)
                 if session.planning_generation != generation or session.status != "planning":
                     return
+                asset = self._plot_workflow.create_generated_asset(
+                    name=f"{intent[:48]} — first pass",
+                    svg_text=safe_svg,
+                )
                 now = datetime.now(timezone.utc)
                 session.plan = DrawingSessionPlan(
                     summary=draft.summary.strip(),

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1196,8 +1196,19 @@ def test_v2_drawing_session_plans_revises_and_approves_without_early_motion(tmp_
         assert summaries[0]["id"] == created["id"]
         assert summaries[0]["preview_url"] == revised["current_proposal"]["asset"]["public_url"]
 
+        missing_preflight = client.post(
+            f"/api/drawing-sessions/{created['id']}/approve",
+            json={"paper_ready": False},
+        )
+        assert missing_preflight.status_code == 400
+        assert missing_preflight.json() == {
+            "detail": "Confirm that a blank sheet and pen are ready before drawing."
+        }
+        assert client.get("/api/plot-runs").json()["runs"] == []
+
         approved_response = client.post(
-            f"/api/drawing-sessions/{created['id']}/approve"
+            f"/api/drawing-sessions/{created['id']}/approve",
+            json={"paper_ready": True},
         )
         assert approved_response.status_code == 200
         approved = approved_response.json()
@@ -1205,6 +1216,44 @@ def test_v2_drawing_session_plans_revises_and_approves_without_early_motion(tmp_
         assert approved["authorization"]["approved_at"] is not None
         assert approved["pass_count"] == 1
         assert len(approved["iterations"]) == 1
+        assert approved["paper_preflight"] == {
+            "confirmed_at": approved["approved_at"],
+            "page_width_mm": 210.0,
+            "page_height_mm": 297.0,
+            "drawable_width_mm": 170.0,
+            "drawable_height_mm": 257.0,
+        }
+        assert any(
+            event["type"] == "paper_confirmed" for event in approved["events"]
+        )
+
+
+def test_v2_unplotted_session_can_be_abandoned_without_motion(tmp_path):
+    with create_test_client(
+        tmp_path,
+        plotter=MockPlotter(plot_delay_s=0),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "An idea I changed my mind about"},
+        ).json()
+        wait_for_session_status(client, created["id"], {"awaiting_approval"})
+
+        response = client.post(
+            f"/api/drawing-sessions/{created['id']}/abandon"
+        )
+        unchanged = client.post(
+            f"/api/drawing-sessions/{created['id']}/abandon"
+        )
+
+    assert response.status_code == 200
+    abandoned = response.json()
+    assert abandoned["status"] == "abandoned"
+    assert abandoned["abandoned_at"] is not None
+    assert abandoned["pass_count"] == 0
+    assert abandoned["events"][-1]["type"] == "session_abandoned"
+    assert unchanged.json()["status"] == "abandoned"
 
 
 def test_v2_drawing_session_disabled_advisor_pauses_without_motion(tmp_path):
@@ -1234,7 +1283,8 @@ def test_v2_session_auto_continues_consumes_guidance_and_completes(tmp_path):
         ).json()
         planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
         approved = client.post(
-            f"/api/drawing-sessions/{planned['id']}/approve"
+            f"/api/drawing-sessions/{planned['id']}/approve",
+            json={"paper_ready": True},
         ).json()
         guidance_response = client.post(
             f"/api/drawing-sessions/{planned['id']}/messages",
@@ -1274,7 +1324,8 @@ def test_v2_stop_after_pass_prevents_another_plot(tmp_path):
         ).json()
         planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
         approved = client.post(
-            f"/api/drawing-sessions/{planned['id']}/approve"
+            f"/api/drawing-sessions/{planned['id']}/approve",
+            json={"paper_ready": True},
         ).json()
         stopped = client.post(
             f"/api/drawing-sessions/{approved['id']}/stop",
@@ -1283,9 +1334,49 @@ def test_v2_stop_after_pass_prevents_another_plot(tmp_path):
         assert stopped.status_code == 200
 
         paused = drive_v2_session_until(client, approved["id"], {"paused"})
+        finished = client.post(
+            f"/api/drawing-sessions/{approved['id']}/finish"
+        ).json()
 
     assert paused["authorization"]["stop_requested"] is True
     assert paused["pass_count"] == 1
+    assert finished["status"] == "completed"
+    assert finished["events"][-1]["details"]["source"] == "user"
+    assert plotter.plot_count == 1
+
+
+def test_v2_finish_request_completes_current_pass_without_another_plot(tmp_path):
+    plotter = CountingPlotter(plot_delay_s=0.05)
+    with create_test_client(
+        tmp_path,
+        plotter=plotter,
+        camera=LowConfidenceCamera(),
+        config_overrides={"drawing_advisor_driver": "mock"},
+    ) as client:
+        created = client.post(
+            "/api/drawing-sessions",
+            json={"intent": "One final thoughtful flower"},
+        ).json()
+        planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
+        approved = client.post(
+            f"/api/drawing-sessions/{planned['id']}/approve",
+            json={"paper_ready": True},
+        ).json()
+
+        active_abandon = client.post(
+            f"/api/drawing-sessions/{approved['id']}/abandon"
+        )
+        finish_response = client.post(
+            f"/api/drawing-sessions/{approved['id']}/finish"
+        )
+        completed = drive_v2_session_until(client, approved["id"], {"completed"})
+
+    assert active_abandon.status_code == 409
+    assert finish_response.status_code == 200
+    assert completed["pass_count"] == 1
+    assert completed["authorization"]["finish_requested"] is False
+    assert completed["events"][-1]["type"] == "session_completed"
+    assert completed["events"][-1]["details"]["source"] == "user"
     assert plotter.plot_count == 1
 
 
@@ -1303,7 +1394,8 @@ def test_v2_emergency_stop_cancels_plot_without_capture_or_continuation(tmp_path
         ).json()
         planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
         approved = client.post(
-            f"/api/drawing-sessions/{planned['id']}/approve"
+            f"/api/drawing-sessions/{planned['id']}/approve",
+            json={"paper_ready": True},
         ).json()
         active_run = wait_for_run_status(
             client,
@@ -1349,7 +1441,8 @@ def test_v2_attention_timeout_pauses_before_a_second_plot(tmp_path, monkeypatch)
         ).json()
         planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
         approved = client.post(
-            f"/api/drawing-sessions/{planned['id']}/approve"
+            f"/api/drawing-sessions/{planned['id']}/approve",
+            json={"paper_ready": True},
         ).json()
         first_run = wait_for_run_status(
             client,
@@ -1415,7 +1508,8 @@ def test_v2_backend_restart_requires_explicit_resume(tmp_path):
         ).json()
         planned = wait_for_session_status(client, created["id"], {"awaiting_approval"})
         approved = client.post(
-            f"/api/drawing-sessions/{planned['id']}/approve"
+            f"/api/drawing-sessions/{planned['id']}/approve",
+            json={"paper_ready": True},
         ).json()
         completed = drive_v2_session_until(client, approved["id"], {"completed"})
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -76,10 +76,13 @@ export function App() {
       </header>
 
       {pathname === "/" ? <CreativeHome navigate={navigate} /> : null}
+      {pathname === "/new" ? <CreativeHome navigate={navigate} resumeActive={false} /> : null}
       {pathname === "/gallery" ? <GalleryPage /> : null}
       {pathname === "/controls" ? <ControlsPage /> : null}
-      {sessionMatch ? <SessionStudio sessionId={decodeURIComponent(sessionMatch[1])} /> : null}
-      {!sessionMatch && !["/", "/gallery", "/controls"].includes(pathname) ? (
+      {sessionMatch ? (
+        <SessionStudio sessionId={decodeURIComponent(sessionMatch[1])} navigate={navigate} />
+      ) : null}
+      {!sessionMatch && !["/", "/new", "/gallery", "/controls"].includes(pathname) ? (
         <main className="studio-loading">
           <h1>That page does not exist.</h1>
           <AppLink href="/" navigate={navigate} className="button-primary">Return home</AppLink>

--- a/apps/web/src/app/styles.css
+++ b/apps/web/src/app/styles.css
@@ -2949,6 +2949,12 @@ button {
   gap: 8px;
 }
 
+.studio-session-heading-actions {
+  display: grid;
+  justify-items: end;
+  gap: 12px;
+}
+
 .studio-progress {
   --progress-tone: var(--accent);
   margin-bottom: 18px;
@@ -3479,6 +3485,52 @@ button {
   font-size: 0.9rem;
 }
 
+.studio-paper-preflight {
+  display: grid;
+  gap: 13px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid rgba(208, 161, 95, 0.2);
+}
+
+.studio-paper-preflight > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 5px 14px;
+}
+
+.studio-paper-preflight > div span {
+  color: #e7c493;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.studio-paper-preflight label {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 10px;
+  color: #eee6da;
+  font-size: 0.87rem;
+  line-height: 1.4;
+}
+
+.studio-paper-preflight input {
+  width: 18px;
+  height: 18px;
+  margin: 1px 0 0;
+  accent-color: var(--accent);
+}
+
+.studio-paper-preflight a {
+  width: fit-content;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  text-underline-offset: 3px;
+}
+
 .studio-recovery,
 .studio-complete {
   display: flex;
@@ -3850,6 +3902,10 @@ button {
   .studio-complete-actions,
   .controls-heading .readiness-bar {
     justify-content: flex-start;
+  }
+
+  .studio-session-heading-actions {
+    justify-items: start;
   }
 
   .studio-progress {

--- a/apps/web/src/features/plot-workflow/DrawingSessionPanel.tsx
+++ b/apps/web/src/features/plot-workflow/DrawingSessionPanel.tsx
@@ -20,6 +20,7 @@ const STATUS_LABELS = {
   stopping: "Stopping safely",
   completed: "Iteration limit reached",
   failed: "Session stopped",
+  abandoned: "Left unfinished",
 };
 
 export function DrawingSessionPanel({

--- a/apps/web/src/features/studio/CreativeHome.tsx
+++ b/apps/web/src/features/studio/CreativeHome.tsx
@@ -18,7 +18,13 @@ const RESUMABLE_STATUSES = new Set([
   "stopping",
 ]);
 
-export function CreativeHome({ navigate }: { navigate: (path: string) => void }) {
+export function CreativeHome({
+  navigate,
+  resumeActive = true,
+}: {
+  navigate: (path: string) => void;
+  resumeActive?: boolean;
+}) {
   const [intent, setIntent] = useState("");
   const [hardware, setHardware] = useState<HardwareStatus | null>(null);
   const [recentSession, setRecentSession] = useState<DrawingSession | null>(null);
@@ -35,7 +41,11 @@ export function CreativeHome({ navigate }: { navigate: (path: string) => void })
         setHardware(status);
         setRecentSession(latest.session);
         setError(null);
-        if (latest.session && RESUMABLE_STATUSES.has(latest.session.status)) {
+        if (
+          resumeActive &&
+          latest.session &&
+          RESUMABLE_STATUSES.has(latest.session.status)
+        ) {
           navigate(`/sessions/${latest.session.id}`);
         }
       })
@@ -51,7 +61,7 @@ export function CreativeHome({ navigate }: { navigate: (path: string) => void })
     return () => {
       mountedRef.current = false;
     };
-  }, []);
+  }, [resumeActive]);
 
   async function submit(event: FormEvent) {
     event.preventDefault();

--- a/apps/web/src/features/studio/SessionStudio.tsx
+++ b/apps/web/src/features/studio/SessionStudio.tsx
@@ -18,16 +18,27 @@ const STATUS_LABELS: Record<DrawingSessionStatus, string> = {
   stopping: "Stopping safely",
   completed: "Drawing complete",
   failed: "Session failed",
+  abandoned: "Left unfinished",
 };
 
 function activeSession(status: DrawingSessionStatus) {
   return ["running", "awaiting_capture_review", "stopping"].includes(status);
 }
 
-export function SessionStudio({ sessionId }: { sessionId: string }) {
+export function SessionStudio({
+  sessionId,
+  navigate,
+}: {
+  sessionId: string;
+  navigate: (path: string) => void;
+}) {
   const controller = useStudioSession(sessionId);
   const [showEmergencyConfirm, setShowEmergencyConfirm] = useState(false);
+  const [showNewDrawingConfirm, setShowNewDrawingConfirm] = useState(false);
+  const [startNewAfterFinish, setStartNewAfterFinish] = useState(false);
+  const [paperReady, setPaperReady] = useState(false);
   const emergencyCancelRef = useRef<HTMLButtonElement | null>(null);
+  const newDrawingCancelRef = useRef<HTMLButtonElement | null>(null);
   const planHeadingRef = useRef<HTMLHeadingElement | null>(null);
   const recoveryHeadingRef = useRef<HTMLHeadingElement | null>(null);
   const session = controller.session;
@@ -42,6 +53,24 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     if (showEmergencyConfirm) emergencyCancelRef.current?.focus();
   }, [showEmergencyConfirm]);
+
+  useEffect(() => {
+    if (showNewDrawingConfirm) newDrawingCancelRef.current?.focus();
+  }, [showNewDrawingConfirm]);
+
+  useEffect(() => {
+    setPaperReady(false);
+  }, [session?.current_proposal?.asset.id]);
+
+  useEffect(() => {
+    if (
+      startNewAfterFinish &&
+      session &&
+      ["completed", "abandoned"].includes(session.status)
+    ) {
+      navigate("/new");
+    }
+  }, [navigate, session, startNewAfterFinish]);
 
   useEffect(() => {
     const activeElement = document.activeElement;
@@ -82,6 +111,36 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
   const canEmergencyStop = Boolean(
     currentRun && ["pending", "plotting"].includes(currentRun.status),
   );
+  const pageSize = controller.plotterWorkspace?.page_size_mm ?? null;
+  const pageOrientation = pageSize
+    ? pageSize.width_mm > pageSize.height_mm
+      ? "landscape"
+      : pageSize.height_mm > pageSize.width_mm
+        ? "portrait"
+        : "square"
+    : null;
+  const hasPlottedWork = session.pass_count > 0;
+  const isEnded = ["completed", "failed", "abandoned"].includes(session.status);
+
+  async function abandonAndStart() {
+    const succeeded = await controller.abandon();
+    if (succeeded) navigate("/new");
+  }
+
+  async function finishAndStart() {
+    setStartNewAfterFinish(true);
+    setShowNewDrawingConfirm(false);
+    const succeeded = await controller.finish();
+    if (!succeeded) setStartNewAfterFinish(false);
+  }
+
+  function requestNewDrawing() {
+    if (isEnded) {
+      navigate("/new");
+      return;
+    }
+    setShowNewDrawingConfirm(true);
+  }
 
   return (
     <main className="studio-session-shell">
@@ -96,14 +155,24 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
             {session.session_version === 1 ? <span>Legacy session</span> : null}
           </div>
         </div>
-        <div className="studio-session-readiness" aria-label="Machine readiness">
-          <StatusPill
-            label="Studio"
-            value={controller.hardwareStatus ? "online" : "offline"}
-            tone={controller.hardwareStatus ? "ok" : "warn"}
-          />
-          <StatusPill label="Plotter" value={plotterReady ? "ready" : "attention"} tone={plotterReady ? "ok" : "warn"} />
-          <StatusPill label="Camera" value={cameraReady ? "ready" : "attention"} tone={cameraReady ? "ok" : "warn"} />
+        <div className="studio-session-heading-actions">
+          <div className="studio-session-readiness" aria-label="Machine readiness">
+            <StatusPill
+              label="Studio"
+              value={controller.hardwareStatus ? "online" : "offline"}
+              tone={controller.hardwareStatus ? "ok" : "warn"}
+            />
+            <StatusPill label="Plotter" value={plotterReady ? "ready" : "attention"} tone={plotterReady ? "ok" : "warn"} />
+            <StatusPill label="Camera" value={cameraReady ? "ready" : "attention"} tone={cameraReady ? "ok" : "warn"} />
+          </div>
+          <button
+            type="button"
+            className="button-secondary"
+            disabled={controller.busyAction !== null}
+            onClick={requestNewDrawing}
+          >
+            New drawing
+          </button>
         </div>
       </header>
 
@@ -171,6 +240,26 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
                 </dl>
               </div>
               <div className="studio-approval">
+                <div className="studio-paper-preflight">
+                  <div>
+                    <strong>Before the plotter moves</strong>
+                    <span>
+                      {pageSize && pageOrientation
+                        ? `${pageSize.width_mm} × ${pageSize.height_mm} mm · ${pageOrientation}`
+                        : "Paper setup is unavailable."}
+                    </span>
+                  </div>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={paperReady}
+                      disabled={controller.busyAction !== null || !pageSize}
+                      onChange={(event) => setPaperReady(event.target.checked)}
+                    />
+                    <span>I have a blank sheet loaded in this orientation and a pen installed.</span>
+                  </label>
+                  <a href="/controls">Change paper or machine setup</a>
+                </div>
                 <p>
                   Approving authorizes an attended sequence of plot, photograph, and agent-decision
                   cycles. It may add more than one permanent layer without asking again.
@@ -178,8 +267,14 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
                 <button
                   type="button"
                   className="button-primary"
-                  disabled={controller.busyAction !== null || !plotterReady || !cameraReady}
-                  onClick={() => void controller.approve()}
+                  disabled={
+                    controller.busyAction !== null ||
+                    !plotterReady ||
+                    !cameraReady ||
+                    !pageSize ||
+                    !paperReady
+                  }
+                  onClick={() => void controller.approve(paperReady)}
                 >
                   {controller.busyAction === "approve" ? "Authorizing…" : "Approve and begin"}
                 </button>
@@ -207,6 +302,16 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
                     {controller.busyAction === "retry-capture" ? "Retaking…" : "Retake photo only"}
                   </button>
                 ) : null}
+                {hasPlottedWork ? (
+                  <button
+                    type="button"
+                    className="button-secondary"
+                    disabled={controller.busyAction !== null}
+                    onClick={() => void controller.finish()}
+                  >
+                    {controller.busyAction === "finish" ? "Finishing…" : "Finish drawing"}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="button-primary"
@@ -226,7 +331,7 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
               <p>{completionMessage}</p>
               <div className="studio-complete-actions">
                 <a className="button-secondary" href="/gallery">View gallery</a>
-                <a className="button-primary" href="/">Create another drawing</a>
+                <a className="button-primary" href="/new">Create another drawing</a>
               </div>
             </section>
           ) : null}
@@ -238,7 +343,18 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
                 <h2 id="failed-title">This drawing needs a fresh start.</h2>
                 <p>{session.error ?? "The session could not continue safely."}</p>
               </div>
-              <a className="button-primary" href="/">Create another drawing</a>
+              <a className="button-primary" href="/new">Create another drawing</a>
+            </section>
+          ) : null}
+
+          {session.status === "abandoned" ? (
+            <section className="studio-recovery">
+              <div>
+                <p className="eyebrow">Left unfinished</p>
+                <h2>This session will not make another move.</h2>
+                <p>Its plan, events, and any completed passes remain available here for reference.</p>
+              </div>
+              <a className="button-primary" href="/new">Start a new drawing</a>
             </section>
           ) : null}
         </div>
@@ -263,6 +379,14 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
             onClick={() => void controller.stopAfterPass()}
           >
             {controller.busyAction === "stop-after-pass" ? "Stopping…" : "Stop after this pass"}
+          </button>
+          <button
+            type="button"
+            className="button-secondary"
+            disabled={controller.busyAction !== null || session.status === "stopping"}
+            onClick={() => void controller.finish()}
+          >
+            {controller.busyAction === "finish" ? "Finishing…" : "Finish drawing"}
           </button>
           <button
             type="button"
@@ -302,6 +426,68 @@ export function SessionStudio({ sessionId }: { sessionId: string }) {
                 }}
               >
                 Pause after current segment
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {showNewDrawingConfirm ? (
+        <div
+          className="studio-confirm-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="new-drawing-title"
+          aria-describedby="new-drawing-description"
+        >
+          <div className="studio-confirm-card">
+            <p className="eyebrow">New drawing</p>
+            <h2 id="new-drawing-title">
+              {hasPlottedWork ? "What should happen to this drawing?" : "Leave this draft?"}
+            </h2>
+            <p id="new-drawing-description">
+              {hasPlottedWork
+                ? session.status === "paused"
+                  ? "You can preserve it as a completed drawing or leave it unfinished. Neither choice moves the machine."
+                  : "The current plot and photograph must finish safely. The studio will then complete this drawing and open a blank prompt."
+                : "Nothing has been plotted. The unused plan will remain in Gallery as an unfinished session."}
+            </p>
+            <div>
+              <button
+                ref={newDrawingCancelRef}
+                type="button"
+                className="button-secondary"
+                onClick={() => setShowNewDrawingConfirm(false)}
+              >
+                Keep this session
+              </button>
+              {hasPlottedWork && session.status === "paused" ? (
+                <button
+                  type="button"
+                  className="button-secondary"
+                  disabled={controller.busyAction !== null}
+                  onClick={() => void abandonAndStart()}
+                >
+                  Leave unfinished
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="button-primary"
+                disabled={controller.busyAction !== null}
+                onClick={() => {
+                  if (hasPlottedWork) {
+                    void finishAndStart();
+                  } else {
+                    void abandonAndStart();
+                  }
+                }}
+              >
+                {hasPlottedWork
+                  ? session.status === "paused"
+                    ? "Finish and start new"
+                    : "Finish this pass, then start new"
+                  : "Abandon and start new"}
               </button>
             </div>
           </div>

--- a/apps/web/src/features/studio/StudioConversation.tsx
+++ b/apps/web/src/features/studio/StudioConversation.tsx
@@ -37,7 +37,7 @@ export function StudioConversation({
   const endRef = useRef<HTMLLIElement | null>(null);
   const canSend =
     draft.trim().length > 0 &&
-    !["completed", "failed", "stopping"].includes(session.status) &&
+    !["completed", "failed", "abandoned", "stopping"].includes(session.status) &&
     busyAction !== "message";
 
   useEffect(() => {
@@ -97,7 +97,7 @@ export function StudioConversation({
           value={draft}
           rows={3}
           maxLength={2000}
-          disabled={["completed", "failed", "stopping"].includes(session.status)}
+          disabled={["completed", "failed", "abandoned", "stopping"].includes(session.status)}
           placeholder={
             session.authorization.approved_at
               ? "For example: make the rhythm less regular"

--- a/apps/web/src/features/studio/studioProgress.ts
+++ b/apps/web/src/features/studio/studioProgress.ts
@@ -159,8 +159,12 @@ export function deriveStudioProgress(
   }
   if (session.status === "awaiting_capture_review") {
     return {
-      title: `Page registration needed for pass ${number}`,
-      detail: "Place the four corner markers on the physical sheet, or retake the photo, before the advisor continues.",
+      title: session.authorization.finish_requested
+        ? `Register the final photo for pass ${number}`
+        : `Page registration needed for pass ${number}`,
+      detail: session.authorization.finish_requested
+        ? "Place the four corner markers, or retake the photo. The drawing will finish after this observation is saved."
+        : "Place the four corner markers on the physical sheet, or retake the photo, before the advisor continues.",
       passLabel,
       tone: "attention",
       steps: stepsFor("register", "attention"),
@@ -169,10 +173,14 @@ export function deriveStudioProgress(
   if (session.status === "stopping") {
     const emergencyStopInProgress = run?.status === "stopping";
     return {
-      title: emergencyStopInProgress
+      title: session.authorization.finish_requested
+        ? `Finishing pass ${number}`
+        : emergencyStopInProgress
         ? "Stopping safely"
         : `Finishing pass ${number}, then stopping`,
-      detail: emergencyStopInProgress
+      detail: session.authorization.finish_requested
+        ? "The current plot and its photograph will finish safely. No additional drawing layer will begin."
+        : emergencyStopInProgress
         ? "The plotter will pause after its current path segment. No photograph or later pass will begin."
         : "The current pass and its observation will finish, but the studio will not begin another layer.",
       passLabel,
@@ -207,6 +215,15 @@ export function deriveStudioProgress(
       detail: session.error ?? "The drawing could not continue safely.",
       passLabel,
       tone: "failed",
+      steps: stepsFor(inferRunStep(run), "attention"),
+    };
+  }
+  if (session.status === "abandoned") {
+    return {
+      title: "Session left unfinished",
+      detail: "The studio will not return to this drawing or make another physical move for it.",
+      passLabel: session.pass_count === 0 ? "No passes plotted" : passLabel,
+      tone: "attention",
       steps: stepsFor(inferRunStep(run), "attention"),
     };
   }

--- a/apps/web/src/features/studio/useStudioSession.ts
+++ b/apps/web/src/features/studio/useStudioSession.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import {
+  abandonDrawingSession,
   approveDrawingSession,
   confirmPlotRunCaptureReview,
   fetchDrawingSession,
@@ -8,6 +9,7 @@ import {
   fetchPlotterWorkspace,
   fetchPlotRun,
   fetchPlotRunCaptureReview,
+  finishDrawingSession,
   heartbeatDrawingSession,
   resumeDrawingSession,
   retryPlotRunCapture,
@@ -41,6 +43,8 @@ export const STUDIO_HEARTBEAT_MS = 10000;
 export type StudioAction =
   | "message"
   | "approve"
+  | "finish"
+  | "abandon"
   | "stop-after-pass"
   | "emergency-stop"
   | "resume"
@@ -131,12 +135,12 @@ export function useStudioSession(sessionId: string) {
   async function runAction(
     action: Exclude<StudioAction, null>,
     callback: () => Promise<DrawingSession | PlotRun | { run: PlotRun }>,
-  ) {
+  ): Promise<boolean> {
     try {
       setBusyAction(action);
       setError(null);
       const result = await callback();
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) return false;
       if ("session_version" in result) {
         setSession(result);
       } else if ("run" in result) {
@@ -145,12 +149,14 @@ export function useStudioSession(sessionId: string) {
         setRuns((current) => ({ ...current, [result.id]: result }));
       }
       await refresh({ silent: true });
+      return true;
     } catch (actionError) {
       if (mountedRef.current) {
         setError(
           actionError instanceof Error ? actionError.message : "The studio action failed.",
         );
       }
+      return false;
     } finally {
       if (mountedRef.current) {
         setBusyAction(null);
@@ -230,17 +236,28 @@ export function useStudioSession(sessionId: string) {
     busyAction,
     error,
     refresh,
-    sendMessage: (text: string) =>
-      runAction("message", () => sendDrawingSessionMessage(sessionId, text)),
-    approve: () => runAction("approve", () => approveDrawingSession(sessionId)),
-    stopAfterPass: () =>
-      runAction("stop-after-pass", () => stopDrawingSession(sessionId, "after_pass")),
-    emergencyStop: () =>
-      runAction("emergency-stop", () => stopDrawingSession(sessionId, "emergency")),
-    resume: () => runAction("resume", () => resumeDrawingSession(sessionId)),
-    retryCapture: (runId: string) =>
-      runAction("retry-capture", () => retryPlotRunCapture(runId)),
-    confirmRegistration: (runId: string, corners: NormalizationCorners) =>
-      runAction("register", () => confirmPlotRunCaptureReview(runId, corners)),
+    sendMessage: async (text: string) => {
+      await runAction("message", () => sendDrawingSessionMessage(sessionId, text));
+    },
+    approve: async (paperReady: boolean) => {
+      await runAction("approve", () => approveDrawingSession(sessionId, paperReady));
+    },
+    finish: () => runAction("finish", () => finishDrawingSession(sessionId)),
+    abandon: () => runAction("abandon", () => abandonDrawingSession(sessionId)),
+    stopAfterPass: async () => {
+      await runAction("stop-after-pass", () => stopDrawingSession(sessionId, "after_pass"));
+    },
+    emergencyStop: async () => {
+      await runAction("emergency-stop", () => stopDrawingSession(sessionId, "emergency"));
+    },
+    resume: async () => {
+      await runAction("resume", () => resumeDrawingSession(sessionId));
+    },
+    retryCapture: async (runId: string) => {
+      await runAction("retry-capture", () => retryPlotRunCapture(runId));
+    },
+    confirmRegistration: async (runId: string, corners: NormalizationCorners) => {
+      await runAction("register", () => confirmPlotRunCaptureReview(runId, corners));
+    },
   };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -387,8 +387,22 @@ export function sendDrawingSessionMessage(sessionId: string, text: string) {
   });
 }
 
-export function approveDrawingSession(sessionId: string) {
+export function approveDrawingSession(sessionId: string, paperReady: boolean) {
   return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/approve`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ paper_ready: paperReady }),
+  });
+}
+
+export function finishDrawingSession(sessionId: string) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/finish`, {
+    method: "POST",
+  });
+}
+
+export function abandonDrawingSession(sessionId: string) {
+  return requestJson<DrawingSession>(`/api/drawing-sessions/${sessionId}/abandon`, {
     method: "POST",
   });
 }

--- a/apps/web/src/types/drawing.ts
+++ b/apps/web/src/types/drawing.ts
@@ -10,7 +10,8 @@ export type DrawingSessionStatus =
   | "paused"
   | "stopping"
   | "completed"
-  | "failed";
+  | "failed"
+  | "abandoned";
 
 export interface DrawingAdvisorStatus {
   driver: "disabled" | "mock" | "openai";
@@ -74,14 +75,23 @@ export interface DrawingSession {
   authorization: {
     approved_at: string | null;
     stop_requested: boolean;
+    finish_requested: boolean;
     last_heartbeat_at: string | null;
   };
+  paper_preflight: {
+    confirmed_at: string;
+    page_width_mm: number;
+    page_height_mm: number;
+    drawable_width_mm: number;
+    drawable_height_mm: number;
+  } | null;
   queued_guidance: string[];
   requested_human_action: string | null;
   events: DrawingSessionEvent[];
   approved_at: string | null;
   paused_at: string | null;
   completed_at: string | null;
+  abandoned_at: string | null;
 }
 
 export type DrawingSessionEventType =
@@ -89,6 +99,7 @@ export type DrawingSessionEventType =
   | "user_guidance"
   | "plan_ready"
   | "plan_failed"
+  | "paper_confirmed"
   | "session_approved"
   | "plot_started"
   | "observation_ready"
@@ -96,8 +107,10 @@ export type DrawingSessionEventType =
   | "session_paused"
   | "session_resumed"
   | "stop_requested"
+  | "finish_requested"
   | "session_completed"
-  | "session_failed";
+  | "session_failed"
+  | "session_abandoned";
 
 export interface DrawingSessionEvent {
   id: string;

--- a/apps/web/tests/creativeStudio.test.tsx
+++ b/apps/web/tests/creativeStudio.test.tsx
@@ -94,8 +94,18 @@ function buildSession(
     authorization: {
       approved_at: approved ? now : null,
       stop_requested: status === "stopping",
+      finish_requested: false,
       last_heartbeat_at: approved ? now : null,
     },
+    paper_preflight: approved
+      ? {
+          confirmed_at: now,
+          page_width_mm: 279.4,
+          page_height_mm: 215.9,
+          drawable_width_mm: 259.4,
+          drawable_height_mm: 195.9,
+        }
+      : null,
     queued_guidance: [],
     requested_human_action: null,
     events: [
@@ -108,6 +118,7 @@ function buildSession(
     approved_at: approved ? now : null,
     paused_at: status === "paused" ? now : null,
     completed_at: status === "completed" ? now : null,
+    abandoned_at: status === "abandoned" ? now : null,
     ...overrides,
   };
 }
@@ -242,6 +253,9 @@ function installStudioMock(
     requests.push({ method, url, body: typeof init?.body === "string" ? init.body : undefined });
 
     if (url === "/api/hardware/status") return Response.json(defaultAxiDrawHardwareStatus);
+    if (url === "/api/drawing-sessions/latest" && method === "GET") {
+      return Response.json({ session: currentSession });
+    }
     if (url === "/api/plotter/workspace") {
       return Response.json({
         plotter_bounds_mm: { width_mm: 289.974, height_mm: 207.932 },
@@ -285,6 +299,40 @@ function installStudioMock(
     if (url.endsWith("/approve") && method === "POST") {
       currentSession = buildSession("running");
       currentRun = buildRun("plotting");
+      return Response.json(currentSession);
+    }
+    if (url.endsWith("/finish") && method === "POST") {
+      currentSession = {
+        ...currentSession,
+        status: "completed",
+        completed_at: now,
+        paused_at: null,
+        authorization: {
+          ...currentSession.authorization,
+          stop_requested: false,
+          finish_requested: false,
+        },
+        events: [
+          ...currentSession.events,
+          event("session_completed", "Finished by you after the current pass.", {
+            source: "user",
+          }),
+        ],
+      };
+      return Response.json(currentSession);
+    }
+    if (url.endsWith("/abandon") && method === "POST") {
+      currentSession = {
+        ...currentSession,
+        status: "abandoned",
+        abandoned_at: now,
+        error: null,
+        queued_guidance: [],
+        events: [
+          ...currentSession.events,
+          event("session_abandoned", "This session was left unfinished."),
+        ],
+      };
       return Response.json(currentSession);
     }
     if (url.endsWith("/stop") && method === "POST") {
@@ -348,6 +396,18 @@ it("starts with creative intent and creates a prompt-only planning session", asy
   expect(requests.some((request) => request.url === "/api/plot-runs")).toBe(false);
 });
 
+it("keeps the deliberate new-drawing route on a blank prompt", async () => {
+  window.history.replaceState({}, "", "/new");
+  installStudioMock(buildSession("paused"), buildRun("completed", buildCapture()));
+
+  render(<App />);
+
+  expect(
+    await screen.findByRole("heading", { name: /what should we draw/i }),
+  ).toBeInTheDocument();
+  expect(window.location.pathname).toBe("/new");
+});
+
 it("shows the plan, explains open-ended approval, and lets a message replace the proposal", async () => {
   window.history.replaceState({}, "", "/sessions/session-1");
   const harness = installStudioMock(buildSession("awaiting_approval"));
@@ -371,6 +431,58 @@ it("shows the plan, explains open-ended approval, and lets a message replace the
       (request) => request.url.endsWith("/messages") && request.body?.includes("room on the right"),
     ),
   ).toBe(true);
+});
+
+it("requires a paper and pen preflight before first motion", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const harness = installStudioMock(buildSession("awaiting_approval"));
+  render(<App />);
+
+  const approve = await screen.findByRole("button", { name: /approve and begin/i });
+  expect(approve).toBeDisabled();
+  expect(screen.getByText(/279.4 × 215.9 mm · landscape/i)).toBeInTheDocument();
+
+  fireEvent.click(
+    screen.getByRole("checkbox", { name: /blank sheet loaded in this orientation/i }),
+  );
+  expect(approve).toBeEnabled();
+  fireEvent.click(approve);
+
+  await waitFor(() => {
+    const request = harness.requests.find((item) => item.url.endsWith("/approve"));
+    expect(JSON.parse(request?.body ?? "{}")).toEqual({ paper_ready: true });
+  });
+});
+
+it("abandons an unused plan before opening a blank new drawing", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const harness = installStudioMock(buildSession("awaiting_approval"));
+  render(<App />);
+
+  fireEvent.click(await screen.findByRole("button", { name: /new drawing/i }));
+  const dialog = screen.getByRole("dialog", { name: /leave this draft/i });
+  expect(within(dialog).getByText(/nothing has been plotted/i)).toBeInTheDocument();
+  fireEvent.click(within(dialog).getByRole("button", { name: /abandon and start new/i }));
+
+  expect(
+    await screen.findByRole("heading", { name: /what should we draw/i }),
+  ).toBeInTheDocument();
+  expect(window.location.pathname).toBe("/new");
+  expect(harness.requests.some((request) => request.url.endsWith("/abandon"))).toBe(true);
+});
+
+it("lets the user finish a safely paused drawing", async () => {
+  window.history.replaceState({}, "", "/sessions/session-1");
+  const harness = installStudioMock(buildSession("paused"), buildRun("completed", buildCapture()));
+  render(<App />);
+
+  fireEvent.click(await screen.findByRole("button", { name: /^finish drawing$/i }));
+  await waitFor(() => {
+    expect(harness.requests.some((request) => request.url.endsWith("/finish"))).toBe(true);
+  });
+  expect(
+    await screen.findAllByText(/finished by you after the current pass/i),
+  ).not.toHaveLength(0);
 });
 
 it("queues active guidance, sends heartbeats, and confirmation-protects emergency stop", async () => {

--- a/apps/web/tests/drawingSessionPanel.test.tsx
+++ b/apps/web/tests/drawingSessionPanel.test.tsx
@@ -70,14 +70,17 @@ function buildSession(status: DrawingSession["status"]): DrawingSession {
     authorization: {
       approved_at: null,
       stop_requested: false,
+      finish_requested: false,
       last_heartbeat_at: null,
     },
+    paper_preflight: null,
     queued_guidance: [],
     requested_human_action: null,
     events: [],
     approved_at: null,
     paused_at: null,
     completed_at: null,
+    abandoned_at: null,
   };
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ The current backend structure centers on:
 The frontend is a lightweight local creative studio. Its primary surface describes and follows a drawing; operational tools remain secondary.
 
 - `/` starts from “What should we draw?” or redirects to the current active session
+- `/new` always opens a blank creative prompt, even while a completed or unfinished session remains in Gallery
 - `/sessions/:id` presents the plan, cumulative intended artwork, latest registered observation, exact overlay, conversation, recovery actions, and persistent stop controls
 - `/gallery` lists session-level work using the latest or final observation as its preview
 - `/controls` retains paper setup, hardware readiness, test capture, fixed diagnostics, manual SVG plotting, and manual registration
@@ -114,13 +115,15 @@ V1 capture and run JSON remains readable without migration. Its detector fields 
 
 V2 `DrawingSession` records begin from intent alone. Creation persists `planning` state and dispatches provider work without moving hardware. The drawing advisor returns a concise plan, paper strategy, completion intent, and first-pass SVG. That SVG is untrusted: the backend validates its exact drawable-area canvas, supported passive elements, direct coordinates, safe stroke styling, and in-bounds geometry before storing it as a generated asset and exposing `awaiting_approval`.
 
-Guidance submitted before approval is appended to the session event timeline, invalidates the current proposal, and starts a newer planning generation. A stale provider response cannot replace the latest generation. Approval is the first operation that creates a normal PlotRun; all existing preparation, active-run exclusion, hardware adapters, capture registration, and persistence remain authoritative.
+Guidance submitted before approval is appended to the session event timeline, invalidates the current proposal, and starts a newer planning generation. A stale provider response cannot replace the latest generation. Approval requires an explicit `paper_ready` assertion that a blank sheet is loaded in the displayed orientation and a pen is installed. The backend records the approved workspace page and drawable dimensions with the confirmation timestamp before creating the first normal PlotRun. All existing preparation, active-run exclusion, hardware adapters, capture registration, and persistence remain authoritative.
 
 V2 persistence adds an append-only typed event timeline, plan and proposal references, authorization timestamps, current-run identity, pass count, and queued guidance. SVGs and images remain separate stored artifacts. Session-list responses expose compact gallery summaries without embedding artifact data. Provider calls remain read-only and receive no hardware tools.
 
 After a registered observation completes, a single backend coordinator sends the rectified grayscale page, current plan, bounded interpretation history, and atomically consumed guidance through `assess_iteration`. `continue` requires a validated incremental SVG and creates exactly one next normal PlotRun. `complete` ends the session. `pause` records its reason and any requested human action. Provider, hardware, registration, and artifact failures pause rather than permitting another physical pass.
 
-Authorization remains attended. The creative client posts a heartbeat; if it is absent for 30 seconds, the current physical pass and its capture may finish, but another pass cannot begin. Stop-after-pass uses the same boundary. Backend startup converts persisted active V2 sessions to a paused recovery state, so process restart never restarts hardware automatically. Resume refreshes attendance, clears the soft-stop request, and re-enters coordination only after normal readiness checks.
+Authorization remains attended. The creative client posts a heartbeat; if it is absent for 30 seconds, the current physical pass and its capture may finish, but another pass cannot begin. Stop-after-pass uses the same boundary and leaves the session paused. Finish drawing instead makes the latest safely completed observation terminal; when requested during plotting or capture it waits for that physical pass and its persistence to finish, then takes precedence over another advisor decision. Backend startup converts persisted active V2 sessions to a paused recovery state, so process restart never restarts hardware automatically. Resume refreshes attendance, clears the soft-stop and finish requests, and re-enters coordination only after normal readiness checks.
+
+An unused or safely paused V2 session can be abandoned. Abandon is terminal, retains the plan, event history, and completed run references for Gallery, and is rejected while plotting, capturing, or waiting for capture registration. Completed and abandoned sessions remain immutable through these lifecycle operations. Existing session JSON loads with default lifecycle fields and is never rewritten merely to adopt the V2 additions.
 
 A plot run may retake its capture after plotting completed. The run retains an ordered `capture_attempts` history, keeps `capture` as the selected current attempt for compatibility, and sends only that current attempt through registration and normalization. Retake never invokes the plotter. Earlier capture files and metadata remain immutable evidence.
 
@@ -136,7 +139,7 @@ Existing session JSON without `session_version` parses as V1. Its bounded two-to
 
 ## Creative Studio Interaction Contract
 
-Planning never implies motion. The home may create a planning session while plotter or camera readiness is incomplete; approval and every later pass still pass through backend hardware-readiness and safety checks. Pre-approval guidance replaces the proposal. Approval copy explicitly describes the attended, open-ended plot/capture/assessment authorization.
+Planning never implies motion. The home may create a planning session while plotter or camera readiness is incomplete; approval and every later pass still pass through backend hardware-readiness and safety checks. Pre-approval guidance replaces the proposal. Before approval, the interface displays the backend-owned page dimensions and orientation and requires the operator to confirm a matching blank sheet and installed pen. Approval copy explicitly describes the attended, open-ended plot/capture/assessment authorization.
 
 The active canvas treats the physical page as the common coordinate frame. Intended mode stacks every prepared incremental SVG, observed mode shows the latest registered photograph, and overlay mode stacks those two views without cropping only when capture metadata proves a V2 page-aligned frame. Pending manual registration embeds the existing corner editor in the canvas and preserves validation errors and the draft.
 
@@ -145,6 +148,8 @@ The conversation records user guidance, agent plans, interpretations, decisions,
 The creative screen posts heartbeats only while visible and on an active authorized session. Closing or hiding it therefore allows the current physical pass to finish but prevents another pass after the backend grace period. Stop-after-pass preserves that same safe boundary. Emergency stop is confirmation-protected and is offered only while the current run is pending or plotting; its copy states that interruption occurs after the current path segment.
 
 Paused capture failures and questionable frames awaiting manual registration offer a camera-only retake, which cannot create a replacement plot run. Manual registration remains in-context on the canvas after the replacement capture. Resume is explicit and rechecks backend readiness.
+
+Every session offers New drawing. Terminal sessions open `/new` directly. An unused plan can be left unfinished without motion; a safely paused drawing can either be preserved as complete or left unfinished; an active drawing can finish its current plot and observation before the blank prompt opens. These choices are explicit so “stop,” “finish,” and “start over” never share hidden state semantics.
 
 Advisor credentials remain a backend-owned secret. Controls may submit an API key to the loopback-only configuration endpoint, but the frontend clears the password field after success and never writes the key to browser storage, artifacts, URLs, or responses. A thread-safe advisor delegate swaps the active provider atomically for planning and assessment work already owned by the drawing-session service. Runtime configuration exists only in backend process memory and clear/restart restores the startup environment configuration.
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -204,4 +204,12 @@ This document keeps the internal slice-by-slice evolution notes that used to liv
 - Consolidated live status announcements into the progress panel and added responsive, reduced-motion, and non-color-only state treatment
 - Left polling, orchestration, advisor behavior, registration, capture, and hardware control unchanged
 
+## Creative Session Lifecycle And Paper Preflight Slice
+
+- Added a deliberate New drawing path that can abandon an unused plan, preserve a safely paused session as unfinished, or finish the active physical pass before opening a blank prompt
+- Distinguished stop-after-pass from user-requested completion and made completion win before another autonomous assessment or plot can begin
+- Added terminal abandoned sessions while retaining their plans, event timelines, and completed run references in Gallery
+- Required an explicit blank-sheet, displayed-orientation, and installed-pen confirmation before first motion, with the backend persisting the approved workspace dimensions and timestamp
+- Kept active abandonment invalid, all hardware transitions backend-owned, and existing V1/V2 artifacts readable through defaulted lifecycle fields
+
 For the current architecture and system boundaries, see [architecture.md](architecture.md).


### PR DESCRIPTION
## Summary

- Add an always-available New drawing path with explicit abandon, preserve, and finish choices.
- Require a blank-sheet, displayed-orientation, and installed-pen confirmation before the first PlotRun is created.
- Persist V2 finish/abandon lifecycle state and paper preflight metadata without rewriting existing sessions.
- Keep stop-after-pass distinct from completion, and prevent a finish request from allowing another autonomous pass.

This closes the lifecycle and physical-preflight gaps found during the creative-studio usability pass. It is a focused follow-up to the agentic studio redesign in #47. Model-only configuration remains separately tracked in #67.

Closes #68
Related to #47

## Checks

- [x] make api-test — 147 passed
- [x] make web-test — 53 passed
- [x] make web-build — passed
- [x] I listed the verification I actually ran in the PR body
- [x] I noted any checks I could not run and why
- [x] make api-lint — passed
- [x] make web-lint — passed

## Architecture

- [x] Backend remains the sole owner of hardware access
- [x] AxiDraw-specific behavior stays isolated to adapters and wrappers
- [x] Mock adapters still work, or I explained why they changed

## Risk Review

- [x] I called out any hardware assumptions or undocumented behavior
- [x] I called out version-sensitive behavior when relevant
- [x] I updated docs or config notes if behavior changed
- [x] This PR is a narrow, reviewable slice

The paper/pen preflight is an explicit human assertion, not sensor verification. No AxiDraw behavior changed, and verification intentionally did not move connected hardware. Existing V1/V2 persisted session JSON loads through defaulted fields.